### PR TITLE
fix: Standardgebot-Bug, ROUNDUP, Fehlbetrag, Status-Badges

### DIFF
--- a/src/lib/solidarisch.ts
+++ b/src/lib/solidarisch.ts
@@ -80,7 +80,7 @@ export function generiereEmojiId(): string {
  */
 export function berechneRichtwert(gesamtkosten: number, slots: Slot[]): number {
   const summe = slots.reduce((s, slot) => s + slot.gewichtung * slot.anzahl, 0);
-  return Math.round(gesamtkosten / summe * 100) / 100;
+  return Math.ceil(gesamtkosten / summe * 100) / 100;
 }
 
 function runden(x: number): number {
@@ -115,7 +115,8 @@ export function berechneAuswertung(
     (s, slot) => s + slot.gewichtung * slot.anzahl,
     0,
   );
-  const richtwert = runden(gesamtkosten / summeAlleGewichtungen);
+  const rawRichtwert = gesamtkosten / summeAlleGewichtungen;
+  const richtwert = Math.ceil(rawRichtwert * 100) / 100; // ROUNDUP (wie Excel)
 
   // 2. Summe Gebote + Überschuss (negativ = Fehlbetrag)
   const summeGebote = runden(gebote.reduce((s, g) => s + g.betrag, 0));
@@ -124,7 +125,7 @@ export function berechneAuswertung(
 
   // 3. Erster Pass: richtwertAnteil + ueberRichtwert pro Gebot
   const mitUeberRichtwert = gebote.map((g) => {
-    const richtwertAnteil = runden(g.gewichtung * richtwert);
+    const richtwertAnteil = Math.ceil(g.gewichtung * rawRichtwert * 100) / 100; // ROUNDUP pro Person
     const ueberRichtwert = runden(Math.max(0, g.betrag - richtwertAnteil));
     return { ...g, richtwertAnteil, ueberRichtwert };
   });

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -302,11 +302,11 @@ import Layout from '../layouts/Layout.astro';
     }, 0);
     if (summeGewichtungen <= 0) return;
 
-    const richtwert = Math.round((gesamtkosten / summeGewichtungen) * 100) / 100;
+    const rawRichtwert = gesamtkosten / summeGewichtungen;
 
     slotEls.forEach((el) => {
       const g = parseFloat((el.querySelector('[name="gewichtung[]"]') as HTMLInputElement).value) || 1;
-      const richtwertSlot = Math.round(richtwert * g * 100) / 100;
+      const richtwertSlot = Math.ceil(rawRichtwert * g * 100) / 100;
 
       const stdInput = el.querySelector<HTMLInputElement>('[name="standardgebot[]"]');
       if (stdInput && stdInput.dataset.auto === 'true') {
@@ -494,7 +494,10 @@ import Layout from '../layouts/Layout.astro';
       const slots = labels.map((label, i) => {
         const ausgabenRaw = (slotEintraege[i]?.querySelector('[name="ausgaben[]"]') as HTMLInputElement)?.value;
         const ausgaben = ausgabenRaw ? parseFloat(ausgabenRaw) : undefined;
-        const stdRaw = (slotEintraege[i]?.querySelector('[name="standardgebot[]"]') as HTMLInputElement)?.value;
+        const stdCheckbox = slotEintraege[i]?.querySelector<HTMLInputElement>('.standardgebot-checkbox');
+        const stdRaw = stdCheckbox?.checked
+          ? (slotEintraege[i]?.querySelector<HTMLInputElement>('[name="standardgebot[]"]'))?.value
+          : undefined;
         const standardgebot = stdRaw ? parseFloat(stdRaw) : undefined;
         return {
           label,

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -165,9 +165,7 @@ import Layout from '../../layouts/Layout.astro';
       (s, slot) => s + slot.gewichtung * slot.anzahl,
       0,
     );
-    const richtwert = summeGewichtungen > 0
-      ? Math.round((blob.gesamtkosten / summeGewichtungen) * 100) / 100
-      : 0;
+    const rawRichtwert = summeGewichtungen > 0 ? blob.gesamtkosten / summeGewichtungen : 0;
 
     // Seite befüllen
     document.getElementById('runde-name')!.textContent = blob.rundeName;
@@ -176,7 +174,7 @@ import Layout from '../../layouts/Layout.astro';
     // Slot-Auswahl rendern
     const slotAuswahl = document.getElementById('slot-auswahl')!;
     blob.slots.forEach((slot, idx) => {
-      const richtwertSlot = Math.round(richtwert * slot.gewichtung * 100) / 100;
+      const richtwertSlot = Math.ceil(rawRichtwert * slot.gewichtung * 100) / 100;
       const label = document.createElement('label');
       label.className =
         'flex items-center gap-3 bg-white border border-slate-200 rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 transition-colors';
@@ -197,7 +195,7 @@ import Layout from '../../layouts/Layout.astro';
     function aktualisiereBetragFeld(slotIdx: number) {
       const slot = blob.slots[slotIdx];
       if (!slot) return;
-      const richtwertSlot = Math.round(richtwert * slot.gewichtung * 100) / 100;
+      const richtwertSlot = Math.ceil(rawRichtwert * slot.gewichtung * 100) / 100;
       if (slot.standardgebot !== undefined) {
         betragInput.value = slot.standardgebot.toFixed(2);
         betragHinweis.textContent = `Standardgebot: ${slot.standardgebot.toFixed(2).replace('.', ',')} € · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -55,13 +55,14 @@ import Layout from '../../../../layouts/Layout.astro';
       <table class="w-full text-sm border-collapse">
         <thead>
           <tr class="border-b border-slate-200 text-left text-xs text-slate-500">
-            <th class="pb-2 pr-4 font-medium">Emoji-ID</th>
+            <th class="pb-2 pr-4 font-medium emoji-spalte">Emoji-ID</th>
             <th class="pb-2 pr-4 font-medium">Slot</th>
             <th class="pb-2 pr-4 font-medium text-right">Faktor</th>
             <th class="pb-2 pr-4 font-medium text-right">Richtwert</th>
             <th class="pb-2 pr-4 font-medium text-right splid-spalte vollstaendig-spalte hidden">Ausgaben</th>
             <th class="pb-2 pr-4 font-medium text-right vollstaendig-spalte hidden">Beitrag</th>
             <th class="pb-2 pr-4 font-medium text-right splid-spalte vollstaendig-spalte hidden">Noch zu zahlen</th>
+            <th class="pb-2 font-medium">Status</th>
           </tr>
         </thead>
         <tbody id="tabelle-body" class="divide-y divide-slate-100"></tbody>
@@ -89,7 +90,7 @@ import Layout from '../../../../layouts/Layout.astro';
     decrypt,
     decryptGebot,
   } from '../../../../lib/crypto';
-  import { berechneAuswertung, type Gebot } from '../../../../lib/solidarisch';
+  import { berechneAuswertung, type Gebot, type GebotErgebnis } from '../../../../lib/solidarisch';
 
   interface TeilnehmerBlob {
     rundeName: string;
@@ -201,87 +202,131 @@ import Layout from '../../../../layouts/Layout.astro';
     document.getElementById('runde-name')!.textContent = blob.rundeName;
     document.getElementById('kz-gesamtkosten')!.textContent = eur(blob.gesamtkosten);
 
-    if (alleGebote.length === 0) {
-      document.getElementById('kz-richtwert')!.textContent = '–';
-      document.getElementById('gebote-anzahl')!.textContent = `0 von ${totalErwartet} Geboten eingegangen.`;
-      document.getElementById('zustand-laden')!.classList.add('hidden');
-      document.getElementById('zustand-auswertung')!.classList.remove('hidden');
-      return;
+    // Fehlbetrag-Früherkennung: wenn alle Gebote da, aber Summe < Kosten
+    if (allesDa && alleGebote.length > 0) {
+      const summeGebote = Math.round(alleGebote.reduce((s, g) => s + g.betrag, 0) * 100) / 100;
+      if (summeGebote < blob.gesamtkosten) {
+        const fehlbetrag = Math.round((blob.gesamtkosten - summeGebote) * 100) / 100;
+        document.getElementById('fehlbetrag-text')!.textContent = eur(fehlbetrag);
+        document.getElementById('fehlbetrag-box')!.classList.remove('hidden');
+        document.getElementById('gebote-anzahl')!.textContent =
+          'Alle Gebote eingegangen — Fehlbetrag, Runde muss wiederholt werden.';
+        document.getElementById('zustand-laden')!.classList.add('hidden');
+        document.getElementById('zustand-auswertung')!.classList.remove('hidden');
+        return;
+      }
     }
 
-    // Auswertung berechnen (mit echten + synthetischen Geboten)
-    const auswertung = berechneAuswertung(blob.gesamtkosten, alleGebote, blob.slots);
+    // Auswertung berechnen (nur wenn Gebote vorhanden)
+    const auswertung = alleGebote.length > 0
+      ? berechneAuswertung(blob.gesamtkosten, alleGebote, blob.slots)
+      : null;
 
-    document.getElementById('kz-richtwert')!.textContent = eur(auswertung.richtwert);
-    document.getElementById('kz-summe-beitraege')!.textContent = eur(auswertung.summeBeitraege);
-
-    // Fehlbetrag / Überschuss nur bei Vollständigkeit befüllen (Box bleibt hidden bis allesDa)
-    if (allesDa) {
-      if (auswertung.fehlbetrag > 0.005) {
-        document.getElementById('fehlbetrag-text')!.textContent = eur(auswertung.fehlbetrag);
-      } else if (auswertung.ueberschuss > 0.005) {
-        document.getElementById('ueberschuss-text')!.textContent = eur(auswertung.ueberschuss);
-      }
+    // Richtwert für Anzeige + "fehlt"-Zeilen
+    const summeAlleGewichtungen = blob.slots.reduce((s, sl) => s + sl.gewichtung * sl.anzahl, 0);
+    const rawRichtwert = blob.gesamtkosten / summeAlleGewichtungen;
+    document.getElementById('kz-richtwert')!.textContent = auswertung
+      ? eur(auswertung.richtwert)
+      : eur(Math.ceil(rawRichtwert * 100) / 100);
+    if (auswertung) {
+      document.getElementById('kz-summe-beitraege')!.textContent = eur(auswertung.summeBeitraege);
     }
 
     // Splid-Ausgaben-Map aufbauen (slotLabel → ausgaben)
     const ausgabenMap = new Map<string, number>();
     for (const slot of blob.slots) {
-      if (slot.ausgaben !== undefined) {
-        ausgabenMap.set(slot.label, slot.ausgaben);
-      }
+      if (slot.ausgaben !== undefined) ausgabenMap.set(slot.label, slot.ausgaben);
     }
     const hatSplidDaten = ausgabenMap.size > 0;
 
-    // Tabelle befüllen
+    // Ergebnisse nach Slot gruppieren für positionsbasierte Darstellung
+    const ergebnisseBySlot = new Map<string, GebotErgebnis[]>();
+    if (auswertung) {
+      for (const e of auswertung.ergebnisse) {
+        if (!ergebnisseBySlot.has(e.slotLabel)) ergebnisseBySlot.set(e.slotLabel, []);
+        ergebnisseBySlot.get(e.slotLabel)!.push(e);
+      }
+    }
+
+    // Tabelle befüllen — alle Slot-Positionen (geboten / auto / fehlt)
     const tbody = document.getElementById('tabelle-body')!;
-    for (const e of auswertung.ergebnisse) {
-      const tr = document.createElement('tr');
-      if (e.istStandard) tr.classList.add('text-slate-400');
+    for (const slot of blob.slots) {
+      const slotErgebnisse = ergebnisseBySlot.get(slot.label) ?? [];
+      const richtwertAnteil = Math.ceil(slot.gewichtung * rawRichtwert * 100) / 100;
+      const ausgaben = ausgabenMap.get(slot.label) ?? 0;
 
-      const ausgaben = ausgabenMap.get(e.slotLabel) ?? 0;
-      const nochZuZahlen = e.solidarischerBeitrag - ausgaben;
-      const nochSign = nochZuZahlen > 0.005 ? '+' : '';
-      const nochClass = e.istStandard ? '' : (nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700');
-      const ausgabenZelle = hatSplidDaten
-        ? `<td class="py-2 pr-4 text-right splid-spalte vollstaendig-spalte hidden">${eur(ausgaben)}</td>`
-        : '';
-      const nochZuZahlenZelle = hatSplidDaten
-        ? `<td class="py-2 pr-4 text-right font-medium splid-spalte vollstaendig-spalte hidden ${nochClass}">${nochSign}${eur(nochZuZahlen)}</td>`
-        : '';
-      const emojiZelle = e.istStandard
-        ? `<td class="py-2 pr-4"><span class="text-xs bg-slate-100 text-slate-500 rounded px-1.5 py-0.5">Standard</span></td>`
-        : `<td class="py-2 pr-4 text-lg">${e.emojiId}</td>`;
+      for (let i = 0; i < slot.anzahl; i++) {
+        const e = slotErgebnisse[i];
+        const istStandard = e?.istStandard === true;
+        const hatGebot = !!e && !istStandard;
+        const fehlt = !e;
 
-      tr.innerHTML = `
-        ${emojiZelle}
-        <td class="py-2 pr-4">${e.slotLabel}</td>
-        <td class="py-2 pr-4 text-right">${e.gewichtung}</td>
-        <td class="py-2 pr-4 text-right">${eur(e.richtwertAnteil)}</td>
-        ${ausgabenZelle}
-        <td class="py-2 pr-4 text-right font-medium vollstaendig-spalte hidden">${eur(e.solidarischerBeitrag)}</td>
-        ${nochZuZahlenZelle}
-      `;
-      tbody.appendChild(tr);
+        const tr = document.createElement('tr');
+        if (!hatGebot) tr.classList.add('text-slate-400');
+
+        let statusBadge: string;
+        if (hatGebot) {
+          statusBadge = '<span class="text-xs bg-green-100 text-green-700 rounded px-1.5 py-0.5 font-medium">geboten</span>';
+        } else if (istStandard) {
+          statusBadge = '<span class="text-xs bg-green-100 text-green-700 rounded px-1.5 py-0.5 font-medium">auto</span>';
+        } else {
+          statusBadge = '<span class="text-xs bg-slate-100 text-slate-500 rounded px-1.5 py-0.5">fehlt</span>';
+        }
+
+        const emojiZelle = hatGebot
+          ? `<td class="py-2 pr-4 text-lg emoji-spalte">${e.emojiId}</td>`
+          : `<td class="py-2 pr-4 emoji-spalte">—</td>`;
+
+        const ausgabenZelle = hatSplidDaten
+          ? `<td class="py-2 pr-4 text-right splid-spalte vollstaendig-spalte hidden">${fehlt ? '—' : eur(ausgaben)}</td>`
+          : '';
+
+        const beitragZelle = fehlt
+          ? `<td class="py-2 pr-4 text-right vollstaendig-spalte hidden">—</td>`
+          : `<td class="py-2 pr-4 text-right font-medium vollstaendig-spalte hidden">${eur(e.solidarischerBeitrag)}</td>`;
+
+        let nochZuZahlenZelle = '';
+        if (hatSplidDaten) {
+          if (fehlt) {
+            nochZuZahlenZelle = `<td class="py-2 pr-4 text-right splid-spalte vollstaendig-spalte hidden">—</td>`;
+          } else {
+            const nochZuZahlen = e.solidarischerBeitrag - ausgaben;
+            const nochSign = nochZuZahlen > 0.005 ? '+' : '';
+            const nochClass = istStandard ? '' : (nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700');
+            nochZuZahlenZelle = `<td class="py-2 pr-4 text-right font-medium splid-spalte vollstaendig-spalte hidden ${nochClass}">${nochSign}${eur(nochZuZahlen)}</td>`;
+          }
+        }
+
+        tr.innerHTML = `
+          ${emojiZelle}
+          <td class="py-2 pr-4">${slot.label}</td>
+          <td class="py-2 pr-4 text-right">${slot.gewichtung}</td>
+          <td class="py-2 pr-4 text-right">${fehlt ? eur(richtwertAnteil) : eur(e.richtwertAnteil)}</td>
+          ${ausgabenZelle}
+          ${beitragZelle}
+          ${nochZuZahlenZelle}
+          <td class="py-2 pr-4">${statusBadge}</td>
+        `;
+        tbody.appendChild(tr);
+      }
     }
 
     // Vollständige Spalten + Boxen einblenden
-    if (allesDa) {
+    if (allesDa && auswertung) {
       document.querySelectorAll('.vollstaendig-spalte').forEach((el) => el.classList.remove('hidden'));
-      // Splid-Spalten nur wenn Splid-Daten vorhanden (vollstaendig-spalte hat schon hidden entfernt,
-      // splid-spalte-Elemente brauchen beide Klassen)
       if (!hatSplidDaten) {
         document.querySelectorAll('.splid-spalte').forEach((el) => el.classList.add('hidden'));
       }
-      // Fehlbetrag/Überschuss-Box
-      if (auswertung.fehlbetrag > 0.005) {
-        document.getElementById('fehlbetrag-box')!.classList.remove('hidden');
-      } else if (auswertung.ueberschuss > 0.005) {
+      if (hatSplidDaten) {
+        document.querySelectorAll('.emoji-spalte').forEach((el) => el.classList.add('hidden'));
+      }
+      if (auswertung.ueberschuss > 0.005) {
+        document.getElementById('ueberschuss-text')!.textContent = eur(auswertung.ueberschuss);
         document.getElementById('ueberschuss-box')!.classList.remove('hidden');
       }
     }
 
-    // Statuszeile (echte Gebote zählen, nicht synthetische)
+    // Statuszeile
     if (allesDa) {
       document.getElementById('gebote-anzahl')!.textContent =
         totalErwartet === 0


### PR DESCRIPTION
## Was wurde gebaut

### Fix 1 — Standardgebot-Bug
`neu.astro`: Der Submit-Handler prüft jetzt ob die Checkbox „Standardgebot festlegen" tatsächlich aktiv ist, bevor der Wert übernommen wird. Zuvor wurde das per `aktualisiereRichtwert()` vorausgefüllte (aber versteckte) Feld immer mitgesendet.

### Fix 2 — ROUNDUP für Richtwert
`solidarisch.ts`, `neu.astro`, `runde/[id].astro`, `admin/[token].astro`: Alle Richtwert-Berechnungen verwenden jetzt `Math.ceil(rawRichtwert × faktor × 100) / 100` statt `Math.round` — entspricht der Excel-Formel `ROUNDUP(kosten/summe × faktor, 2)`.

### Fix 3 — Fehlbetrag-Anzeige
`admin/[token].astro`: Wenn alle Gebote eingegangen sind, die Summe aber die Kosten nicht deckt, wird nur eine Fehlbetrag-Meldung angezeigt („Runde muss wiederholt werden") — keine unnötige Berechnungstabelle.

### Fix 4 — Status-Badges in der Admin-Tabelle
`admin/[token].astro`: Die Tabelle iteriert jetzt über alle Slot-Positionen (statt nur über eingegangene Gebote) und zeigt pro Zeile einen Status-Badge:
- **geboten** (grün) — echtes Gebot eingegangen
- **auto** (grün) — Standardgebot, kein echtes Gebot nötig
- **fehlt** (grau) — noch kein Gebot

### Fix 5 — Emoji-Spalte in Splid-Ansicht
Bei importierten Splid-Daten (Personen mit Klarnamen) wird die Emoji-ID-Spalte ausgeblendet — der Label ist der primäre Bezeichner.

### Fix 6 — Dev-Server im Worktree
`start-dev.mjs`: Fallback auf `node_modules` des Hauptprojekts, wenn im Worktree keine installiert sind.

## Wie wurde getestet

- Richtwert-Berechnung im Browser verifiziert: 1526,23 € / 7,375 → 206,95 € (ROUNDUP ✓)
- Keine Browser-Konsolenfehler
- `npm run test` ausstehend (bitte vor dem Merge ausführen)

## Was kommt als nächstes

Feature 2 (Gebot nachträglich korrigieren) oder Feature 3 (Ausgleichszahlungen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)