### PR TITLE
fix: Berechnungslogik korrigieren (Richtwert + Überschuss-Verteilung)

### DIFF
--- a/src/lib/solidarisch.test.ts
+++ b/src/lib/solidarisch.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
-  berechneRichtwert,
-  berechneBeitrag,
   berechneAuswertung,
   type Gebot,
+  type Slot,
 } from './solidarisch';
 
 // ---------------------------------------------------------------------------
-// Hilfsfunktion: Gebot-Objekt mit Defaults
+// Hilfsfunktionen
 // ---------------------------------------------------------------------------
 
 function gebot(
@@ -24,152 +23,246 @@ function gebot(
   };
 }
 
+function slot(label: string, gewichtung: number, anzahl = 1): Slot {
+  return { label, gewichtung, anzahl };
+}
+
 // ---------------------------------------------------------------------------
-// berechneRichtwert
+// Richtwert aus ALLEN Slots (inkl. unbelegte)
 // ---------------------------------------------------------------------------
 
-describe('berechneRichtwert', () => {
-  it('einfacher Fall: zwei gleiche Gewichtungen', () => {
-    const gebote = [gebot(1, 100), gebot(1, 100)];
-    // richtwert = 200 / (1 + 1) = 100
-    expect(berechneRichtwert(200, gebote)).toBe(100);
+describe('Richtwert-Berechnung aus allen Slots', () => {
+  it('verwendet alle Slots, auch wenn nicht alle belegt sind', () => {
+    // 3 Slots definiert: je Gewichtung 1, anzahl 1 → summe = 3
+    // richtwert = 300 / 3 = 100
+    // Aber nur 2 Gebote eingegangen
+    const slots = [slot('A', 1), slot('B', 1), slot('C', 1)];
+    const gebote = [
+      gebot(1, 120, { slotLabel: 'A' }),
+      gebot(1, 100, { slotLabel: 'B' }),
+    ];
+    const result = berechneAuswertung(300, gebote, slots);
+    expect(result.richtwert).toBe(100);
   });
 
-  it('unterschiedliche Gewichtungen', () => {
-    const gebote = [gebot(2, 80), gebot(1, 15)];
-    // richtwert = 150 / (2 + 1) = 50
-    expect(berechneRichtwert(150, gebote)).toBeCloseTo(50);
-  });
-
-  it('einzelnes Gebot', () => {
-    const gebote = [gebot(1.5, 200)];
-    // richtwert = 300 / 1.5 = 200
-    expect(berechneRichtwert(300, gebote)).toBeCloseTo(200);
-  });
-
-  it('wirft bei leerer Gebote-Liste', () => {
-    expect(() => berechneRichtwert(100, [])).toThrow('Keine Gebote vorhanden');
+  it('berücksichtigt anzahl bei Slots', () => {
+    // Slot "Familie" gewichtung=2, anzahl=3 → trägt 6 bei
+    // Slot "Single" gewichtung=1, anzahl=2 → trägt 2 bei
+    // summe = 8, richtwert = 800 / 8 = 100
+    const slots = [slot('Familie', 2, 3), slot('Single', 1, 2)];
+    const gebote = [gebot(2, 150, { slotLabel: 'Familie' })];
+    const result = berechneAuswertung(800, gebote, slots);
+    expect(result.richtwert).toBe(100);
   });
 });
 
 // ---------------------------------------------------------------------------
-// berechneBeitrag
+// Fehlbetrag-Fall: alle bieten weniger als Richtwert-Anteil
 // ---------------------------------------------------------------------------
 
-describe('berechneBeitrag', () => {
-  it('Gebot unter Anteil → zahlt nur Gebot', () => {
-    const g = gebot(1, 70);
-    const ergebnis = berechneBeitrag(g, 100);
-    expect(ergebnis.anteil).toBe(100);
-    expect(ergebnis.solidarischerBeitrag).toBe(70);
-    expect(ergebnis.differenz).toBe(0);
-  });
-
-  it('Gebot über Anteil → wird auf Anteil reduziert', () => {
-    const g = gebot(1, 150);
-    const ergebnis = berechneBeitrag(g, 100);
-    expect(ergebnis.anteil).toBe(100);
-    expect(ergebnis.solidarischerBeitrag).toBe(100);
-    expect(ergebnis.differenz).toBe(50);
-  });
-
-  it('Gebot exakt gleich Anteil → zahlt Anteil', () => {
-    const g = gebot(1, 100);
-    const ergebnis = berechneBeitrag(g, 100);
-    expect(ergebnis.solidarischerBeitrag).toBe(100);
-    expect(ergebnis.differenz).toBe(0);
-  });
-
-  it('Faktor 0.5: Anteil ist halb so groß', () => {
-    const g = gebot(0.5, 30);
-    const ergebnis = berechneBeitrag(g, 100);
-    // anteil = 0.5 × 100 = 50, Gebot 30 < 50 → beitrag = 30
-    expect(ergebnis.anteil).toBe(50);
-    expect(ergebnis.solidarischerBeitrag).toBe(30);
-  });
-
-  it('gibt korrekte Metadaten zurück', () => {
-    const g = gebot(2, 80, { emojiId: '🦊🌙⭐', slotLabel: 'Familie' });
-    const ergebnis = berechneBeitrag(g, 100);
-    expect(ergebnis.emojiId).toBe('🦊🌙⭐');
-    expect(ergebnis.slotLabel).toBe('Familie');
-    expect(ergebnis.gewichtung).toBe(2);
-    expect(ergebnis.gebot).toBe(80);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// berechneAuswertung
-// ---------------------------------------------------------------------------
-
-describe('berechneAuswertung', () => {
-  it('alle zahlen weniger als Richtwert → Fehlbetrag entsteht', () => {
+describe('Fehlbetrag-Fall', () => {
+  it('kein geldZurueck, summeBeitraege < gesamtkosten', () => {
     // richtwert = 1000 / 2 = 500
-    // beide zahlen je 200 → beitrag 200 + 200 = 400 < 1000 → fehlbetrag = 600
+    // beide bieten 200 < richtwertAnteil 500 → kein ueberRichtwert
+    const slots = [slot('A', 1), slot('B', 1)];
     const gebote = [gebot(1, 200), gebot(1, 200)];
-    const result = berechneAuswertung(1000, gebote);
+    const result = berechneAuswertung(1000, gebote, slots);
+
     expect(result.fehlbetrag).toBeCloseTo(600);
     expect(result.ueberschuss).toBe(0);
+    for (const e of result.ergebnisse) {
+      expect(e.geldZurueck).toBe(0);
+      expect(e.solidarischerBeitrag).toBe(e.gebot);
+    }
   });
 
-  it('alle bieten mehr als Richtwert → Überschuss möglich, alle reduziert', () => {
-    // richtwert = 100 / 2 = 50
-    // beide bieten 200, anteil je 50 → beitrag 50 + 50 = 100 = gesamtkosten
-    const gebote = [gebot(1, 200), gebot(1, 200)];
-    const result = berechneAuswertung(100, gebote);
-    expect(result.summeBeitraege).toBeCloseTo(100);
+  it('fehlbetrag = gesamtkosten − summeBeitraege', () => {
+    const slots = [slot('A', 1)];
+    const gebote = [gebot(1, 50)];
+    const result = berechneAuswertung(200, gebote, slots);
+    expect(result.fehlbetrag).toBeCloseTo(result.gesamtkosten - result.summeBeitraege);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Überschuss-Fall: alle bieten mehr als Richtwert-Anteil
+// ---------------------------------------------------------------------------
+
+describe('Überschuss-Fall', () => {
+  it('geldZurueck verteilt, summeBeitraege ≈ gesamtkosten', () => {
+    // richtwert = 100 / 2 = 50, beide bieten 80 → ueberRichtwert je 30
+    // überschuss = 160 − 100 = 60, geldZurueck je 30
+    // solidarischerBeitrag je 80 − 30 = 50
+    const slots = [slot('A', 1), slot('B', 1)];
+    const gebote = [gebot(1, 80), gebot(1, 80)];
+    const result = berechneAuswertung(100, gebote, slots);
+
+    expect(result.ueberschuss).toBeCloseTo(60);
     expect(result.fehlbetrag).toBe(0);
-    // kein Überschuss, exakt gedeckt
-    expect(result.ueberschuss).toBeCloseTo(0);
+    expect(result.summeBeitraege).toBeCloseTo(100);
+    for (const e of result.ergebnisse) {
+      expect(e.geldZurueck).toBeCloseTo(30);
+      expect(e.solidarischerBeitrag).toBeCloseTo(50);
+    }
   });
 
-  it('Beispiel aus ANFORDERUNGEN.md: gemischte Gebote', () => {
-    // Slot "Familie" Faktor 2.0: Gebot 80
-    // Slot "Student" Faktor 0.5: Gebot 15
-    // richtwert = 1000 / (2.0 + 0.5) = 400
-    // anteil Familie = 800, Gebot 80 < 800 → beitrag = 80
-    // anteil Student = 200, Gebot 15 < 200 → beitrag = 15
-    // summeBeitraege = 95, fehlbetrag = 905
+  it('nur Personen mit ueberRichtwert bekommen geldZurueck', () => {
+    // richtwert = 100 / 2 = 50
+    // A bietet 80 → ueberRichtwert 30
+    // B bietet 30 → kein ueberRichtwert (30 < 50)
+    // überschuss = 110 − 100 = 10
+    // A: geldZurueck = (30/30) × 10 = 10, beitrag = 70
+    // B: geldZurueck = 0, beitrag = 30
+    const slots = [slot('A', 1), slot('B', 1)];
     const gebote = [
-      gebot(2.0, 80, { emojiId: '🐼🚀🌈', slotLabel: 'Familie' }),
-      gebot(0.5, 15, { emojiId: '🦊🌙⭐', slotLabel: 'Student' }),
+      gebot(1, 80, { slotLabel: 'A' }),
+      gebot(1, 30, { slotLabel: 'B' }),
     ];
-    const result = berechneAuswertung(1000, gebote);
-    expect(result.richtwert).toBeCloseTo(400);
-    expect(result.ergebnisse[0].solidarischerBeitrag).toBe(80);
-    expect(result.ergebnisse[1].solidarischerBeitrag).toBe(15);
-    expect(result.summeBeitraege).toBeCloseTo(95);
-    expect(result.fehlbetrag).toBeCloseTo(905);
+    const result = berechneAuswertung(100, gebote, slots);
+
+    const a = result.ergebnisse.find((e) => e.slotLabel === 'A')!;
+    const b = result.ergebnisse.find((e) => e.slotLabel === 'B')!;
+
+    expect(a.geldZurueck).toBeCloseTo(10);
+    expect(a.solidarischerBeitrag).toBeCloseTo(70);
+    expect(b.geldZurueck).toBe(0);
+    expect(b.solidarischerBeitrag).toBe(30);
+    expect(result.summeBeitraege).toBeCloseTo(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gemischter Fall: Überschuss proportional auf Overbidder verteilt
+// ---------------------------------------------------------------------------
+
+describe('Gemischter Fall', () => {
+  it('proportionale Verteilung bei unterschiedlichen ueberRichtwert-Beträgen', () => {
+    // richtwert = 300 / 3 = 100
+    // A: gewichtung=1, Gebot=180 → ueberRichtwert=80
+    // B: gewichtung=1, Gebot=130 → ueberRichtwert=30
+    // C: gewichtung=1, Gebot=60  → kein ueberRichtwert
+    // summeGebote = 370, überschuss = 70
+    // summeUeberRichtwert = 110
+    // A geldZurueck = (80/110) × 70 ≈ 50.91
+    // B geldZurueck = (30/110) × 70 ≈ 19.09
+    const slots = [slot('A', 1), slot('B', 1), slot('C', 1)];
+    const gebote = [
+      gebot(1, 180, { slotLabel: 'A' }),
+      gebot(1, 130, { slotLabel: 'B' }),
+      gebot(1, 60, { slotLabel: 'C' }),
+    ];
+    const result = berechneAuswertung(300, gebote, slots);
+
+    const a = result.ergebnisse.find((e) => e.slotLabel === 'A')!;
+    const b = result.ergebnisse.find((e) => e.slotLabel === 'B')!;
+    const c = result.ergebnisse.find((e) => e.slotLabel === 'C')!;
+
+    expect(a.geldZurueck).toBeGreaterThan(0);
+    expect(b.geldZurueck).toBeGreaterThan(0);
+    expect(c.geldZurueck).toBe(0);
+    expect(a.geldZurueck).toBeGreaterThan(b.geldZurueck);
+    expect(result.summeBeitraege).toBeCloseTo(300);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Normalfall: summeGebote = gesamtkosten → kein geldZurueck
+// ---------------------------------------------------------------------------
+
+describe('Normalfall (exakt gedeckt)', () => {
+  it('keine Überschuss-Verteilung wenn summeGebote = gesamtkosten', () => {
+    // richtwert = 200 / 2 = 100, beide bieten exakt 100
+    const slots = [slot('A', 1), slot('B', 1)];
+    const gebote = [gebot(1, 100), gebot(1, 100)];
+    const result = berechneAuswertung(200, gebote, slots);
+
+    expect(result.ueberschuss).toBe(0);
+    expect(result.fehlbetrag).toBe(0);
+    for (const e of result.ergebnisse) {
+      expect(e.geldZurueck).toBe(0);
+      expect(e.solidarischerBeitrag).toBeCloseTo(e.gebot);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Korrekte Felder in GebotErgebnis
+// ---------------------------------------------------------------------------
+
+describe('GebotErgebnis Felder', () => {
+  it('richtwertAnteil = gewichtung × richtwert', () => {
+    // richtwert = 300 / (1+2) = 100
+    const slots = [slot('A', 1), slot('B', 2)];
+    const gebote = [
+      gebot(1, 80, { slotLabel: 'A' }),
+      gebot(2, 250, { slotLabel: 'B' }),
+    ];
+    const result = berechneAuswertung(300, gebote, slots);
+
+    const a = result.ergebnisse.find((e) => e.slotLabel === 'A')!;
+    const b = result.ergebnisse.find((e) => e.slotLabel === 'B')!;
+
+    expect(a.richtwertAnteil).toBeCloseTo(1 * result.richtwert);
+    expect(b.richtwertAnteil).toBeCloseTo(2 * result.richtwert);
   });
 
-  it('enthält korrekte Anzahl Ergebnisse', () => {
-    const gebote = [gebot(1, 50), gebot(1, 60), gebot(2, 100)];
-    const result = berechneAuswertung(300, gebote);
-    expect(result.ergebnisse).toHaveLength(3);
+  it('differenz = gebot − solidarischerBeitrag', () => {
+    const slots = [slot('A', 1), slot('B', 1)];
+    const gebote = [gebot(1, 120), gebot(1, 80)];
+    const result = berechneAuswertung(200, gebote, slots);
+
+    for (const e of result.ergebnisse) {
+      expect(e.differenz).toBeCloseTo(e.gebot - e.solidarischerBeitrag);
+    }
   });
 
-  it('fehlbetrag und ueberschuss sind nie beide > 0', () => {
-    const gebote = [gebot(1, 50), gebot(1, 200)];
-    const result = berechneAuswertung(100, gebote);
-    expect(result.fehlbetrag === 0 || result.ueberschuss === 0).toBe(true);
-  });
-
-  it('summeGebote ist die Summe aller rohen Gebote', () => {
+  it('summeGebote enthält rohe Gebots-Summe', () => {
+    const slots = [slot('A', 1), slot('B', 1)];
     const gebote = [gebot(1, 50), gebot(1, 70)];
-    const result = berechneAuswertung(200, gebote);
+    const result = berechneAuswertung(200, gebote, slots);
     expect(result.summeGebote).toBe(120);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rundungskorrektur: summeBeitraege ≈ gesamtkosten (nie größer)
+// ---------------------------------------------------------------------------
+
+describe('Rundungskorrektur', () => {
+  it('summeBeitraege weicht höchstens 1 Cent von gesamtkosten ab', () => {
+    // Schiefer Fall mit vielen Dezimalstellen
+    const slots = [slot('A', 1), slot('B', 1), slot('C', 1)];
+    const gebote = [gebot(1, 100), gebot(1, 100), gebot(1, 100)];
+    const result = berechneAuswertung(299.99, gebote, slots);
+
+    expect(Math.abs(result.summeBeitraege - result.gesamtkosten)).toBeLessThanOrEqual(0.01);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fehlerfälle
+// ---------------------------------------------------------------------------
+
+describe('Fehlerfälle', () => {
+  const einSlot = [slot('A', 1)];
+
+  it('wirft bei Gesamtkosten = 0', () => {
+    expect(() => berechneAuswertung(0, [gebot(1, 50)], einSlot)).toThrow(
+      'Gesamtkosten müssen größer als 0 sein',
+    );
+  });
+
+  it('wirft bei negativen Gesamtkosten', () => {
+    expect(() => berechneAuswertung(-100, [gebot(1, 50)], einSlot)).toThrow(
+      'Gesamtkosten müssen größer als 0 sein',
+    );
   });
 
   it('wirft bei leerer Gebote-Liste', () => {
-    expect(() => berechneAuswertung(100, [])).toThrow('Keine Gebote vorhanden');
+    expect(() => berechneAuswertung(100, [], einSlot)).toThrow('Keine Gebote vorhanden');
   });
 
-  it('wirft bei Gesamtkosten <= 0', () => {
-    expect(() => berechneAuswertung(0, [gebot(1, 50)])).toThrow(
-      'Gesamtkosten müssen größer als 0 sein',
-    );
-    expect(() => berechneAuswertung(-100, [gebot(1, 50)])).toThrow(
-      'Gesamtkosten müssen größer als 0 sein',
-    );
+  it('wirft bei leerer Slots-Liste', () => {
+    expect(() => berechneAuswertung(100, [gebot(1, 50)], [])).toThrow('Keine Slots definiert');
   });
 });

--- a/src/lib/solidarisch.ts
+++ b/src/lib/solidarisch.ts
@@ -28,9 +28,11 @@ export interface GebotErgebnis {
   slotLabel: string;
   gewichtung: number;
   gebot: number;
-  anteil: number;
-  solidarischerBeitrag: number;
-  differenz: number;
+  richtwertAnteil: number;      // gewichtung × richtwert (fairer Anteil laut Richtwert)
+  ueberRichtwert: number;       // max(0, gebot − richtwertAnteil)
+  geldZurueck: number;          // proportionaler Anteil am Überschuss
+  solidarischerBeitrag: number; // gebot − geldZurueck
+  differenz: number;            // gebot − solidarischerBeitrag (= geldZurueck)
 }
 
 export interface Auswertung {
@@ -38,8 +40,8 @@ export interface Auswertung {
   gesamtkosten: number;
   summeGebote: number;
   summeBeitraege: number;
-  fehlbetrag: number;
-  ueberschuss: number;
+  fehlbetrag: number;  // > 0 wenn Gebote die Kosten nicht decken
+  ueberschuss: number; // summeGebote − gesamtkosten vor Verteilung (>= 0)
   ergebnisse: GebotErgebnis[];
 }
 
@@ -70,52 +72,100 @@ export function generiereEmojiId(): string {
 // Berechnungslogik
 // ---------------------------------------------------------------------------
 
-/**
- * Berechnet den Richtwert pro Gewichtseinheit.
- * Nenner = Summe der Gewichtungen aller eingegangenen Gebote.
- */
-export function berechneRichtwert(gesamtkosten: number, gebote: Gebot[]): number {
-  if (gebote.length === 0) throw new Error('Keine Gebote vorhanden');
-  const summeGewichtungen = gebote.reduce((sum, g) => sum + g.gewichtung, 0);
-  return gesamtkosten / summeGewichtungen;
+function runden(x: number): number {
+  return Math.round(x * 100) / 100;
 }
 
 /**
- * Berechnet den solidarischen Beitrag für ein einzelnes Gebot.
- * - Wer weniger als seinen Anteil bietet, zahlt nur das Gebot.
- * - Wer mehr bietet, wird auf den Anteil reduziert.
+ * Vollständige Auswertung einer Runde nach dem solidarischen Modell.
+ *
+ * @param gesamtkosten - Gesamtkosten der Runde
+ * @param gebote       - Eingegangene Gebote
+ * @param alleSlots    - ALLE definierten Slot-Typen inkl. unbelegter
+ *
+ * Der Richtwert wird aus ALLEN definierten Slots berechnet (gewichtung × anzahl),
+ * nicht nur aus den eingegangenen Geboten. Das stellt sicher, dass unbelegte Slots
+ * die Kosten mitverantworten und der Richtwert stabil bleibt.
+ *
+ * Überschuss (summeGebote > gesamtkosten) wird proportional an die zurückgegeben,
+ * die mehr als ihren Richtwert-Anteil geboten haben — sodass summeBeitraege ≈ gesamtkosten.
  */
-export function berechneBeitrag(gebot: Gebot, richtwert: number): GebotErgebnis {
-  const anteil = gebot.gewichtung * richtwert;
-  const solidarischerBeitrag = gebot.betrag <= anteil ? gebot.betrag : anteil;
-  const differenz = gebot.betrag - solidarischerBeitrag;
-  return {
-    emojiId: gebot.emojiId,
-    slotLabel: gebot.slotLabel,
-    gewichtung: gebot.gewichtung,
-    gebot: gebot.betrag,
-    anteil,
-    solidarischerBeitrag,
-    differenz,
-  };
-}
-
-/**
- * Vollständige Auswertung einer Runde.
- * Wirft bei leerer Gebote-Liste oder ungültigen Gesamtkosten.
- */
-export function berechneAuswertung(gesamtkosten: number, gebote: Gebot[]): Auswertung {
+export function berechneAuswertung(
+  gesamtkosten: number,
+  gebote: Gebot[],
+  alleSlots: Slot[],
+): Auswertung {
   if (gesamtkosten <= 0) throw new Error('Gesamtkosten müssen größer als 0 sein');
   if (gebote.length === 0) throw new Error('Keine Gebote vorhanden');
+  if (alleSlots.length === 0) throw new Error('Keine Slots definiert');
 
-  const richtwert = berechneRichtwert(gesamtkosten, gebote);
-  const ergebnisse = gebote.map((g) => berechneBeitrag(g, richtwert));
+  // 1. Richtwert aus ALLEN definierten Slots (gewichtung × anzahl)
+  const summeAlleGewichtungen = alleSlots.reduce(
+    (s, slot) => s + slot.gewichtung * slot.anzahl,
+    0,
+  );
+  const richtwert = runden(gesamtkosten / summeAlleGewichtungen);
 
-  const summeGebote = gebote.reduce((sum, g) => sum + g.betrag, 0);
-  const summeBeitraege = ergebnisse.reduce((sum, e) => sum + e.solidarischerBeitrag, 0);
+  // 2. Summe Gebote + Überschuss (negativ = Fehlbetrag)
+  const summeGebote = runden(gebote.reduce((s, g) => s + g.betrag, 0));
+  const rohUeberschuss = runden(summeGebote - gesamtkosten);
+  const istFehlbetrag = rohUeberschuss < 0;
 
-  const fehlbetrag = Math.max(0, gesamtkosten - summeBeitraege);
-  const ueberschuss = Math.max(0, summeBeitraege - gesamtkosten);
+  // 3. Erster Pass: richtwertAnteil + ueberRichtwert pro Gebot
+  const mitUeberRichtwert = gebote.map((g) => {
+    const richtwertAnteil = runden(g.gewichtung * richtwert);
+    const ueberRichtwert = runden(Math.max(0, g.betrag - richtwertAnteil));
+    return { ...g, richtwertAnteil, ueberRichtwert };
+  });
+
+  const summeUeberRichtwert = runden(
+    mitUeberRichtwert.reduce((s, g) => s + g.ueberRichtwert, 0),
+  );
+
+  // 4. Zweiter Pass: geldZurueck + solidarischerBeitrag
+  const ergebnisse: GebotErgebnis[] = mitUeberRichtwert.map((g) => {
+    let geldZurueck = 0;
+    if (!istFehlbetrag && g.ueberRichtwert > 0 && summeUeberRichtwert > 0) {
+      geldZurueck = runden((g.ueberRichtwert / summeUeberRichtwert) * rohUeberschuss);
+    }
+    const solidarischerBeitrag = runden(g.betrag - geldZurueck);
+    return {
+      emojiId: g.emojiId,
+      slotLabel: g.slotLabel,
+      gewichtung: g.gewichtung,
+      gebot: g.betrag,
+      richtwertAnteil: g.richtwertAnteil,
+      ueberRichtwert: g.ueberRichtwert,
+      geldZurueck,
+      solidarischerBeitrag,
+      differenz: runden(g.betrag - solidarischerBeitrag),
+    };
+  });
+
+  // 5. Rundungskorrektur: Differenz auf letzten Slot mit ueberRichtwert > 0 anwenden
+  if (!istFehlbetrag && ergebnisse.length > 0) {
+    const summeBerechnete = runden(
+      ergebnisse.reduce((s, e) => s + e.solidarischerBeitrag, 0),
+    );
+    const delta = runden(summeBerechnete - gesamtkosten);
+    if (delta !== 0) {
+      const rueckwaerts = [...ergebnisse].reverse().findIndex((e) => e.ueberRichtwert > 0);
+      const idx =
+        rueckwaerts >= 0 ? ergebnisse.length - 1 - rueckwaerts : ergebnisse.length - 1;
+      ergebnisse[idx].geldZurueck = runden(ergebnisse[idx].geldZurueck + delta);
+      ergebnisse[idx].solidarischerBeitrag = runden(
+        ergebnisse[idx].solidarischerBeitrag - delta,
+      );
+      ergebnisse[idx].differenz = runden(
+        ergebnisse[idx].gebot - ergebnisse[idx].solidarischerBeitrag,
+      );
+    }
+  }
+
+  const summeBeitraege = runden(
+    ergebnisse.reduce((s, e) => s + e.solidarischerBeitrag, 0),
+  );
+  const fehlbetrag = Math.max(0, runden(gesamtkosten - summeBeitraege));
 
   return {
     richtwert,
@@ -123,7 +173,7 @@ export function berechneAuswertung(gesamtkosten: number, gebote: Gebot[]): Auswe
     summeGebote,
     summeBeitraege,
     fehlbetrag,
-    ueberschuss,
+    ueberschuss: Math.max(0, rohUeberschuss),
     ergebnisse,
   };
 }

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -62,7 +62,9 @@ import Layout from '../../../../layouts/Layout.astro';
             <th class="pb-2 pr-4 font-medium">Emoji-ID</th>
             <th class="pb-2 pr-4 font-medium">Slot</th>
             <th class="pb-2 pr-4 font-medium text-right">Faktor</th>
+            <th class="pb-2 pr-4 font-medium text-right">Richtwert-Anteil</th>
             <th class="pb-2 pr-4 font-medium text-right">Gebot</th>
+            <th class="pb-2 pr-4 font-medium text-right">Geld zurück</th>
             <th class="pb-2 pr-4 font-medium text-right">Beitrag</th>
             <th class="pb-2 pr-4 font-medium text-right splid-spalte hidden">Ausgaben (Splid)</th>
             <th class="pb-2 pr-4 font-medium text-right splid-spalte hidden">Noch zu zahlen</th>
@@ -192,7 +194,7 @@ import Layout from '../../../../layouts/Layout.astro';
     }
 
     // Auswertung berechnen
-    const auswertung = berechneAuswertung(blob.gesamtkosten, gebote);
+    const auswertung = berechneAuswertung(blob.gesamtkosten, gebote, blob.slots);
 
     // Kennzahlen befüllen
     document.getElementById('runde-name')!.textContent = blob.rundeName;
@@ -244,7 +246,9 @@ import Layout from '../../../../layouts/Layout.astro';
         <td class="py-2 pr-4 text-lg">${e.emojiId}</td>
         <td class="py-2 pr-4 text-slate-800">${e.slotLabel}</td>
         <td class="py-2 pr-4 text-right text-slate-600">${e.gewichtung}</td>
+        <td class="py-2 pr-4 text-right text-slate-500">${eur(e.richtwertAnteil)}</td>
         <td class="py-2 pr-4 text-right text-slate-600">${eur(e.gebot)}</td>
+        <td class="py-2 pr-4 text-right text-green-700">${e.geldZurueck > 0.005 ? '−' + eur(e.geldZurueck) : '–'}</td>
         <td class="py-2 pr-4 text-right font-medium">${eur(e.solidarischerBeitrag)}</td>
         ${splidZellen}
         <td class="py-2 text-right ${diffClass}">${diffSign}${eur(e.differenz)}</td>


### PR DESCRIPTION
## Was wurde gebaut

Zwei fundamentale Fehler in der Auswertungslogik (`solidarisch.ts`) wurden behoben:

**1. Falscher Richtwert-Nenner**
Der Richtwert wurde bisher nur aus den Gewichtungen der eingegangenen Gebote berechnet. Korrekt ist: alle definierten Slots (inkl. unbelegter) tragen zum Nenner bei. Das hält den Richtwert stabil, wenn nicht alle Plätze belegt sind.

**2. Fehlende Überschuss-Verteilung**
Wenn die Gruppe kollektiv mehr bot als die Gesamtkosten, wurde das überschüssige Geld einfach einbehalten — Gebote wurden still auf den Richtwert-Anteil gekappt. Jetzt gilt: Personen, die über ihrem Richtwert-Anteil geboten haben, bekommen `geldZurueck` proportional zurück, sodass `summeBeitraege ≈ gesamtkosten`.

## Änderungen

- `solidarisch.ts`: `berechneAuswertung` hat jetzt einen dritten Parameter `alleSlots`; neue Felder in `GebotErgebnis`: `richtwertAnteil`, `ueberRichtwert`, `geldZurueck`
- `solidarisch.test.ts`: 16 Tests komplett neu geschrieben für den korrekten Algorithmus
- `admin/[token].astro`: Aufruf auf `blob.slots` korrigiert; Tabelle zeigt jetzt auch „Richtwert-Anteil" und „Geld zurück"

## Wie wurde getestet

- 16 Vitest-Unit-Tests (alle grün): Richtwert aus unbelegten Slots, Überschuss-Fall mit `geldZurueck`-Verteilung, Fehlbetrag-Fall, gemischter Fall, Rundungskorrektur, Fehlerfälle
- Algorithmus anhand der verifizierten Referenzimplementierung in `input/berechnung.ts` validiert

## Was kommt als nächstes

Feature 2 (aus BACKLOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)