### PR TITLE
fix: Ausgleichszahlungen mit Labels + allesDa-Bug bei Standardgebot

### DIFF
--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -190,7 +190,14 @@ import Layout from '../../../../layouts/Layout.astro';
     const totalErwartet = blob.slots
       .filter((s) => s.standardgebot === undefined)
       .reduce((s, slot) => s + slot.anzahl, 0);
-    const allesDa = gebote.length === totalErwartet;
+
+    // Für allesDa nur Gebote für Slots ohne standardgebot zählen —
+    // echte Gebote für Slots mit standardgebot (z.B. Kind 1 überschreibt Auto) sind ok und ignorierbar
+    const labelsOhneStandard = new Set(
+      blob.slots.filter((s) => s.standardgebot === undefined).map((s) => s.label),
+    );
+    const geboteOhneStandard = gebote.filter((g) => labelsOhneStandard.has(g.slotLabel));
+    const allesDa = geboteOhneStandard.length === totalErwartet;
 
     // Duplikat-Check: Gebote pro Slot zählen und gegen slot.anzahl prüfen
     const zuVieleProSlot = blob.slots
@@ -348,10 +355,17 @@ import Layout from '../../../../layouts/Layout.astro';
     if (allesDa && !hatDuplikate && auswertung && auswertung.fehlbetrag <= 0.005 && ausgabenMap.size > 0) {
       const zahlungen = berechneAusgleich(auswertung.ergebnisse, ausgabenMap);
       if (zahlungen.length > 0) {
+        // Hilfsmaps: emojiId → slotLabel (für Namensanzeige statt Emoji-ID)
+        const emojiZuLabel = new Map<string, string>();
+        for (const e of auswertung.ergebnisse) {
+          if (!e.istStandard) emojiZuLabel.set(e.emojiId, e.slotLabel);
+        }
         const liste = document.getElementById('ausgleich-liste')!;
         for (const z of zahlungen) {
           const li = document.createElement('li');
-          li.textContent = `${z.von} → ${z.an}   ${eur(z.betrag)}`;
+          const vonLabel = emojiZuLabel.get(z.von) ?? z.von;
+          const anLabel = emojiZuLabel.get(z.an) ?? z.an;
+          li.textContent = `${vonLabel} → ${anLabel}   ${eur(z.betrag)}`;
           liste.appendChild(li);
         }
         document.getElementById('ausgleich-section')!.classList.remove('hidden');
@@ -373,18 +387,17 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Statuszeile (echte Gebote zählen, nicht synthetische)
+    // Statuszeile (nur Gebote für Slots ohne standardgebot zählen)
     if (hatDuplikate) {
-      const total = gebote.length;
       document.getElementById('gebote-anzahl')!.textContent =
-        `${total} Gebote eingegangen, ${totalErwartet} erwartet — bitte Doppelgebote klären`;
+        `${geboteOhneStandard.length} Gebote eingegangen, ${totalErwartet} erwartet — bitte Doppelgebote klären`;
     } else if (allesDa) {
       document.getElementById('gebote-anzahl')!.textContent =
         totalErwartet === 0
           ? 'Auswertung vollständig (alle Slots mit Standardgebot)'
           : `Alle ${totalErwartet} Gebote eingegangen — Auswertung vollständig`;
     } else {
-      document.getElementById('gebote-anzahl')!.textContent = `${gebote.length} von ${totalErwartet} Geboten eingegangen`;
+      document.getElementById('gebote-anzahl')!.textContent = `${geboteOhneStandard.length} von ${totalErwartet} Geboten eingegangen`;
     }
 
     document.getElementById('zustand-laden')!.classList.add('hidden');


### PR DESCRIPTION
## Was wurde gefixt

### Bug 1: Ausgleichszahlungen zeigten Emoji-IDs statt Slot-Labels

Vorher: `🦢🦋🎉 → 🚀🌺🦩   325,60 €`
Nachher: `Laura → Sandra   325,60 €`

Lösung: Map `emojiId → slotLabel` aus den Ergebnissen gebaut, Labels in der Anzeige verwendet (Fallback auf Emoji-ID falls kein Label vorhanden).

### Bug 2: `allesDa`-Check zählte echte Gebote für Slots mit Standardgebot falsch

Wenn jemand für einen Slot mit Standardgebot (z.B. Kind 1) ein echtes Gebot abgibt, wurde dieses Gebot gegen `totalErwartet` gezählt — obwohl `totalErwartet` nur Slots *ohne* Standardgebot umfasst. Ergebnis: „8 von 7 Geboten eingegangen" obwohl alles korrekt war.

Lösung: `allesDa` und die Statuszeile zählen jetzt nur Gebote für Slots ohne Standardgebot (`labelsOhneStandard`-Filter). Echte Gebote für Slots mit Standardgebot ersetzen wie gewünscht das Auto-Gebot — ohne den Zähler zu verfälschen.

## Tests

50 Tests grün (keine neuen Tests nötig — reine Anzeigelogik in Astro-Script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)