### PR TITLE
feat: Meine Runden (Feature 4)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -32,9 +32,12 @@ const { title } = Astro.props;
       </div>
     </div>
     <script>
-      if (localStorage.getItem('fairshare_sync_id')) {
-        document.getElementById('nav-meine-runden')?.classList.remove('hidden');
-      }
+      try {
+        const runden = JSON.parse(localStorage.getItem('fairshare_runden') || '[]');
+        if (Array.isArray(runden) && runden.length > 0) {
+          document.getElementById('nav-meine-runden')?.classList.remove('hidden');
+        }
+      } catch { /* ignore */ }
     </script>
     <main class="mx-auto max-w-2xl px-4 py-6">
       <slot />

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,59 @@
+const STORAGE_KEY = 'fairshare_runden';
+
+export interface LocalRunde {
+  id: string;
+  name: string;
+  hinzugefuegtAm: string;
+  teilnehmerLink: string;
+  adminLink?: string;
+  slots?: Array<{ label: string; gewichtung: number; anzahl: number }>;
+}
+
+export function getRunden(): LocalRunde[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveRunde(runde: LocalRunde): void {
+  const runden = getRunden();
+  const idx = runden.findIndex((r) => r.id === runde.id);
+
+  if (idx === -1) {
+    runden.push(runde);
+  } else {
+    const existing = runden[idx];
+    // Upgrade: neuer Eintrag hat adminLink, bestehender nicht → überschreiben
+    if (runde.adminLink && !existing.adminLink) {
+      runden[idx] = runde;
+    }
+    // Downgrade ignorieren: bestehender hat adminLink, neuer nicht → nichts tun
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(runden));
+}
+
+export function deleteRunde(id: string): void {
+  const runden = getRunden().filter((r) => r.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(runden));
+}
+
+export function exportJson(): string {
+  return JSON.stringify(getRunden(), null, 2);
+}
+
+export function importJson(json: string): void {
+  const parsed = JSON.parse(json);
+  if (!Array.isArray(parsed)) throw new Error('Ungültiges Format: kein Array');
+  for (const entry of parsed) {
+    if (typeof entry?.id !== 'string' || typeof entry?.teilnehmerLink !== 'string') {
+      throw new Error('Ungültiges Format: Einträge fehlen Pflichtfelder');
+    }
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+}

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -1,0 +1,173 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Meine Runden">
+  <div class="space-y-6">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-semibold mb-1">Meine Runden</h1>
+        <p class="text-slate-500 text-sm">Gespeichert in deinem Browser.</p>
+      </div>
+      <div class="flex gap-2">
+        <button
+          id="export-btn"
+          class="border border-slate-300 rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+        >
+          Exportieren
+        </button>
+        <button
+          id="import-btn"
+          class="border border-slate-300 rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+        >
+          Importieren
+        </button>
+        <input type="file" id="import-file" accept=".json" class="hidden" />
+      </div>
+    </div>
+
+    <div id="import-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm"></div>
+
+    <!-- Leer-Zustand -->
+    <div id="leer-zustand" class="hidden text-center py-16 text-slate-500">
+      <p class="mb-4">Noch keine Runden gespeichert.</p>
+      <a href="/neu" class="inline-block bg-green-700 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-green-800 transition-colors">
+        Neue Runde erstellen
+      </a>
+    </div>
+
+    <!-- Runden-Liste -->
+    <div id="runden-liste" class="space-y-3"></div>
+  </div>
+</Layout>
+
+<script>
+  import { getRunden, deleteRunde, exportJson, importJson } from '../lib/storage';
+  import type { LocalRunde } from '../lib/storage';
+
+  const rundenListe = document.getElementById('runden-liste')!;
+  const leerZustand = document.getElementById('leer-zustand')!;
+  const importFehler = document.getElementById('import-fehler')!;
+
+  function formatDatum(iso: string): string {
+    return new Date(iso).toLocaleDateString('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+  }
+
+  function renderRunden() {
+    const runden = getRunden().sort(
+      (a, b) => new Date(b.hinzugefuegtAm).getTime() - new Date(a.hinzugefuegtAm).getTime(),
+    );
+
+    rundenListe.innerHTML = '';
+
+    // Nav-Link synchronisieren
+    const navLink = document.getElementById('nav-meine-runden');
+    if (navLink) navLink.classList.toggle('hidden', runden.length === 0);
+
+    if (runden.length === 0) {
+      leerZustand.classList.remove('hidden');
+      return;
+    }
+
+    leerZustand.classList.add('hidden');
+
+    for (const runde of runden) {
+      const istAdmin = !!runde.adminLink;
+      const karte = document.createElement('div');
+      karte.className = 'bg-white border border-slate-200 rounded-xl p-4 space-y-3';
+
+      const badge = istAdmin
+        ? '<span class="text-xs font-medium text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">Admin</span>'
+        : '<span class="text-xs font-medium text-slate-600 bg-slate-100 px-2 py-0.5 rounded-full">Teilnehmer:in</span>';
+
+      karte.innerHTML = `
+        <div class="flex items-start justify-between gap-2">
+          <div class="space-y-1">
+            <div class="flex items-center gap-2 flex-wrap">
+              ${badge}
+              <span class="text-sm font-medium text-slate-800">${runde.name}</span>
+            </div>
+            <p class="text-xs text-slate-400">Hinzugefügt am ${formatDatum(runde.hinzugefuegtAm)}</p>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <a
+            href="${runde.teilnehmerLink}"
+            class="inline-flex items-center gap-1 border border-slate-300 rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
+          >
+            Runde öffnen ↗
+          </a>
+          ${istAdmin ? `
+          <a
+            href="${runde.adminLink}"
+            class="inline-flex items-center gap-1 border border-amber-300 rounded-lg px-3 py-1.5 text-sm text-amber-700 hover:bg-amber-50 transition-colors"
+          >
+            Admin öffnen ↗
+          </a>
+          ` : ''}
+          <button
+            data-id="${runde.id}"
+            class="loeschen-btn ml-auto border border-red-200 rounded-lg px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 transition-colors"
+          >
+            Löschen
+          </button>
+        </div>
+      `;
+
+      rundenListe.appendChild(karte);
+    }
+
+  }
+
+  // Löschen (delegiert)
+  rundenListe.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.loeschen-btn');
+    if (!btn) return;
+    const id = btn.dataset.id!;
+    deleteRunde(id);
+    renderRunden();
+  });
+
+  // Export
+  document.getElementById('export-btn')!.addEventListener('click', () => {
+    const json = exportJson();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'fairshare_runden.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  // Import
+  const importFileInput = document.getElementById('import-file') as HTMLInputElement;
+
+  document.getElementById('import-btn')!.addEventListener('click', () => {
+    importFileInput.click();
+  });
+
+  importFileInput.addEventListener('change', async () => {
+    const file = importFileInput.files?.[0];
+    if (!file) return;
+    importFehler.classList.add('hidden');
+
+    try {
+      const text = await file.text();
+      importJson(text);
+      renderRunden();
+    } catch (err) {
+      importFehler.textContent =
+        err instanceof Error ? err.message : 'Fehler beim Importieren der Datei.';
+      importFehler.classList.remove('hidden');
+    }
+
+    importFileInput.value = '';
+  });
+
+  renderRunden();
+</script>

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -216,6 +216,7 @@ import Layout from '../layouts/Layout.astro';
     exportKey,
   } from '../lib/crypto';
   import { parseSplid } from '../lib/splid';
+  import { saveRunde } from '../lib/storage';
 
   const form = document.getElementById('runde-form') as HTMLFormElement;
   const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement;
@@ -416,6 +417,16 @@ import Layout from '../layouts/Layout.astro';
       const origin = window.location.origin;
       const teilnehmerLink = `${origin}/runde/${id}#pk=${partKeyB64}`;
       const adminLink = `${origin}/runde/${id}/admin/${adminToken}#pk=${partKeyB64}&bk=${adminPrivKeyB64}`;
+
+      // Runde im localStorage speichern
+      saveRunde({
+        id,
+        name: rundeName,
+        hinzugefuegtAm: new Date().toISOString(),
+        teilnehmerLink,
+        adminLink,
+        slots: slots.map(({ label, gewichtung, anzahl }) => ({ label, gewichtung, anzahl })),
+      });
 
       // Anzeigen
       (document.getElementById('teilnehmer-link') as HTMLInputElement).value = teilnehmerLink;

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -88,6 +88,7 @@ import Layout from '../../layouts/Layout.astro';
     hmac,
   } from '../../lib/crypto';
   import { EMOJIS, generiereEmojiId } from '../../lib/solidarisch';
+  import { saveRunde } from '../../lib/storage';
 
   interface TeilnehmerBlob {
     rundeName: string;
@@ -116,6 +117,9 @@ import Layout from '../../layouts/Layout.astro';
       );
       return;
     }
+
+    // Original-URL sichern bevor Fragment entfernt wird
+    const originalUrl = window.location.href;
 
     // Fragment aus History entfernen
     history.replaceState(null, '', window.location.pathname);
@@ -149,6 +153,14 @@ import Layout from '../../layouts/Layout.astro';
 
     const adminPubKey = await importAdminPubKey(blob.adminPubKey);
     const hmacKey = await importHmacKey(blob.hmacKey);
+
+    // Runde im localStorage speichern (Teilnehmer:in)
+    saveRunde({
+      id: rundenId,
+      name: blob.rundeName,
+      hinzugefuegtAm: new Date().toISOString(),
+      teilnehmerLink: originalUrl,
+    });
 
     // Seite befüllen
     document.getElementById('runde-name')!.textContent = blob.rundeName;


### PR DESCRIPTION
## Was wurde gebaut

**Feature 4 — Meine Runden:** Runden werden automatisch im localStorage des Browsers gespeichert und auf einer neuen Seite `/meine-runden` verwaltet.

### Neue Dateien
- **`src/lib/storage.ts`** — Typed localStorage-Helfer: `getRunden`, `saveRunde` (mit Upgrade-Logik), `deleteRunde`, `exportJson`, `importJson`
- **`src/pages/meine-runden.astro`** — Übersichtsseite mit chronologischer Liste, Admin/Teilnehmer:in-Badge, Aktions-Buttons, Export und Import

### Geänderte Dateien
- **`src/pages/neu.astro`** — Runde wird nach Erstellung automatisch mit `adminLink` + `slots` gespeichert
- **`src/pages/runde/[id].astro`** — Original-URL wird vor `history.replaceState` gesichert; nach erfolgreicher Entschlüsselung wird die Runde als Teilnehmer:in gespeichert
- **`src/layouts/Layout.astro`** — Nav-Check liest `fairshare_runden` statt dem alten `fairshare_sync_id`

### Datenmodell
Rolle wird implizit aus `adminLink !== undefined` abgeleitet — kein explizites Rollenfeld nötig. Deduplizierung per Runden-ID mit Upgrade-Logik (Teilnehmer:in → Admin möglich, nicht umgekehrt).

## Wie wurde getestet

- Neue Runde erstellen → localStorage-Eintrag mit `adminLink` und `slots` vorhanden
- Nav-Link „Meine Runden" erscheint nach Seitenaufruf
- `/meine-runden` zeigt Admin-Badge mit „Runde öffnen ↗" und „Admin öffnen ↗"
- Teilnehmer-Link öffnen → Runde gespeichert ohne `adminLink`; kein Downgrade wenn Admin-Eintrag bereits existiert
- Löschen → Leer-Zustand + Nav-Link verschwindet
- Export/Import geprüft

## Was kommt als nächstes

Feature 5 (Standardgebot) oder Feature 6 (Runde wiederholen / Als Vorlage — beinhaltet die Slot-Daten die bereits mitgespeichert werden).