### PR TITLE
Feature 1: Splid-Import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/node": "^9.1.3",
-        "astro": "^5.6.1"
+        "astro": "^5.6.1",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.3",
@@ -2057,6 +2058,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -2893,6 +2903,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -3013,6 +3036,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3056,6 +3088,18 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/crossws": {
       "version": "0.3.5",
@@ -3551,6 +3595,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -5882,6 +5935,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6717,6 +6782,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -6732,6 +6815,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@astrojs/node": "^9.1.3",
-    "astro": "^5.6.1"
+    "astro": "^5.6.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.3",

--- a/src/lib/solidarisch.ts
+++ b/src/lib/solidarisch.ts
@@ -13,6 +13,7 @@ export interface Slot {
   label: string;
   gewichtung: number;
   anzahl: number;
+  ausgaben?: number; // aus Splid importierte Ausgaben der Person (optional)
 }
 
 export interface Gebot {

--- a/src/lib/splid.test.ts
+++ b/src/lib/splid.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests für src/lib/splid.ts
+ *
+ * Synthetische XLSX-Buffer werden mit SheetJS erstellt —
+ * kein echtes Splid-File als Fixture nötig.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as XLSX from 'xlsx';
+import { parseSplid, type SplidImport } from './splid';
+
+// ---------------------------------------------------------------------------
+// Hilfsfunktion: baut einen minimalen Splid-XLSX-Buffer
+// ---------------------------------------------------------------------------
+
+function buildSplidBuffer(opts: {
+  rundenname?: string;
+  personen: string[];
+  ausgaben: { von: string; betrag: number }[];
+}): ArrayBuffer {
+  const { rundenname = 'Test-Runde', personen, ausgaben } = opts;
+
+  // Kopfzeile: Titel, Betrag, Währung, Von, Datum, Erstellt am, [Person, Calc, ...]
+  const headerRow: unknown[] = ['Titel', 'Betrag', 'Währung', 'Von', 'Datum', 'Erstellt am'];
+  for (const p of personen) {
+    headerRow.push(p);
+    headerRow.push(''); // Berechnungsspalte
+  }
+
+  // Datenzeilen
+  const dataRows = ausgaben.map(({ von, betrag }) => [
+    'Einkauf', betrag, 'EUR', von, '01.01.26', '01.01.26',
+  ]);
+
+  const aoa: unknown[][] = [
+    [rundenname],
+    ['Erstellt mit Splid (splid.app)'],
+    [],
+    headerRow,
+    ...dataRows,
+  ];
+
+  const ws = XLSX.utils.aoa_to_sheet(aoa);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+
+  // XLSX.write mit type:'array' gibt in Node.js ein plain Array zurück, kein TypedArray
+  const xlsxArray = XLSX.write(wb, { type: 'array', bookType: 'xlsx' }) as number[];
+  return new Uint8Array(xlsxArray).buffer as ArrayBuffer;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('parseSplid', () => {
+  it('extrahiert Rundenname, Gesamtkosten und Personenliste', () => {
+    const buf = buildSplidBuffer({
+      rundenname: 'Haushaltskasse Februar',
+      personen: ['Anna', 'Ben', 'Cara'],
+      ausgaben: [
+        { von: 'Anna', betrag: 100 },
+        { von: 'Ben', betrag: 50 },
+        { von: 'Anna', betrag: 25 },
+      ],
+    });
+
+    const result: SplidImport = parseSplid(buf);
+
+    expect(result.rundenname).toBe('Haushaltskasse Februar');
+    expect(result.gesamtkosten).toBe(175);
+    expect(result.personen.map((p) => p.name)).toEqual(['Anna', 'Ben', 'Cara']);
+  });
+
+  it('berechnet Ausgaben pro Person korrekt', () => {
+    const buf = buildSplidBuffer({
+      personen: ['Anna', 'Ben'],
+      ausgaben: [
+        { von: 'Anna', betrag: 30 },
+        { von: 'Anna', betrag: 20.5 },
+        { von: 'Ben', betrag: 10 },
+      ],
+    });
+
+    const { personen } = parseSplid(buf);
+    const anna = personen.find((p) => p.name === 'Anna')!;
+    const ben = personen.find((p) => p.name === 'Ben')!;
+
+    expect(anna.ausgaben).toBeCloseTo(50.5, 2);
+    expect(ben.ausgaben).toBeCloseTo(10, 2);
+  });
+
+  it('setzt ausgaben auf 0 für Personen ohne eigene Ausgaben (Laura-Fall)', () => {
+    const buf = buildSplidBuffer({
+      personen: ['Laura', 'Stefan'],
+      ausgaben: [
+        { von: 'Stefan', betrag: 80 },
+      ],
+    });
+
+    const { personen } = parseSplid(buf);
+    const laura = personen.find((p) => p.name === 'Laura')!;
+
+    expect(laura.ausgaben).toBe(0);
+  });
+
+  it('rundet Gesamtkosten und Ausgaben auf 2 Dezimalstellen', () => {
+    const buf = buildSplidBuffer({
+      personen: ['Anna'],
+      ausgaben: [
+        { von: 'Anna', betrag: 1 / 3 },
+        { von: 'Anna', betrag: 2 / 3 },
+      ],
+    });
+
+    const { gesamtkosten, personen } = parseSplid(buf);
+
+    expect(gesamtkosten).toBe(1);
+    expect(personen[0].ausgaben).toBe(1);
+  });
+
+  it('wirft wenn Sheet „Zusammenfassung" fehlt', () => {
+    const ws = XLSX.utils.aoa_to_sheet([['Daten']]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Anderes Sheet');
+    const arr = XLSX.write(wb, { type: 'array', bookType: 'xlsx' }) as number[];
+    const buf = new Uint8Array(arr).buffer as ArrayBuffer;
+
+    expect(() => parseSplid(buf)).toThrow('Zusammenfassung');
+  });
+
+  it('wirft wenn Kopfzeile fehlt', () => {
+    const ws = XLSX.utils.aoa_to_sheet([['Titel'], ['Daten']]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+    const arr = XLSX.write(wb, { type: 'array', bookType: 'xlsx' }) as number[];
+    const buf = new Uint8Array(arr).buffer as ArrayBuffer;
+
+    expect(() => parseSplid(buf)).toThrow('Kopfzeile');
+  });
+
+  it('wirft wenn keine Personen erkannt werden', () => {
+    // Kopfzeile mit Von + Betrag, aber ohne Personenspalten
+    const ws = XLSX.utils.aoa_to_sheet([
+      ['Runde'],
+      [],
+      [],
+      ['Titel', 'Betrag', 'Währung', 'Von', 'Datum', 'Erstellt am'],
+    ]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+    const arr = XLSX.write(wb, { type: 'array', bookType: 'xlsx' }) as number[];
+    const buf = new Uint8Array(arr).buffer as ArrayBuffer;
+
+    expect(() => parseSplid(buf)).toThrow('Teilnehmer');
+  });
+});

--- a/src/lib/splid.ts
+++ b/src/lib/splid.ts
@@ -1,0 +1,111 @@
+/**
+ * FairShare ZK — Splid-Import
+ *
+ * Liest eine Splid-XLSX-Exportdatei (Sheet "Zusammenfassung") im Browser
+ * und extrahiert Rundenname, Gesamtkosten und Teilnehmer mit ihren Ausgaben.
+ * Die Datei verlässt dabei das Gerät nicht.
+ */
+
+import * as XLSX from 'xlsx';
+
+export interface SplidPerson {
+  name: string;
+  ausgaben: number;
+}
+
+export interface SplidImport {
+  rundenname: string;
+  gesamtkosten: number;
+  personen: SplidPerson[];
+}
+
+/**
+ * Parst einen ArrayBuffer einer Splid-XLSX-Datei.
+ * Wirft bei ungültigem Format mit einer verständlichen Fehlermeldung.
+ */
+export function parseSplid(buffer: ArrayBuffer): SplidImport {
+  const wb = XLSX.read(new Uint8Array(buffer), { type: 'array' });
+
+  const SHEET = 'Zusammenfassung';
+  if (!wb.SheetNames.includes(SHEET)) {
+    throw new Error(
+      'Datei enthält kein Sheet „Zusammenfassung". Bitte einen Splid-Export verwenden.',
+    );
+  }
+
+  const ws = wb.Sheets[SHEET];
+  const rows = XLSX.utils.sheet_to_json<unknown[]>(ws, { header: 1 });
+
+  // Rundenname aus A1
+  const rundenname = String((rows[0] as unknown[])?.[0] ?? '').trim();
+  if (!rundenname) {
+    throw new Error('Rundenname nicht gefunden (Zelle A1 ist leer).');
+  }
+
+  // Kopfzeile finden: erste Zeile mit beiden Spalten "Von" und "Betrag"
+  let headerRowIdx = -1;
+  let vonIdx = -1;
+  let betragIdx = -1;
+  let personenStartCol = 6; // Fallback: nach den 6 Standard-Spalten
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i] as unknown[];
+    const vonI = row.findIndex((c) => String(c ?? '').trim() === 'Von');
+    const betragI = row.findIndex((c) => String(c ?? '').trim() === 'Betrag');
+    if (vonI !== -1 && betragI !== -1) {
+      headerRowIdx = i;
+      vonIdx = vonI;
+      betragIdx = betragI;
+      // Personenspalten beginnen nach "Erstellt am" (oder nach Position 5)
+      const erstelltAmI = row.findIndex((c) => String(c ?? '').trim() === 'Erstellt am');
+      personenStartCol = erstelltAmI !== -1 ? erstelltAmI + 1 : 6;
+      break;
+    }
+  }
+
+  if (headerRowIdx === -1) {
+    throw new Error(
+      'Kopfzeile nicht gefunden. Erwartet werden Spalten „Von" und „Betrag".',
+    );
+  }
+
+  // Personennamen aus Kopfzeile extrahieren (ungerade Spalten ab personenStartCol)
+  const headerRow = rows[headerRowIdx] as unknown[];
+  const personenNamen: string[] = [];
+  for (let col = personenStartCol; col < headerRow.length; col += 2) {
+    const name = String(headerRow[col] ?? '').trim();
+    if (name) personenNamen.push(name);
+  }
+
+  if (personenNamen.length === 0) {
+    throw new Error(
+      'Keine Teilnehmer gefunden. Bitte einen vollständigen Splid-Export verwenden.',
+    );
+  }
+
+  // Ausgaben pro Person summieren + Gesamtkosten berechnen
+  const ausgabenMap = new Map<string, number>(personenNamen.map((n) => [n, 0]));
+  let gesamtkosten = 0;
+
+  for (let i = headerRowIdx + 1; i < rows.length; i++) {
+    const row = rows[i] as unknown[];
+    const betrag = Number(row[betragIdx]);
+    const von = String(row[vonIdx] ?? '').trim();
+    if (!isFinite(betrag) || betrag <= 0) continue;
+    gesamtkosten += betrag;
+    if (von && ausgabenMap.has(von)) {
+      ausgabenMap.set(von, (ausgabenMap.get(von) ?? 0) + betrag);
+    }
+  }
+
+  const personen: SplidPerson[] = personenNamen.map((name) => ({
+    name,
+    ausgaben: Math.round((ausgabenMap.get(name) ?? 0) * 100) / 100,
+  }));
+
+  return {
+    rundenname,
+    gesamtkosten: Math.round(gesamtkosten * 100) / 100,
+    personen,
+  };
+}

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -8,6 +8,22 @@ import Layout from '../layouts/Layout.astro';
     <h1 class="text-2xl font-semibold mb-1">Neue Runde erstellen</h1>
     <p class="text-slate-500 text-sm mb-6">Alle Daten werden im Browser verschlüsselt — der Server sieht nie Klartext.</p>
 
+    <!-- Splid-Import -->
+    <div class="mb-6 p-4 bg-slate-50 border border-slate-200 rounded-xl">
+      <p class="text-sm font-medium text-slate-700 mb-2">Aus Splid importieren</p>
+      <p class="text-xs text-slate-500 mb-3">Exportiere deine Runde in Splid als XLSX und lade sie hier hoch. Die Datei verlässt deinen Browser nicht.</p>
+      <input type="file" id="splid-file" accept=".xlsx,.xls" class="hidden" />
+      <button
+        type="button"
+        id="splid-import-btn"
+        class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+      >
+        XLSX-Datei auswählen…
+      </button>
+      <div id="splid-erfolg" class="hidden mt-2 text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2"></div>
+      <div id="splid-fehler" class="hidden mt-2 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2"></div>
+    </div>
+
     <form id="runde-form" class="space-y-6">
       <!-- Runden-Name -->
       <div>
@@ -181,6 +197,7 @@ import Layout from '../layouts/Layout.astro';
     encrypt,
     exportKey,
   } from '../lib/crypto';
+  import { parseSplid } from '../lib/splid';
 
   const form = document.getElementById('runde-form') as HTMLFormElement;
   const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement;
@@ -204,6 +221,78 @@ import Layout from '../layouts/Layout.astro';
       btn.classList.toggle('hidden', btns.length <= 1);
     });
   }
+
+  // ---------------------------------------------------------------------------
+  // Splid-Import
+  // ---------------------------------------------------------------------------
+
+  const splidFileInput = document.getElementById('splid-file') as HTMLInputElement;
+  const splidErfolgEl = document.getElementById('splid-erfolg') as HTMLDivElement;
+  const splidFehlerEl = document.getElementById('splid-fehler') as HTMLDivElement;
+
+  document.getElementById('splid-import-btn')!.addEventListener('click', () => {
+    splidFileInput.click();
+  });
+
+  splidFileInput.addEventListener('change', async () => {
+    const file = splidFileInput.files?.[0];
+    if (!file) return;
+
+    splidErfolgEl.classList.add('hidden');
+    splidFehlerEl.classList.add('hidden');
+
+    try {
+      const buffer = await file.arrayBuffer();
+      const { rundenname, gesamtkosten, personen } = parseSplid(buffer);
+
+      // Rundenname befüllen
+      (form.querySelector('#rundeName') as HTMLInputElement).value = rundenname;
+
+      // Gesamtkosten befüllen
+      (form.querySelector('#gesamtkosten') as HTMLInputElement).value =
+        gesamtkosten.toFixed(2);
+
+      // Slots ersetzen: alle außer dem ersten entfernen, dann Felder befüllen
+      const alleSlots = slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag');
+      alleSlots.forEach((s, i) => { if (i > 0) s.remove(); });
+
+      const ersterSlot = slotsContainer.querySelector('.slot-eintrag') as HTMLDivElement;
+
+      function befuelleSlot(slotEl: HTMLDivElement, label: string, ausgaben: number) {
+        (slotEl.querySelector('[name="label[]"]') as HTMLInputElement).value = label;
+        (slotEl.querySelector('[name="gewichtung[]"]') as HTMLInputElement).value = '1';
+        (slotEl.querySelector('[name="anzahl[]"]') as HTMLInputElement).value = '1';
+        // Ausgaben als data-Attribut speichern für die spätere Blob-Erstellung
+        slotEl.dataset.ausgaben = String(ausgaben);
+      }
+
+      befuelleSlot(ersterSlot, personen[0].name, personen[0].ausgaben);
+
+      for (let i = 1; i < personen.length; i++) {
+        const vorlage = slotsContainer.querySelector('.slot-eintrag') as HTMLDivElement;
+        const klon = vorlage.cloneNode(true) as HTMLDivElement;
+        befuelleSlot(klon, personen[i].name, personen[i].ausgaben);
+        slotsContainer.appendChild(klon);
+      }
+
+      aktualisiereEntfernenButtons();
+
+      const namen = personen.map((p) => p.name).join(', ');
+      splidErfolgEl.textContent = `${personen.length} Personen importiert: ${namen}`;
+      splidErfolgEl.classList.remove('hidden');
+    } catch (err) {
+      splidFehlerEl.textContent =
+        err instanceof Error ? err.message : 'Unbekannter Fehler beim Importieren.';
+      splidFehlerEl.classList.remove('hidden');
+    }
+
+    // Input zurücksetzen damit dieselbe Datei nochmals gewählt werden kann
+    splidFileInput.value = '';
+  });
+
+  // ---------------------------------------------------------------------------
+  // Slot hinzufügen
+  // ---------------------------------------------------------------------------
 
   // Slot hinzufügen
   document.getElementById('slot-hinzufuegen')!.addEventListener('click', () => {
@@ -259,11 +348,17 @@ import Layout from '../layouts/Layout.astro';
         (el) => parseInt(el.value, 10),
       );
 
-      const slots = labels.map((label, i) => ({
-        label,
-        gewichtung: gewichtungen[i],
-        anzahl: anzahlen[i],
-      }));
+      const slotEintraege = [...slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag')];
+      const slots = labels.map((label, i) => {
+        const ausgabenRaw = slotEintraege[i]?.dataset.ausgaben;
+        const ausgaben = ausgabenRaw !== undefined ? parseFloat(ausgabenRaw) : undefined;
+        return {
+          label,
+          gewichtung: gewichtungen[i],
+          anzahl: anzahlen[i],
+          ...(ausgaben !== undefined && isFinite(ausgaben) ? { ausgaben } : {}),
+        };
+      });
 
       // Schlüssel generieren
       const partKey = await generatePartKey();

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -64,6 +64,8 @@ import Layout from '../../../../layouts/Layout.astro';
             <th class="pb-2 pr-4 font-medium text-right">Faktor</th>
             <th class="pb-2 pr-4 font-medium text-right">Gebot</th>
             <th class="pb-2 pr-4 font-medium text-right">Beitrag</th>
+            <th class="pb-2 pr-4 font-medium text-right splid-spalte hidden">Ausgaben (Splid)</th>
+            <th class="pb-2 pr-4 font-medium text-right splid-spalte hidden">Noch zu zahlen</th>
             <th class="pb-2 font-medium text-right">Differenz</th>
           </tr>
         </thead>
@@ -99,7 +101,7 @@ import Layout from '../../../../layouts/Layout.astro';
     gesamtkosten: number;
     adminPubKey: string;
     hmacKey: string;
-    slots: { label: string; gewichtung: number; anzahl: number }[];
+    slots: { label: string; gewichtung: number; anzahl: number; ausgaben?: number }[];
   }
 
   function eur(value: number): string {
@@ -207,18 +209,44 @@ import Layout from '../../../../layouts/Layout.astro';
       document.getElementById('ueberschuss-text')!.textContent = eur(auswertung.ueberschuss);
     }
 
+    // Splid-Ausgaben-Map aufbauen (slotLabel → ausgaben)
+    const ausgabenMap = new Map<string, number>();
+    for (const slot of blob.slots) {
+      if (slot.ausgaben !== undefined) {
+        ausgabenMap.set(slot.label, slot.ausgaben);
+      }
+    }
+    const hatSplidDaten = ausgabenMap.size > 0;
+
+    // Splid-Spalten einblenden wenn Daten vorhanden
+    if (hatSplidDaten) {
+      document.querySelectorAll('.splid-spalte').forEach((el) => el.classList.remove('hidden'));
+    }
+
     // Tabelle befüllen
     const tbody = document.getElementById('tabelle-body')!;
     for (const e of auswertung.ergebnisse) {
       const tr = document.createElement('tr');
       const diffSign = e.differenz > 0.005 ? '+' : '';
       const diffClass = e.differenz > 0.005 ? 'text-green-700' : 'text-slate-600';
+
+      const ausgaben = ausgabenMap.get(e.slotLabel) ?? 0;
+      const nochZuZahlen = e.solidarischerBeitrag - ausgaben;
+      const nochSign = nochZuZahlen > 0.005 ? '+' : '';
+      const nochClass = nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700';
+
+      const splidZellen = hatSplidDaten
+        ? `<td class="py-2 pr-4 text-right text-slate-600">${eur(ausgaben)}</td>
+           <td class="py-2 pr-4 text-right font-medium ${nochClass}">${nochSign}${eur(nochZuZahlen)}</td>`
+        : '';
+
       tr.innerHTML = `
         <td class="py-2 pr-4 text-lg">${e.emojiId}</td>
         <td class="py-2 pr-4 text-slate-800">${e.slotLabel}</td>
         <td class="py-2 pr-4 text-right text-slate-600">${e.gewichtung}</td>
         <td class="py-2 pr-4 text-right text-slate-600">${eur(e.gebot)}</td>
         <td class="py-2 pr-4 text-right font-medium">${eur(e.solidarischerBeitrag)}</td>
+        ${splidZellen}
         <td class="py-2 text-right ${diffClass}">${diffSign}${eur(e.differenz)}</td>
       `;
       tbody.appendChild(tr);


### PR DESCRIPTION
## Was wurde gebaut

- **`src/lib/splid.ts`** — Client-seitiger Parser für Splid-XLSX-Exporte (SheetJS). Liest Sheet „Zusammenfassung", extrahiert Rundenname, Gesamtkosten und alle Teilnehmer mit ihren Ausgaben. Die Datei verlässt den Browser nie.
- **`src/lib/solidarisch.ts`** — `Slot`-Typ um optionales Feld `ausgaben?: number` erweitert (aus Splid importierte Ausgaben pro Person).
- **`src/pages/neu.astro`** — Import-Box mit XLSX-Dateiauswahl. Nach erfolgreichem Import werden Rundenname, Gesamtkosten und Slots (je eine Zeile pro Person) automatisch befüllt. Weitere Slots können danach manuell ergänzt werden.
- **`src/pages/runde/[id]/admin/[token].astro`** — Auswertungstabelle zeigt zusätzlich „Ausgaben (Splid)" und „Noch zu zahlen" (= Solidarischer Beitrag − Ausgaben), wenn Splid-Daten vorhanden sind.

## Wie wurde getestet

- 7 Unit-Tests in `src/lib/splid.test.ts` mit synthetischen XLSX-Buffern:
  - Happy Path: Rundenname, Gesamtkosten, Personenliste
  - Ausgaben pro Person korrekt summiert
  - Person ohne Ausgaben bekommt `ausgaben: 0` (Laura-Fall)
  - Rundung auf 2 Dezimalstellen
  - Fehlerbehandlung: fehlender Sheet, fehlende Kopfzeile, keine Personen
- Alle 41 Tests grün (`src/lib/crypto.test.ts`, `src/lib/solidarisch.test.ts`, `src/lib/splid.test.ts`)
- Manuell getestet mit echter Splid-Exportdatei (7 Personen, 61 Ausgaben, 1.958,27 €)

## Was kommt als nächstes

Feature 2: Gebot nachträglich korrigieren