### PR TITLE
feat: Standardgebot pro Slot-Typ mit Richtwert-Anzeige

### DIFF
--- a/src/lib/solidarisch.test.ts
+++ b/src/lib/solidarisch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   berechneAuswertung,
+  berechneRichtwert,
   type Gebot,
   type Slot,
 } from './solidarisch';
@@ -226,6 +227,85 @@ describe('Rundungskorrektur', () => {
     const result = berechneAuswertung(299.99, gebote, slots);
 
     expect(Math.abs(result.summeBeitraege - result.gesamtkosten)).toBeLessThanOrEqual(0.01);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// berechneRichtwert
+// ---------------------------------------------------------------------------
+
+describe('berechneRichtwert', () => {
+  it('berechnet richtwert korrekt', () => {
+    // 3 Slots à gewichtung=1, anzahl=1 → summe=3, richtwert=300/3=100
+    const slots: Slot[] = [
+      { label: 'A', gewichtung: 1, anzahl: 1 },
+      { label: 'B', gewichtung: 1, anzahl: 1 },
+      { label: 'C', gewichtung: 1, anzahl: 1 },
+    ];
+    expect(berechneRichtwert(300, slots)).toBe(100);
+  });
+
+  it('berücksichtigt gewichtung × anzahl', () => {
+    // Familie: gewichtung=2, anzahl=2 → 4; Single: gewichtung=1, anzahl=1 → 1; summe=5
+    const slots: Slot[] = [
+      { label: 'Familie', gewichtung: 2, anzahl: 2 },
+      { label: 'Single', gewichtung: 1, anzahl: 1 },
+    ];
+    expect(berechneRichtwert(500, slots)).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Standardgebot: synthetische Gebote werden korrekt verarbeitet
+// ---------------------------------------------------------------------------
+
+describe('Standardgebot (synthetische Gebote)', () => {
+  it('istStandard wird in GebotErgebnis durchgereicht', () => {
+    const slots: Slot[] = [
+      { label: 'Erwachsener', gewichtung: 1, anzahl: 1 },
+      { label: 'Kind', gewichtung: 0.5, anzahl: 1, standardgebot: 40 },
+    ];
+    const gebote: Gebot[] = [
+      { emojiId: '🐼🚀🌈', slotLabel: 'Erwachsener', gewichtung: 1, betrag: 80 },
+      { emojiId: '—', slotLabel: 'Kind', gewichtung: 0.5, betrag: 40, istStandard: true },
+    ];
+    const result = berechneAuswertung(120, gebote, slots);
+
+    const kind = result.ergebnisse.find((e) => e.slotLabel === 'Kind')!;
+    expect(kind.istStandard).toBe(true);
+    expect(kind.gebot).toBe(40);
+  });
+
+  it('echtes Gebot für Slot mit standardgebot: istStandard bleibt undefined', () => {
+    const slots: Slot[] = [
+      { label: 'Kind', gewichtung: 0.5, anzahl: 1, standardgebot: 40 },
+    ];
+    const gebote: Gebot[] = [
+      { emojiId: '🌟🎉🦋', slotLabel: 'Kind', gewichtung: 0.5, betrag: 60 },
+    ];
+    const result = berechneAuswertung(120, gebote, slots);
+    expect(result.ergebnisse[0].istStandard).toBeUndefined();
+    expect(result.ergebnisse[0].gebot).toBe(60);
+  });
+
+  it('summeBeitraege korrekt bei gemischten echten + synthetischen Geboten', () => {
+    // richtwert = 120 / (1×1 + 0.5×1) = 120 / 1.5 = 80
+    // Erwachsener: gebot=90, richtwertAnteil=80, ueberRichtwert=10
+    // Kind (Standard): gebot=40, richtwertAnteil=40, ueberRichtwert=0
+    // summeGebote = 130, überschuss = 10
+    // Erwachsener: geldZurueck = 10, beitrag = 80
+    // Kind: beitrag = 40
+    // summeBeitraege ≈ 120
+    const slots: Slot[] = [
+      { label: 'Erwachsener', gewichtung: 1, anzahl: 1 },
+      { label: 'Kind', gewichtung: 0.5, anzahl: 1, standardgebot: 40 },
+    ];
+    const gebote: Gebot[] = [
+      { emojiId: '🐼🚀🌈', slotLabel: 'Erwachsener', gewichtung: 1, betrag: 90 },
+      { emojiId: '—', slotLabel: 'Kind', gewichtung: 0.5, betrag: 40, istStandard: true },
+    ];
+    const result = berechneAuswertung(120, gebote, slots);
+    expect(result.summeBeitraege).toBeCloseTo(120);
   });
 });
 

--- a/src/lib/solidarisch.ts
+++ b/src/lib/solidarisch.ts
@@ -14,6 +14,7 @@ export interface Slot {
   gewichtung: number;
   anzahl: number;
   ausgaben?: number; // aus Splid importierte Ausgaben der Person (optional)
+  standardgebot?: number; // optionaler Standardwert (€), wird zur Auswertungszeit eingesetzt
 }
 
 export interface Gebot {
@@ -21,6 +22,7 @@ export interface Gebot {
   slotLabel: string;
   gewichtung: number;
   betrag: number;
+  istStandard?: boolean; // true wenn aus standardgebot synthetisiert (kein echtes Gebot)
 }
 
 export interface GebotErgebnis {
@@ -32,6 +34,7 @@ export interface GebotErgebnis {
   ueberRichtwert: number;       // max(0, gebot − richtwertAnteil)
   geldZurueck: number;          // proportionaler Anteil am Überschuss
   solidarischerBeitrag: number; // gebot − geldZurueck
+  istStandard?: boolean;        // true wenn aus standardgebot synthetisiert (kein echtes Gebot)
 }
 
 export interface Auswertung {
@@ -70,6 +73,15 @@ export function generiereEmojiId(): string {
 // ---------------------------------------------------------------------------
 // Berechnungslogik
 // ---------------------------------------------------------------------------
+
+/**
+ * Berechnet den Richtwert (Kosten pro Gewichtungseinheit) aus allen definierten Slots.
+ * Kann auf Teilnehmer- und Admin-Seite genutzt werden.
+ */
+export function berechneRichtwert(gesamtkosten: number, slots: Slot[]): number {
+  const summe = slots.reduce((s, slot) => s + slot.gewichtung * slot.anzahl, 0);
+  return Math.round(gesamtkosten / summe * 100) / 100;
+}
 
 function runden(x: number): number {
   return Math.round(x * 100) / 100;
@@ -137,6 +149,7 @@ export function berechneAuswertung(
       ueberRichtwert: g.ueberRichtwert,
       geldZurueck,
       solidarischerBeitrag,
+      ...(g.istStandard ? { istStandard: true } : {}),
     };
   });
 

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -126,6 +126,23 @@ import Layout from '../layouts/Layout.astro';
                 class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
               />
             </div>
+            <div class="standardgebot-zeile flex items-center gap-2 flex-wrap">
+              <span class="standardgebot-richtwert text-xs text-slate-400"></span>
+              <label class="flex items-center gap-1 text-xs text-slate-500 cursor-pointer select-none">
+                <input type="checkbox" class="standardgebot-checkbox accent-green-700" />
+                Standardgebot festlegen
+              </label>
+              <div class="standardgebot-eingabe hidden flex items-center gap-1">
+                <input
+                  type="number"
+                  name="standardgebot[]"
+                  min="0"
+                  step="0.01"
+                  data-auto="true"
+                  class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                />
+              </div>
+            </div>
           </div>
         </div>
         <p class="text-xs text-slate-400 mt-1">Label ist optional. Ohne Label heißt der Slot „Slot".</p>
@@ -271,6 +288,67 @@ import Layout from '../layouts/Layout.astro';
     });
   }
 
+  function aktualisiereRichtwert() {
+    const gesamtkosten = parseFloat(
+      (form.querySelector('#gesamtkosten') as HTMLInputElement).value,
+    );
+    if (!gesamtkosten || gesamtkosten <= 0) return;
+
+    const slotEls = [...slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag')];
+    const summeGewichtungen = slotEls.reduce((s, el) => {
+      const g = parseFloat((el.querySelector('[name="gewichtung[]"]') as HTMLInputElement).value) || 0;
+      const a = parseInt((el.querySelector('[name="anzahl[]"]') as HTMLInputElement).value) || 0;
+      return s + g * a;
+    }, 0);
+    if (summeGewichtungen <= 0) return;
+
+    const richtwert = Math.round((gesamtkosten / summeGewichtungen) * 100) / 100;
+
+    slotEls.forEach((el) => {
+      const g = parseFloat((el.querySelector('[name="gewichtung[]"]') as HTMLInputElement).value) || 1;
+      const richtwertSlot = Math.round(richtwert * g * 100) / 100;
+
+      const stdInput = el.querySelector<HTMLInputElement>('[name="standardgebot[]"]');
+      if (stdInput && stdInput.dataset.auto === 'true') {
+        stdInput.value = richtwertSlot.toFixed(2);
+      }
+
+      const richtwertAnzeige = el.querySelector<HTMLSpanElement>('.standardgebot-richtwert');
+      if (richtwertAnzeige) {
+        richtwertAnzeige.textContent = `Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
+      }
+    });
+  }
+
+  document.getElementById('gesamtkosten')!.addEventListener('input', aktualisiereRichtwert);
+
+  slotsContainer.addEventListener('input', (e) => {
+    const target = e.target as HTMLInputElement;
+    if (target.name === 'standardgebot[]') {
+      target.dataset.auto = 'false';
+    } else if (target.name === 'gewichtung[]' || target.name === 'anzahl[]') {
+      aktualisiereRichtwert();
+    }
+  });
+
+  slotsContainer.addEventListener('change', (e) => {
+    const target = e.target as HTMLInputElement;
+    if (!target.classList.contains('standardgebot-checkbox')) return;
+    const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
+    const eingabe = eintrag.querySelector('.standardgebot-eingabe') as HTMLDivElement;
+    const stdInput = eintrag.querySelector<HTMLInputElement>('[name="standardgebot[]"]');
+    if (target.checked) {
+      eingabe.classList.remove('hidden');
+      // aktualisiereRichtwert hat data-auto-Felder schon befüllt
+    } else {
+      eingabe.classList.add('hidden');
+      if (stdInput) {
+        stdInput.value = '';
+        stdInput.dataset.auto = 'true';
+      }
+    }
+  });
+
   // ---------------------------------------------------------------------------
   // Splid-Import
   // ---------------------------------------------------------------------------
@@ -326,6 +404,7 @@ import Layout from '../layouts/Layout.astro';
       aktualisiereEntfernenButtons();
       ausgabenToggle.checked = true;
       setzeAusgabenSichtbarkeit(true);
+      aktualisiereRichtwert();
 
       const namen = personen.map((p) => p.name).join(', ');
       splidErfolgEl.textContent = `${personen.length} Personen importiert: ${namen}`;
@@ -354,11 +433,21 @@ import Layout from '../layouts/Layout.astro';
       else if (inp.name === 'anzahl[]') inp.value = '1';
       else inp.value = '';
     });
+    // Standardgebot zurücksetzen
+    const stdCheckbox = klon.querySelector<HTMLInputElement>('.standardgebot-checkbox');
+    if (stdCheckbox) stdCheckbox.checked = false;
+    const stdEingabe = klon.querySelector<HTMLDivElement>('.standardgebot-eingabe');
+    if (stdEingabe) stdEingabe.classList.add('hidden');
+    const stdInput = klon.querySelector<HTMLInputElement>('[name="standardgebot[]"]');
+    if (stdInput) { stdInput.value = ''; stdInput.dataset.auto = 'true'; }
+    const richtwertAnzeige = klon.querySelector<HTMLSpanElement>('.standardgebot-richtwert');
+    if (richtwertAnzeige) richtwertAnzeige.textContent = '';
     // Ausgaben-Zeile entsprechend Toggle-Zustand ein-/ausblenden
     const ausgabenZeile = klon.querySelector('.ausgaben-zeile') as HTMLDivElement;
     ausgabenZeile.classList.toggle('hidden', !ausgabenToggle.checked);
     slotsContainer.appendChild(klon);
     aktualisiereEntfernenButtons();
+    aktualisiereRichtwert();
   });
 
   // Slot entfernen (delegiert)
@@ -405,11 +494,16 @@ import Layout from '../layouts/Layout.astro';
       const slots = labels.map((label, i) => {
         const ausgabenRaw = (slotEintraege[i]?.querySelector('[name="ausgaben[]"]') as HTMLInputElement)?.value;
         const ausgaben = ausgabenRaw ? parseFloat(ausgabenRaw) : undefined;
+        const stdRaw = (slotEintraege[i]?.querySelector('[name="standardgebot[]"]') as HTMLInputElement)?.value;
+        const standardgebot = stdRaw ? parseFloat(stdRaw) : undefined;
         return {
           label,
           gewichtung: gewichtungen[i],
           anzahl: anzahlen[i],
           ...(ausgaben !== undefined && isFinite(ausgaben) ? { ausgaben } : {}),
+          ...(standardgebot !== undefined && isFinite(standardgebot) && standardgebot > 0
+            ? { standardgebot }
+            : {}),
         };
       });
 

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -45,9 +45,7 @@ import Layout from '../../layouts/Layout.astro';
           placeholder="z.B. 80"
           class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
         />
-        <p class="text-xs text-slate-400 mt-1">
-          Gib den Betrag, den du beitragen kannst oder möchtest.
-        </p>
+        <p id="betrag-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
       </div>
 
       <!-- Fehler -->
@@ -95,7 +93,7 @@ import Layout from '../../layouts/Layout.astro';
     gesamtkosten: number;
     adminPubKey: string;
     hmacKey: string;
-    slots: { label: string; gewichtung: number; anzahl: number }[];
+    slots: { label: string; gewichtung: number; anzahl: number; standardgebot?: number }[];
   }
 
   function zeigeFehler(msg: string) {
@@ -162,6 +160,15 @@ import Layout from '../../layouts/Layout.astro';
       teilnehmerLink: originalUrl,
     });
 
+    // Richtwert berechnen
+    const summeGewichtungen = blob.slots.reduce(
+      (s, slot) => s + slot.gewichtung * slot.anzahl,
+      0,
+    );
+    const richtwert = summeGewichtungen > 0
+      ? Math.round((blob.gesamtkosten / summeGewichtungen) * 100) / 100
+      : 0;
+
     // Seite befüllen
     document.getElementById('runde-name')!.textContent = blob.rundeName;
     document.getElementById('gesamtkosten')!.textContent = `${blob.gesamtkosten.toLocaleString('de-DE')} €`;
@@ -169,6 +176,7 @@ import Layout from '../../layouts/Layout.astro';
     // Slot-Auswahl rendern
     const slotAuswahl = document.getElementById('slot-auswahl')!;
     blob.slots.forEach((slot, idx) => {
+      const richtwertSlot = Math.round(richtwert * slot.gewichtung * 100) / 100;
       const label = document.createElement('label');
       label.className =
         'flex items-center gap-3 bg-white border border-slate-200 rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 transition-colors';
@@ -176,11 +184,38 @@ import Layout from '../../layouts/Layout.astro';
         <input type="radio" name="slot" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
         <span class="flex-1">
           <span class="text-sm font-medium text-slate-800">${slot.label}</span>
-          <span class="text-xs text-slate-500 ml-2">Faktor ${slot.gewichtung} · ${slot.anzahl} Platz/Plätze</span>
+          <span class="text-xs text-slate-500 ml-2">Faktor ${slot.gewichtung} · ${slot.anzahl} Platz/Plätze · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
         </span>
       `;
       slotAuswahl.appendChild(label);
     });
+
+    // Betrag-Feld + Richtwert-Hinweis bei Slot-Wechsel aktualisieren
+    const betragInput = document.getElementById('betrag') as HTMLInputElement;
+    const betragHinweis = document.getElementById('betrag-richtwert-hinweis')!;
+
+    function aktualisiereBetragFeld(slotIdx: number) {
+      const slot = blob.slots[slotIdx];
+      if (!slot) return;
+      const richtwertSlot = Math.round(richtwert * slot.gewichtung * 100) / 100;
+      if (slot.standardgebot !== undefined) {
+        betragInput.value = slot.standardgebot.toFixed(2);
+        betragHinweis.textContent = `Standardgebot: ${slot.standardgebot.toFixed(2).replace('.', ',')} € · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
+      } else {
+        betragInput.value = '';
+        betragHinweis.textContent = `Richtwert für diesen Slot: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
+      }
+    }
+
+    slotAuswahl.addEventListener('change', (e) => {
+      const radio = e.target as HTMLInputElement;
+      if (radio.name === 'slot') {
+        aktualisiereBetragFeld(parseInt(radio.value, 10));
+      }
+    });
+
+    // Initiale Vorausfüllung für den ersten Slot
+    aktualisiereBetragFeld(0);
 
     // Formular anzeigen
     document.getElementById('zustand-laden')!.classList.add('hidden');

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -96,7 +96,7 @@ import Layout from '../../../../layouts/Layout.astro';
     gesamtkosten: number;
     adminPubKey: string;
     hmacKey: string;
-    slots: { label: string; gewichtung: number; anzahl: number; ausgaben?: number }[];
+    slots: { label: string; gewichtung: number; anzahl: number; ausgaben?: number; standardgebot?: number }[];
   }
 
   function eur(value: number): string {
@@ -174,15 +174,34 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Vollständigkeit prüfen
-    const totalErwartet = blob.slots.reduce((s, slot) => s + slot.anzahl, 0);
+    // Nur Slots OHNE standardgebot brauchen echte Gebote
+    const totalErwartet = blob.slots
+      .filter((s) => s.standardgebot === undefined)
+      .reduce((s, slot) => s + slot.anzahl, 0);
     const allesDa = gebote.length >= totalErwartet;
+
+    // Synthetische Gebote für Slots mit standardgebot (fehlende Plätze auffüllen)
+    const alleGebote: Gebot[] = [...gebote];
+    for (const slot of blob.slots) {
+      if (slot.standardgebot === undefined) continue;
+      const echteDesSlots = gebote.filter((g) => g.slotLabel === slot.label).length;
+      const fehlende = slot.anzahl - echteDesSlots;
+      for (let i = 0; i < fehlende; i++) {
+        alleGebote.push({
+          emojiId: '—',
+          slotLabel: slot.label,
+          gewichtung: slot.gewichtung,
+          betrag: slot.standardgebot,
+          istStandard: true,
+        });
+      }
+    }
 
     // Kopfdaten immer anzeigen
     document.getElementById('runde-name')!.textContent = blob.rundeName;
     document.getElementById('kz-gesamtkosten')!.textContent = eur(blob.gesamtkosten);
 
-    if (gebote.length === 0) {
+    if (alleGebote.length === 0) {
       document.getElementById('kz-richtwert')!.textContent = '–';
       document.getElementById('gebote-anzahl')!.textContent = `0 von ${totalErwartet} Geboten eingegangen.`;
       document.getElementById('zustand-laden')!.classList.add('hidden');
@@ -190,8 +209,8 @@ import Layout from '../../../../layouts/Layout.astro';
       return;
     }
 
-    // Auswertung berechnen
-    const auswertung = berechneAuswertung(blob.gesamtkosten, gebote, blob.slots);
+    // Auswertung berechnen (mit echten + synthetischen Geboten)
+    const auswertung = berechneAuswertung(blob.gesamtkosten, alleGebote, blob.slots);
 
     document.getElementById('kz-richtwert')!.textContent = eur(auswertung.richtwert);
     document.getElementById('kz-summe-beitraege')!.textContent = eur(auswertung.summeBeitraege);
@@ -218,23 +237,27 @@ import Layout from '../../../../layouts/Layout.astro';
     const tbody = document.getElementById('tabelle-body')!;
     for (const e of auswertung.ergebnisse) {
       const tr = document.createElement('tr');
+      if (e.istStandard) tr.classList.add('text-slate-400');
 
       const ausgaben = ausgabenMap.get(e.slotLabel) ?? 0;
       const nochZuZahlen = e.solidarischerBeitrag - ausgaben;
       const nochSign = nochZuZahlen > 0.005 ? '+' : '';
-      const nochClass = nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700';
+      const nochClass = e.istStandard ? '' : (nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700');
       const ausgabenZelle = hatSplidDaten
-        ? `<td class="py-2 pr-4 text-right text-slate-600 splid-spalte vollstaendig-spalte hidden">${eur(ausgaben)}</td>`
+        ? `<td class="py-2 pr-4 text-right splid-spalte vollstaendig-spalte hidden">${eur(ausgaben)}</td>`
         : '';
       const nochZuZahlenZelle = hatSplidDaten
         ? `<td class="py-2 pr-4 text-right font-medium splid-spalte vollstaendig-spalte hidden ${nochClass}">${nochSign}${eur(nochZuZahlen)}</td>`
         : '';
+      const emojiZelle = e.istStandard
+        ? `<td class="py-2 pr-4"><span class="text-xs bg-slate-100 text-slate-500 rounded px-1.5 py-0.5">Standard</span></td>`
+        : `<td class="py-2 pr-4 text-lg">${e.emojiId}</td>`;
 
       tr.innerHTML = `
-        <td class="py-2 pr-4 text-lg">${e.emojiId}</td>
-        <td class="py-2 pr-4 text-slate-800">${e.slotLabel}</td>
-        <td class="py-2 pr-4 text-right text-slate-600">${e.gewichtung}</td>
-        <td class="py-2 pr-4 text-right text-slate-500">${eur(e.richtwertAnteil)}</td>
+        ${emojiZelle}
+        <td class="py-2 pr-4">${e.slotLabel}</td>
+        <td class="py-2 pr-4 text-right">${e.gewichtung}</td>
+        <td class="py-2 pr-4 text-right">${eur(e.richtwertAnteil)}</td>
         ${ausgabenZelle}
         <td class="py-2 pr-4 text-right font-medium vollstaendig-spalte hidden">${eur(e.solidarischerBeitrag)}</td>
         ${nochZuZahlenZelle}
@@ -258,9 +281,12 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Statuszeile
+    // Statuszeile (echte Gebote zählen, nicht synthetische)
     if (allesDa) {
-      document.getElementById('gebote-anzahl')!.textContent = `Alle ${totalErwartet} Gebote eingegangen — Auswertung vollständig`;
+      document.getElementById('gebote-anzahl')!.textContent =
+        totalErwartet === 0
+          ? 'Auswertung vollständig (alle Slots mit Standardgebot)'
+          : `Alle ${totalErwartet} Gebote eingegangen — Auswertung vollständig`;
     } else {
       document.getElementById('gebote-anzahl')!.textContent = `${gebote.length} von ${totalErwartet} Geboten eingegangen`;
     }


### PR DESCRIPTION
## Was wurde gebaut

Feature 5 — Standardgebot pro Slot-Typ

### Rundenerstellung (`neu.astro`)
- Pro Slot-Typ wird der berechnete **Richtwert** angezeigt (aktualisiert sich live bei Änderungen an Gesamtkosten, Faktor oder Plätzen)
- Neue Checkbox „Standardgebot festlegen" — standardmäßig ausgeblendet
- Beim Aktivieren erscheint ein Eingabefeld, vorausgefüllt mit dem Richtwert × Faktor
- Der Standardwert wird verschlüsselt im `encTeilnehmerBlob` gespeichert

### Teilnehmer-Seite (`runde/[id].astro`)
- Jeder Slot zeigt seinen Richtwert im Label (z.B. `Faktor 1 · 2 Plätze · Richtwert: 40,00 €`)
- Ist ein Standardgebot gesetzt, wird das Betrag-Feld damit vorausgefüllt (änderbar)
- Hinweistext unter dem Betrag-Feld zeigt Standardgebot und Richtwert

### Admin-Auswertung (`admin/[token].astro`)
- Slots mit `standardgebot` aber ohne echtes Gebot werden automatisch mit synthetischen Geboten aufgefüllt (Option B: Fallback zur Auswertungszeit)
- Synthetische Zeilen erscheinen mit grauem Text und Badge **„Standard"** statt Emoji-ID
- `totalErwartet` zählt nur Slots ohne `standardgebot` — Vollständigkeit wird korrekt berechnet

### Bibliothek (`solidarisch.ts`)
- `Slot.standardgebot?: number` — neues optionales Feld
- `Gebot.istStandard?: boolean` — kennzeichnet synthetische Gebote
- `GebotErgebnis.istStandard?: boolean` — wird durch `berechneAuswertung` durchgereicht
- Neue exportierte Funktion `berechneRichtwert(gesamtkosten, slots)` — wird auf Teilnehmer- und Admin-Seite genutzt

## Wie wurde getestet

- 3 neue Tests in `solidarisch.test.ts`: `berechneRichtwert`, `istStandard`-Durchreichung, `summeBeitraege` bei gemischten Geboten
- Alle 44 Tests grün (`vitest run`)

## Was kommt als nächstes

- Feature 2: Gebot nachträglich korrigieren
- Feature 6: Runde wiederholen
- Feature 7: Landing Page