### PR TITLE
fix: Fehlbetrag- und Überschuss-Box nicht gleichzeitig anzeigen

### DIFF
--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -40,12 +40,12 @@ import Layout from '../../../../layouts/Layout.astro';
     </div>
 
     <!-- Fehlbetrag / Überschuss -->
-    <div id="fehlbetrag-box" class="vollstaendig-spalte hidden bg-red-50 border border-red-200 rounded-xl p-4 print:rounded-md print:p-3">
+    <div id="fehlbetrag-box" class="hidden bg-red-50 border border-red-200 rounded-xl p-4 print:rounded-md print:p-3">
       <p class="text-sm font-medium text-red-800">Fehlbetrag</p>
       <p id="fehlbetrag-text" class="text-2xl font-bold text-red-700 print:text-xl"></p>
       <p class="text-xs text-red-600 mt-1">Die solidarischen Beiträge decken die Gesamtkosten nicht.</p>
     </div>
-    <div id="ueberschuss-box" class="vollstaendig-spalte hidden bg-green-50 border border-green-200 rounded-xl p-4 print:rounded-md print:p-3">
+    <div id="ueberschuss-box" class="hidden bg-green-50 border border-green-200 rounded-xl p-4 print:rounded-md print:p-3">
       <p class="text-sm font-medium text-green-800">Überschuss</p>
       <p id="ueberschuss-text" class="text-2xl font-bold text-green-700 print:text-xl"></p>
     </div>


### PR DESCRIPTION
## Problem

Bei Runden mit Überschuss wurden fälschlicherweise beide Boxen „Fehlbetrag" und „Überschuss" gleichzeitig angezeigt.

## Ursache

Beide Boxen hatten die CSS-Klasse `vollstaendig-spalte`. Beim Einblenden der vollständigen Ansicht entfernte `querySelectorAll('.vollstaendig-spalte')` `hidden` von beiden Boxen auf einmal — bevor die if/else-Logik selektiv nur eine davon zeigen konnte.

## Fix

`vollstaendig-spalte` von beiden Boxen entfernt. Die Sichtbarkeit wird ausschließlich über die explizite if/else-Logik im Script gesteuert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)