### PR TITLE
fix: Differenz-Spalte entfernen und Dead Code bereinigen

### DIFF
--- a/src/lib/solidarisch.test.ts
+++ b/src/lib/solidarisch.test.ts
@@ -206,16 +206,6 @@ describe('GebotErgebnis Felder', () => {
     expect(b.richtwertAnteil).toBeCloseTo(2 * result.richtwert);
   });
 
-  it('differenz = gebot − solidarischerBeitrag', () => {
-    const slots = [slot('A', 1), slot('B', 1)];
-    const gebote = [gebot(1, 120), gebot(1, 80)];
-    const result = berechneAuswertung(200, gebote, slots);
-
-    for (const e of result.ergebnisse) {
-      expect(e.differenz).toBeCloseTo(e.gebot - e.solidarischerBeitrag);
-    }
-  });
-
   it('summeGebote enthält rohe Gebots-Summe', () => {
     const slots = [slot('A', 1), slot('B', 1)];
     const gebote = [gebot(1, 50), gebot(1, 70)];

--- a/src/lib/solidarisch.ts
+++ b/src/lib/solidarisch.ts
@@ -32,7 +32,6 @@ export interface GebotErgebnis {
   ueberRichtwert: number;       // max(0, gebot − richtwertAnteil)
   geldZurueck: number;          // proportionaler Anteil am Überschuss
   solidarischerBeitrag: number; // gebot − geldZurueck
-  differenz: number;            // gebot − solidarischerBeitrag (= geldZurueck)
 }
 
 export interface Auswertung {
@@ -138,7 +137,6 @@ export function berechneAuswertung(
       ueberRichtwert: g.ueberRichtwert,
       geldZurueck,
       solidarischerBeitrag,
-      differenz: runden(g.betrag - solidarischerBeitrag),
     };
   });
 
@@ -155,9 +153,6 @@ export function berechneAuswertung(
       ergebnisse[idx].geldZurueck = runden(ergebnisse[idx].geldZurueck + delta);
       ergebnisse[idx].solidarischerBeitrag = runden(
         ergebnisse[idx].solidarischerBeitrag - delta,
-      );
-      ergebnisse[idx].differenz = runden(
-        ergebnisse[idx].gebot - ergebnisse[idx].solidarischerBeitrag,
       );
     }
   }

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -62,7 +62,6 @@ import Layout from '../../../../layouts/Layout.astro';
             <th class="pb-2 pr-4 font-medium text-right vollstaendig-spalte hidden">Beitrag</th>
             <th class="pb-2 pr-4 font-medium text-right splid-spalte vollstaendig-spalte hidden">Ausgaben</th>
             <th class="pb-2 pr-4 font-medium text-right splid-spalte vollstaendig-spalte hidden">Noch zu zahlen</th>
-            <th class="pb-2 font-medium text-right vollstaendig-spalte hidden">Differenz</th>
           </tr>
         </thead>
         <tbody id="tabelle-body" class="divide-y divide-slate-100"></tbody>
@@ -224,9 +223,6 @@ import Layout from '../../../../layouts/Layout.astro';
       const nochZuZahlen = e.solidarischerBeitrag - ausgaben;
       const nochSign = nochZuZahlen > 0.005 ? '+' : '';
       const nochClass = nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700';
-      const diffSign = e.differenz > 0.005 ? '+' : '';
-      const diffClass = e.differenz > 0.005 ? 'text-green-700' : 'text-slate-600';
-
       const splidZellen = hatSplidDaten
         ? `<td class="py-2 pr-4 text-right text-slate-600 splid-spalte vollstaendig-spalte hidden">${eur(ausgaben)}</td>
            <td class="py-2 pr-4 text-right font-medium splid-spalte vollstaendig-spalte hidden ${nochClass}">${nochSign}${eur(nochZuZahlen)}</td>`
@@ -239,7 +235,6 @@ import Layout from '../../../../layouts/Layout.astro';
         <td class="py-2 pr-4 text-right text-slate-500">${eur(e.richtwertAnteil)}</td>
         <td class="py-2 pr-4 text-right font-medium vollstaendig-spalte hidden">${eur(e.solidarischerBeitrag)}</td>
         ${splidZellen}
-        <td class="py-2 text-right vollstaendig-spalte hidden ${diffClass}">${diffSign}${eur(e.differenz)}</td>
       `;
       tbody.appendChild(tr);
     }


### PR DESCRIPTION
## Was wurde geändert

### Problem
Die Spalte „Differenz" in der Admin-Auswertung hatte zwei Probleme:

1. **Privacy-Leak:** `Differenz = Gebot − Beitrag`, d.h. `Gebot = Beitrag + Differenz` — in anonymen Runden konnte damit das ursprüngliche Gebot jeder Person exakt rekonstruiert werden. Das widerspricht dem Grundprinzip der App.
2. **Redundanz:** In Runden mit Ausgaben ist „Noch zu zahlen" die relevante Zahl — die Differenz (= Rückerstattung aus dem Überschuss) ist darin bereits eingerechnet und wird nicht separat benötigt.

### Lösung
- Spalte „Differenz" aus der Admin-Ansicht entfernt
- `differenz`-Feld aus dem `GebotErgebnis`-Interface entfernt
- Zugehörige Berechnungen und Rundungskorrektur in `solidarisch.ts` entfernt
- Test für `differenz` in `solidarisch.test.ts` entfernt

## Wie wurde getestet

- Alle 39 Tests grün (`vitest run`)
- Admin-Ansicht manuell geprüft: Spalten Richtwert-Anteil, Beitrag, Ausgaben, Noch zu zahlen erscheinen korrekt

## Was kommt als nächstes

Feature 2 — Gebot nachträglich korrigieren

🤖 Generated with [Claude Code](https://claude.com/claude-code)