### PR TITLE
fix: Duplikat-Gebote erkennen und warnen

### DIFF
--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -51,6 +51,16 @@ import Layout from '../../layouts/Layout.astro';
       <!-- Fehler -->
       <div id="gebot-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm"></div>
 
+      <!-- Duplikat-Warnung (Soft-Warning, kein Hard-Block) -->
+      <div id="duplikat-warnung" class="hidden bg-amber-50 border border-amber-300 text-amber-800 rounded-lg p-3 text-sm space-y-2">
+        <p class="font-medium">Von diesem Gerät wurde für diesen Slot bereits ein Gebot abgegeben.</p>
+        <p class="text-xs text-amber-700">Möchtest du trotzdem ein weiteres Gebot einreichen?</p>
+        <div class="flex gap-2 pt-1">
+          <button type="button" id="duplikat-abbrechen" class="flex-1 border border-amber-400 text-amber-800 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 transition-colors">Abbrechen</button>
+          <button type="button" id="duplikat-bestaetigen" class="flex-1 bg-amber-600 text-white rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-700 transition-colors">Trotzdem abgeben</button>
+        </div>
+      </div>
+
       <button
         type="submit"
         id="gebot-btn"
@@ -58,6 +68,8 @@ import Layout from '../../layouts/Layout.astro';
       >
         Gebot abgeben
       </button>
+
+      <p class="text-xs text-slate-400 text-center">Dieser Schutz gilt nur für dieses Gerät.</p>
     </form>
   </div>
 
@@ -171,10 +183,22 @@ import Layout from '../../layouts/Layout.astro';
     document.getElementById('runde-name')!.textContent = blob.rundeName;
     document.getElementById('gesamtkosten')!.textContent = `${blob.gesamtkosten.toLocaleString('de-DE')} €`;
 
+    // localStorage-Helfer: speichert welche Slots von diesem Gerät bereits geboten wurden
+    function lsKey(label: string) {
+      return `fairshare-slot-${rundenId}-${encodeURIComponent(label)}`;
+    }
+    function slotBereitsGeboten(label: string): boolean {
+      return localStorage.getItem(lsKey(label)) === '1';
+    }
+    function slotAlsGebotenMarkieren(label: string) {
+      localStorage.setItem(lsKey(label), '1');
+    }
+
     // Slot-Auswahl rendern
     const slotAuswahl = document.getElementById('slot-auswahl')!;
     blob.slots.forEach((slot, idx) => {
       const richtwertSlot = Math.ceil(rawRichtwert * slot.gewichtung * 100) / 100;
+      const bereitsGeboten = slotBereitsGeboten(slot.label);
       const label = document.createElement('label');
       label.className =
         'flex items-center gap-3 bg-white border border-slate-200 rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 transition-colors';
@@ -183,6 +207,7 @@ import Layout from '../../layouts/Layout.astro';
         <span class="flex-1">
           <span class="text-sm font-medium text-slate-800">${slot.label}</span>
           <span class="text-xs text-slate-500 ml-2">Faktor ${slot.gewichtung} · ${slot.anzahl} Platz/Plätze · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
+          ${bereitsGeboten ? '<span class="text-xs text-amber-600 ml-1">(bereits abgegeben)</span>' : ''}
         </span>
       `;
       slotAuswahl.appendChild(label);
@@ -223,10 +248,14 @@ import Layout from '../../layouts/Layout.astro';
     const gebotForm = document.getElementById('gebot-form') as HTMLFormElement;
     const gebotBtn = document.getElementById('gebot-btn') as HTMLButtonElement;
     const gebotFehler = document.getElementById('gebot-fehler') as HTMLDivElement;
+    const duplikatWarnung = document.getElementById('duplikat-warnung') as HTMLDivElement;
+    const duplikatAbbrechen = document.getElementById('duplikat-abbrechen') as HTMLButtonElement;
+    const duplikatBestaetigen = document.getElementById('duplikat-bestaetigen') as HTMLButtonElement;
 
-    gebotForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
+    // Kernfunktion: Gebot tatsächlich einreichen
+    async function gebot_einreichen() {
       gebotFehler.classList.add('hidden');
+      duplikatWarnung.classList.add('hidden');
       gebotBtn.disabled = true;
       gebotBtn.textContent = 'Verschlüssele…';
 
@@ -267,6 +296,9 @@ import Layout from '../../layouts/Layout.astro';
           return;
         }
 
+        // localStorage: Slot als geboten markieren
+        slotAlsGebotenMarkieren(selectedSlot.label);
+
         // Bestätigung anzeigen
         document.getElementById('emoji-anzeige')!.textContent = emojiId;
         document.getElementById('emoji-id-text')!.textContent = emojiId;
@@ -280,6 +312,33 @@ import Layout from '../../layouts/Layout.astro';
         gebotBtn.disabled = false;
         gebotBtn.textContent = 'Gebot abgeben';
       }
+    }
+
+    gebotForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+
+      // Prüfen ob gewählter Slot von diesem Gerät bereits geboten wurde
+      const selectedIdx = parseInt(
+        (gebotForm.querySelector('input[name="slot"]:checked') as HTMLInputElement).value,
+        10,
+      );
+      const selectedSlot = blob.slots[selectedIdx];
+
+      if (slotBereitsGeboten(selectedSlot.label)) {
+        // Soft-Warning anzeigen, nicht direkt einreichen
+        duplikatWarnung.classList.remove('hidden');
+        return;
+      }
+
+      await gebot_einreichen();
+    });
+
+    // Warnung-Buttons
+    duplikatAbbrechen.addEventListener('click', () => {
+      duplikatWarnung.classList.add('hidden');
+    });
+    duplikatBestaetigen.addEventListener('click', async () => {
+      await gebot_einreichen();
     });
   }
 

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -40,6 +40,11 @@ import Layout from '../../../../layouts/Layout.astro';
     </div>
 
     <!-- Fehlbetrag / Überschuss -->
+    <div id="duplikat-box" class="hidden bg-red-50 border border-red-200 rounded-xl p-4 print:rounded-md print:p-3">
+      <p class="text-sm font-medium text-red-800">⚠️ Zu viele Gebote — Auswertung nicht möglich</p>
+      <p class="text-xs text-red-700 mt-1 mb-2">Für folgende Slots sind mehr Gebote eingegangen als erwartet. Bitte kläre die Doppeleinreichung und bitte die betroffene Person, nicht nochmals zu bieten.</p>
+      <ul id="duplikat-liste" class="text-xs text-red-700 space-y-0.5 list-disc list-inside"></ul>
+    </div>
     <div id="fehlbetrag-box" class="hidden bg-red-50 border border-red-200 rounded-xl p-4 print:rounded-md print:p-3">
       <p class="text-sm font-medium text-red-800">Fehlbetrag</p>
       <p id="fehlbetrag-text" class="text-2xl font-bold text-red-700 print:text-xl"></p>
@@ -185,7 +190,18 @@ import Layout from '../../../../layouts/Layout.astro';
     const totalErwartet = blob.slots
       .filter((s) => s.standardgebot === undefined)
       .reduce((s, slot) => s + slot.anzahl, 0);
-    const allesDa = gebote.length >= totalErwartet;
+    const allesDa = gebote.length === totalErwartet;
+
+    // Duplikat-Check: Gebote pro Slot zählen und gegen slot.anzahl prüfen
+    const zuVieleProSlot = blob.slots
+      .filter((s) => s.standardgebot === undefined)
+      .map((slot) => ({
+        label: slot.label,
+        eingegangen: gebote.filter((g) => g.slotLabel === slot.label).length,
+        erwartet: slot.anzahl,
+      }))
+      .filter((s) => s.eingegangen > s.erwartet);
+    const hatDuplikate = zuVieleProSlot.length > 0;
 
     // Synthetische Gebote für Slots mit standardgebot (fehlende Plätze auffüllen)
     const alleGebote: Gebot[] = [...gebote];
@@ -221,6 +237,17 @@ import Layout from '../../../../layouts/Layout.astro';
         document.getElementById('zustand-auswertung')!.classList.remove('hidden');
         return;
       }
+    }
+
+    // Duplikat-Warnung anzeigen (vor Berechnung)
+    if (hatDuplikate) {
+      const liste = document.getElementById('duplikat-liste')!;
+      for (const s of zuVieleProSlot) {
+        const li = document.createElement('li');
+        li.textContent = `Slot „${s.label}": ${s.eingegangen} Gebote erhalten, ${s.erwartet} erwartet (+${s.eingegangen - s.erwartet})`;
+        liste.appendChild(li);
+      }
+      document.getElementById('duplikat-box')!.classList.remove('hidden');
     }
 
     // Auswertung berechnen (nur wenn Gebote vorhanden)
@@ -317,8 +344,8 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Ausgleichszahlungen (nur wenn vollständig, kein Fehlbetrag, Ausgaben vorhanden)
-    if (allesDa && auswertung && auswertung.fehlbetrag <= 0.005 && ausgabenMap.size > 0) {
+    // Ausgleichszahlungen (nur wenn vollständig, kein Fehlbetrag, keine Duplikate, Ausgaben vorhanden)
+    if (allesDa && !hatDuplikate && auswertung && auswertung.fehlbetrag <= 0.005 && ausgabenMap.size > 0) {
       const zahlungen = berechneAusgleich(auswertung.ergebnisse, ausgabenMap);
       if (zahlungen.length > 0) {
         const liste = document.getElementById('ausgleich-liste')!;
@@ -331,8 +358,8 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Vollständige Spalten + Boxen einblenden
-    if (allesDa && auswertung) {
+    // Vollständige Spalten + Boxen einblenden (nur wenn vollständig und keine Duplikate)
+    if (allesDa && !hatDuplikate && auswertung) {
       document.querySelectorAll('.vollstaendig-spalte').forEach((el) => el.classList.remove('hidden'));
       if (!hatSplidDaten) {
         document.querySelectorAll('.splid-spalte').forEach((el) => el.classList.add('hidden'));
@@ -346,8 +373,12 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Statuszeile
-    if (allesDa) {
+    // Statuszeile (echte Gebote zählen, nicht synthetische)
+    if (hatDuplikate) {
+      const total = gebote.length;
+      document.getElementById('gebote-anzahl')!.textContent =
+        `${total} Gebote eingegangen, ${totalErwartet} erwartet — bitte Doppelgebote klären`;
+    } else if (allesDa) {
       document.getElementById('gebote-anzahl')!.textContent =
         totalErwartet === 0
           ? 'Auswertung vollständig (alle Slots mit Standardgebot)'


### PR DESCRIPTION
## Was wurde gebaut

**Problem:** Wenn jemand die Teilnehmer-Seite neu lädt und ein zweites Mal bietet (neue Emoji-ID), wurden beide Gebote akzeptiert. Das führte in der Admin-Auswertung zu einem fälschlich wachsenden Überschuss bei kaum veränderten Einzelbeträgen.

### Admin-Seite
- Gebote pro `slotLabel` werden nach dem Entschlüsseln gegen `slot.anzahl` aus dem Blob geprüft
- Bei Duplikaten: rote Warnbox mit Detailangabe pro betroffenen Slot (z.B. „Slot ‚Erwachsener': 3 Gebote erhalten, 2 erwartet (+1)")
- Vollständige Spalten (Beitrag, Ausgleich) bleiben bei Duplikaten versteckt — keine fehlerhafte Berechnung
- Fix: `allesDa` nutzt jetzt `===` statt `>=`

### Teilnehmer-Seite
- localStorage-Key `fairshare-slot-{rundenId}-{slotLabel}` wird nach erfolgreicher Einreichung gesetzt
- Bereits gebotene Slots erhalten den Hinweis „(bereits abgegeben)"
- Beim erneuten Klick auf „Gebot abgeben" für denselben Slot: gelbe Warnbox mit „Abbrechen" / „Trotzdem abgeben"
- Kein Hard-Block — zwei Personen am selben Gerät können für verschiedene Slots bieten (Eltern-Fall)
- Hinweis: „Dieser Schutz gilt nur für dieses Gerät"

**Zero-Knowledge bleibt gewahrt:** Keine Serveränderungen, kein Limit serverseitig.

## Wie wurde getestet

- Alle 50 bestehenden Tests grün (26 solidarisch, 17 crypto, 7 splid)
- Manuelle Verifikation der Logik im Code-Review

## Was kommt als nächstes

- Feature 2: Gebot nachträglich korrigieren
- Feature 6: Runde wiederholen
- Feature 7: Landing Page

🤖 Generated with [Claude Code](https://claude.com/claude-code)