### PR TITLE
feat: add bid correction via insert-only append (Feature 2)

### DIFF
--- a/src/pages/api/runde/[id]/gebot.ts
+++ b/src/pages/api/runde/[id]/gebot.ts
@@ -48,6 +48,7 @@ export const POST: APIRoute = async ({ params, request }) => {
     });
   }
 
+  const isCorrection = b.isCorrection === true;
   const { emojiHmac, encGebot } = b as { emojiHmac: string; encGebot: string };
 
   let runde: RundeJSON;
@@ -64,11 +65,22 @@ export const POST: APIRoute = async ({ params, request }) => {
     throw err;
   }
 
-  if (runde.gebote.some((g) => g.emojiHmac === emojiHmac)) {
-    return new Response(
-      JSON.stringify({ error: 'Gebot mit dieser Emoji-ID bereits vorhanden' }),
-      { status: 409, headers: { 'Content-Type': 'application/json' } },
-    );
+  const exists = runde.gebote.some((g) => g.emojiHmac === emojiHmac);
+
+  if (isCorrection) {
+    if (!exists) {
+      return new Response(
+        JSON.stringify({ error: 'Kein Gebot mit dieser Emoji-ID gefunden' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+  } else {
+    if (exists) {
+      return new Response(
+        JSON.stringify({ error: 'Gebot mit dieser Emoji-ID bereits vorhanden' }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
   }
 
   runde.gebote.push({ emojiHmac, encGebot });

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -23,61 +23,137 @@ import Layout from '../../layouts/Layout.astro';
       </p>
     </div>
 
-    <form id="gebot-form" class="space-y-5">
-      <!-- Slot-Auswahl -->
-      <div>
-        <p class="text-sm font-medium text-slate-700 mb-2">Wähle deinen Slot-Typ</p>
-        <div id="slot-auswahl" class="space-y-2"></div>
-      </div>
-
-      <!-- Betrag -->
-      <div>
-        <label for="betrag" class="block text-sm font-medium text-slate-700 mb-1">
-          Dein Gebot (€)
-        </label>
-        <input
-          type="number"
-          id="betrag"
-          name="betrag"
-          required
-          min="0.01"
-          step="0.01"
-          placeholder="z.B. 80"
-          class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
-        />
-        <p id="betrag-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
-      </div>
-
-      <!-- Fehler -->
-      <div id="gebot-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm"></div>
-
-      <!-- Duplikat-Warnung (Soft-Warning, kein Hard-Block) -->
-      <div id="duplikat-warnung" class="hidden bg-amber-50 border border-amber-300 text-amber-800 rounded-lg p-3 text-sm space-y-2">
-        <p class="font-medium">Von diesem Gerät wurde für diesen Slot bereits ein Gebot abgegeben.</p>
-        <p class="text-xs text-amber-700">Möchtest du trotzdem ein weiteres Gebot einreichen?</p>
-        <div class="flex gap-2 pt-1">
-          <button type="button" id="duplikat-abbrechen" class="flex-1 border border-amber-400 text-amber-800 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 transition-colors">Abbrechen</button>
-          <button type="button" id="duplikat-bestaetigen" class="flex-1 bg-amber-600 text-white rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-700 transition-colors">Trotzdem abgeben</button>
-        </div>
-      </div>
-
+    <!-- Tab-Navigation -->
+    <div class="flex border-b border-slate-200">
       <button
-        type="submit"
-        id="gebot-btn"
-        class="w-full bg-green-700 text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-green-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        id="tab-abgeben"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-green-700 -mb-px transition-colors"
       >
         Gebot abgeben
       </button>
+      <button
+        id="tab-korrigieren"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-transparent text-slate-500 -mb-px hover:text-slate-700 transition-colors"
+      >
+        Gebot korrigieren
+      </button>
+    </div>
 
-      <p class="text-xs text-slate-400 text-center">Dieser Schutz gilt nur für dieses Gerät.</p>
-    </form>
+    <!-- Tab 1: Gebot abgeben -->
+    <div id="panel-abgeben">
+      <form id="gebot-form" class="space-y-5">
+        <!-- Slot-Auswahl -->
+        <div>
+          <p class="text-sm font-medium text-slate-700 mb-2">Wähle deinen Slot-Typ</p>
+          <div id="slot-auswahl" class="space-y-2"></div>
+        </div>
+
+        <!-- Betrag -->
+        <div>
+          <label for="betrag" class="block text-sm font-medium text-slate-700 mb-1">
+            Dein Gebot (€)
+          </label>
+          <input
+            type="number"
+            id="betrag"
+            name="betrag"
+            required
+            min="0.01"
+            step="0.01"
+            placeholder="z.B. 80"
+            class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          />
+          <p id="betrag-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
+        </div>
+
+        <!-- Fehler -->
+        <div id="gebot-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm"></div>
+
+        <!-- Duplikat-Warnung (Soft-Warning, kein Hard-Block) -->
+        <div id="duplikat-warnung" class="hidden bg-amber-50 border border-amber-300 text-amber-800 rounded-lg p-3 text-sm space-y-2">
+          <p class="font-medium">Von diesem Gerät wurde für diesen Slot bereits ein Gebot abgegeben.</p>
+          <p class="text-xs text-amber-700">Möchtest du trotzdem ein weiteres Gebot einreichen? Oder willst du dein bestehendes Gebot korrigieren?</p>
+          <div class="flex gap-2 pt-1 flex-wrap">
+            <button type="button" id="duplikat-abbrechen" class="border border-amber-400 text-amber-800 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 transition-colors">Abbrechen</button>
+            <button type="button" id="duplikat-korrigieren" class="border border-amber-500 bg-amber-100 text-amber-900 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 transition-colors">Gebot korrigieren</button>
+            <button type="button" id="duplikat-bestaetigen" class="bg-amber-600 text-white rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-700 transition-colors">Trotzdem abgeben</button>
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          id="gebot-btn"
+          class="w-full bg-green-700 text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-green-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Gebot abgeben
+        </button>
+
+        <p class="text-xs text-slate-400 text-center">Dieser Schutz gilt nur für dieses Gerät.</p>
+      </form>
+    </div>
+
+    <!-- Tab 2: Gebot korrigieren -->
+    <div id="panel-korrigieren" class="hidden">
+      <form id="korrektur-form" class="space-y-5">
+        <!-- Emoji-ID -->
+        <div>
+          <label for="korrektur-emoji" class="block text-sm font-medium text-slate-700 mb-1">
+            Deine Emoji-ID
+          </label>
+          <input
+            type="text"
+            id="korrektur-emoji"
+            name="emojiId"
+            required
+            placeholder="z.B. 🦊🌙⭐"
+            class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          />
+          <p class="text-xs text-slate-400 mt-1">Die 3 Emojis, die dir beim Abgeben angezeigt wurden.</p>
+        </div>
+
+        <!-- Slot-Auswahl -->
+        <div>
+          <p class="text-sm font-medium text-slate-700 mb-2">Neuer Slot-Typ</p>
+          <div id="slot-auswahl-korrektur" class="space-y-2"></div>
+        </div>
+
+        <!-- Betrag -->
+        <div>
+          <label for="korrektur-betrag" class="block text-sm font-medium text-slate-700 mb-1">
+            Neues Gebot (€)
+          </label>
+          <input
+            type="number"
+            id="korrektur-betrag"
+            name="betrag"
+            required
+            min="0.01"
+            step="0.01"
+            placeholder="z.B. 80"
+            class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          />
+          <p id="korrektur-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
+        </div>
+
+        <!-- Fehler -->
+        <div id="korrektur-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm"></div>
+
+        <button
+          type="submit"
+          id="korrektur-btn"
+          class="w-full bg-green-700 text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-green-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Gebot ersetzen
+        </button>
+      </form>
+    </div>
   </div>
 
   <!-- Bestätigung -->
   <div id="zustand-bestaetigung" class="hidden text-center space-y-4 py-8">
     <div class="text-6xl mb-2" id="emoji-anzeige"></div>
-    <h2 class="text-xl font-semibold">Gebot abgegeben</h2>
-    <p class="text-slate-500 text-sm max-w-sm mx-auto">
+    <h2 id="bestaetigung-titel" class="text-xl font-semibold">Gebot abgegeben</h2>
+    <p id="bestaetigung-text" class="text-slate-500 text-sm max-w-sm mx-auto">
       Das ist dein persönlicher Beleg. Merke dir diese Emoji-Kombination —
       sie beweist, dass dein Gebot registriert wurde.
     </p>
@@ -194,65 +270,106 @@ import Layout from '../../layouts/Layout.astro';
       localStorage.setItem(lsKey(label), '1');
     }
 
-    // Slot-Auswahl rendern
-    const slotAuswahl = document.getElementById('slot-auswahl')!;
-    blob.slots.forEach((slot, idx) => {
-      const richtwertSlot = Math.ceil(rawRichtwert * slot.gewichtung * 100) / 100;
-      const bereitsGeboten = slotBereitsGeboten(slot.label);
-      const label = document.createElement('label');
-      label.className =
-        'flex items-center gap-3 bg-white border border-slate-200 rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 transition-colors';
-      label.innerHTML = `
-        <input type="radio" name="slot" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
-        <span class="flex-1">
-          <span class="text-sm font-medium text-slate-800">${slot.label}</span>
-          <span class="text-xs text-slate-500 ml-2">Faktor ${slot.gewichtung} · ${slot.anzahl} Platz/Plätze · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
-          ${bereitsGeboten ? '<span class="text-xs text-amber-600 ml-1">(bereits abgegeben)</span>' : ''}
-        </span>
-      `;
-      slotAuswahl.appendChild(label);
-    });
+    // Hilfsfunktion: Slot-Auswahl-Radios in einen Container rendern
+    function renderSlotAuswahl(containerId: string, nameAttr: string) {
+      const container = document.getElementById(containerId)!;
+      blob.slots.forEach((slot, idx) => {
+        const richtwertSlot = Math.ceil(rawRichtwert * slot.gewichtung * 100) / 100;
+        const bereitsGeboten = slotBereitsGeboten(slot.label);
+        const label = document.createElement('label');
+        label.className =
+          'flex items-center gap-3 bg-white border border-slate-200 rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 transition-colors';
+        label.innerHTML = `
+          <input type="radio" name="${nameAttr}" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
+          <span class="flex-1">
+            <span class="text-sm font-medium text-slate-800">${slot.label}</span>
+            <span class="text-xs text-slate-500 ml-2">Faktor ${slot.gewichtung} · ${slot.anzahl} Platz/Plätze · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
+            ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-xs text-amber-600 ml-1">(bereits abgegeben)</span>' : ''}
+          </span>
+        `;
+        container.appendChild(label);
+      });
+    }
+
+    renderSlotAuswahl('slot-auswahl', 'slot');
+    renderSlotAuswahl('slot-auswahl-korrektur', 'slot-korrektur');
 
     // Betrag-Feld + Richtwert-Hinweis bei Slot-Wechsel aktualisieren
-    const betragInput = document.getElementById('betrag') as HTMLInputElement;
-    const betragHinweis = document.getElementById('betrag-richtwert-hinweis')!;
-
-    function aktualisiereBetragFeld(slotIdx: number) {
+    function betragFeldAktualisieren(slotIdx: number, betragId: string, hinweisId: string) {
       const slot = blob.slots[slotIdx];
       if (!slot) return;
       const richtwertSlot = Math.ceil(rawRichtwert * slot.gewichtung * 100) / 100;
+      const betragInput = document.getElementById(betragId) as HTMLInputElement;
+      const hinweis = document.getElementById(hinweisId)!;
       if (slot.standardgebot !== undefined) {
         betragInput.value = slot.standardgebot.toFixed(2);
-        betragHinweis.textContent = `Standardgebot: ${slot.standardgebot.toFixed(2).replace('.', ',')} € · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
+        hinweis.textContent = `Standardgebot: ${slot.standardgebot.toFixed(2).replace('.', ',')} € · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
       } else {
         betragInput.value = '';
-        betragHinweis.textContent = `Richtwert für diesen Slot: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
+        hinweis.textContent = `Richtwert für diesen Slot: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
       }
     }
 
-    slotAuswahl.addEventListener('change', (e) => {
+    document.getElementById('slot-auswahl')!.addEventListener('change', (e) => {
       const radio = e.target as HTMLInputElement;
-      if (radio.name === 'slot') {
-        aktualisiereBetragFeld(parseInt(radio.value, 10));
-      }
+      if (radio.name === 'slot') betragFeldAktualisieren(parseInt(radio.value, 10), 'betrag', 'betrag-richtwert-hinweis');
+    });
+    document.getElementById('slot-auswahl-korrektur')!.addEventListener('change', (e) => {
+      const radio = e.target as HTMLInputElement;
+      if (radio.name === 'slot-korrektur') betragFeldAktualisieren(parseInt(radio.value, 10), 'korrektur-betrag', 'korrektur-richtwert-hinweis');
     });
 
-    // Initiale Vorausfüllung für den ersten Slot
-    aktualisiereBetragFeld(0);
+    betragFeldAktualisieren(0, 'betrag', 'betrag-richtwert-hinweis');
+    betragFeldAktualisieren(0, 'korrektur-betrag', 'korrektur-richtwert-hinweis');
+
+    // Tab-Steuerung
+    const tabAbgeben = document.getElementById('tab-abgeben') as HTMLButtonElement;
+    const tabKorrigieren = document.getElementById('tab-korrigieren') as HTMLButtonElement;
+    const panelAbgeben = document.getElementById('panel-abgeben')!;
+    const panelKorrigieren = document.getElementById('panel-korrigieren')!;
+
+    function zeigeTab(tab: 'abgeben' | 'korrigieren') {
+      const istAbgeben = tab === 'abgeben';
+      tabAbgeben.classList.toggle('border-green-600', istAbgeben);
+      tabAbgeben.classList.toggle('text-green-700', istAbgeben);
+      tabAbgeben.classList.toggle('border-transparent', !istAbgeben);
+      tabAbgeben.classList.toggle('text-slate-500', !istAbgeben);
+      tabKorrigieren.classList.toggle('border-green-600', !istAbgeben);
+      tabKorrigieren.classList.toggle('text-green-700', !istAbgeben);
+      tabKorrigieren.classList.toggle('border-transparent', istAbgeben);
+      tabKorrigieren.classList.toggle('text-slate-500', istAbgeben);
+      panelAbgeben.classList.toggle('hidden', !istAbgeben);
+      panelKorrigieren.classList.toggle('hidden', istAbgeben);
+    }
+
+    tabAbgeben.addEventListener('click', () => zeigeTab('abgeben'));
+    tabKorrigieren.addEventListener('click', () => zeigeTab('korrigieren'));
 
     // Formular anzeigen
     document.getElementById('zustand-laden')!.classList.add('hidden');
     document.getElementById('zustand-formular')!.classList.remove('hidden');
 
-    // Gebot abgeben
+    // ── Tab 1: Gebot abgeben ──────────────────────────────────────────────────
     const gebotForm = document.getElementById('gebot-form') as HTMLFormElement;
     const gebotBtn = document.getElementById('gebot-btn') as HTMLButtonElement;
     const gebotFehler = document.getElementById('gebot-fehler') as HTMLDivElement;
     const duplikatWarnung = document.getElementById('duplikat-warnung') as HTMLDivElement;
     const duplikatAbbrechen = document.getElementById('duplikat-abbrechen') as HTMLButtonElement;
+    const duplikatKorrigieren = document.getElementById('duplikat-korrigieren') as HTMLButtonElement;
     const duplikatBestaetigen = document.getElementById('duplikat-bestaetigen') as HTMLButtonElement;
 
-    // Kernfunktion: Gebot tatsächlich einreichen
+    function zeigeBestaetigung(emojiId: string, istKorrektur: boolean) {
+      document.getElementById('emoji-anzeige')!.textContent = emojiId;
+      document.getElementById('emoji-id-text')!.textContent = emojiId;
+      document.getElementById('bestaetigung-titel')!.textContent = istKorrektur ? 'Gebot korrigiert' : 'Gebot abgegeben';
+      document.getElementById('bestaetigung-text')!.textContent = istKorrektur
+        ? 'Dein Gebot wurde erfolgreich ersetzt. Deine Emoji-ID bleibt dieselbe.'
+        : 'Das ist dein persönlicher Beleg. Merke dir diese Emoji-Kombination — sie beweist, dass dein Gebot registriert wurde.';
+      document.getElementById('zustand-formular')!.classList.add('hidden');
+      document.getElementById('zustand-bestaetigung')!.classList.remove('hidden');
+    }
+
+    // Kernfunktion: Gebot tatsächlich einreichen (mit Auto-Retry bei Emoji-Kollision)
     async function gebot_einreichen() {
       gebotFehler.classList.add('hidden');
       duplikatWarnung.classList.add('hidden');
@@ -269,25 +386,29 @@ import Layout from '../../layouts/Layout.astro';
           (gebotForm.querySelector('#betrag') as HTMLInputElement).value,
         );
 
-        // Emoji-ID generieren + HMAC
-        const emojiId = generiereEmojiId();
-        const emojiHmac = await hmac(hmacKey, emojiId);
+        let emojiId: string;
+        let emojiHmac: string;
+        let encGebot: string;
+        let res: Response;
+        let versuche = 0;
 
-        // Gebot verschlüsseln
-        const gebotObjekt = {
-          emojiId,
-          slotLabel: selectedSlot.label,
-          gewichtung: selectedSlot.gewichtung,
-          betrag,
-        };
-        const encGebot = await encryptGebot(adminPubKey, JSON.stringify(gebotObjekt));
-
-        // API-Aufruf
-        const res = await fetch(`/api/runde/${rundenId}/gebot`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ emojiHmac, encGebot }),
-        });
+        // Auto-Retry bei zufälliger Emoji-ID-Kollision (max. 3 Versuche)
+        do {
+          versuche++;
+          emojiId = generiereEmojiId();
+          emojiHmac = await hmac(hmacKey, emojiId);
+          encGebot = await encryptGebot(adminPubKey, JSON.stringify({
+            emojiId,
+            slotLabel: selectedSlot.label,
+            gewichtung: selectedSlot.gewichtung,
+            betrag,
+          }));
+          res = await fetch(`/api/runde/${rundenId}/gebot`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ emojiHmac, encGebot }),
+          });
+        } while (res.status === 409 && versuche < 3);
 
         if (!res.ok) {
           const { error } = (await res.json()) as { error: string };
@@ -296,14 +417,8 @@ import Layout from '../../layouts/Layout.astro';
           return;
         }
 
-        // localStorage: Slot als geboten markieren
         slotAlsGebotenMarkieren(selectedSlot.label);
-
-        // Bestätigung anzeigen
-        document.getElementById('emoji-anzeige')!.textContent = emojiId;
-        document.getElementById('emoji-id-text')!.textContent = emojiId;
-        document.getElementById('zustand-formular')!.classList.add('hidden');
-        document.getElementById('zustand-bestaetigung')!.classList.remove('hidden');
+        zeigeBestaetigung(emojiId!, false);
       } catch (err) {
         gebotFehler.textContent = 'Unerwarteter Fehler. Bitte versuche es erneut.';
         gebotFehler.classList.remove('hidden');
@@ -317,7 +432,6 @@ import Layout from '../../layouts/Layout.astro';
     gebotForm.addEventListener('submit', async (e) => {
       e.preventDefault();
 
-      // Prüfen ob gewählter Slot von diesem Gerät bereits geboten wurde
       const selectedIdx = parseInt(
         (gebotForm.querySelector('input[name="slot"]:checked') as HTMLInputElement).value,
         10,
@@ -325,7 +439,6 @@ import Layout from '../../layouts/Layout.astro';
       const selectedSlot = blob.slots[selectedIdx];
 
       if (slotBereitsGeboten(selectedSlot.label)) {
-        // Soft-Warning anzeigen, nicht direkt einreichen
         duplikatWarnung.classList.remove('hidden');
         return;
       }
@@ -333,12 +446,72 @@ import Layout from '../../layouts/Layout.astro';
       await gebot_einreichen();
     });
 
-    // Warnung-Buttons
     duplikatAbbrechen.addEventListener('click', () => {
       duplikatWarnung.classList.add('hidden');
     });
+    duplikatKorrigieren.addEventListener('click', () => {
+      duplikatWarnung.classList.add('hidden');
+      zeigeTab('korrigieren');
+      document.getElementById('korrektur-emoji')?.focus();
+    });
     duplikatBestaetigen.addEventListener('click', async () => {
       await gebot_einreichen();
+    });
+
+    // ── Tab 2: Gebot korrigieren ──────────────────────────────────────────────
+    const korrekturForm = document.getElementById('korrektur-form') as HTMLFormElement;
+    const korrekturBtn = document.getElementById('korrektur-btn') as HTMLButtonElement;
+    const korrekturFehler = document.getElementById('korrektur-fehler') as HTMLDivElement;
+
+    korrekturForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      korrekturFehler.classList.add('hidden');
+      korrekturBtn.disabled = true;
+      korrekturBtn.textContent = 'Verschlüssele…';
+
+      try {
+        const emojiId = (document.getElementById('korrektur-emoji') as HTMLInputElement).value.trim();
+        const selectedIdx = parseInt(
+          (korrekturForm.querySelector('input[name="slot-korrektur"]:checked') as HTMLInputElement).value,
+          10,
+        );
+        const selectedSlot = blob.slots[selectedIdx];
+        const betrag = parseFloat(
+          (document.getElementById('korrektur-betrag') as HTMLInputElement).value,
+        );
+
+        const emojiHmac = await hmac(hmacKey, emojiId);
+        const encGebot = await encryptGebot(adminPubKey, JSON.stringify({
+          emojiId,
+          slotLabel: selectedSlot.label,
+          gewichtung: selectedSlot.gewichtung,
+          betrag,
+        }));
+
+        const res = await fetch(`/api/runde/${rundenId}/gebot`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ emojiHmac, encGebot, isCorrection: true }),
+        });
+
+        if (!res.ok) {
+          const { error } = (await res.json()) as { error: string };
+          korrekturFehler.textContent = res.status === 404
+            ? 'Emoji-ID nicht gefunden — Tippfehler?'
+            : (error ?? 'Fehler beim Speichern');
+          korrekturFehler.classList.remove('hidden');
+          return;
+        }
+
+        zeigeBestaetigung(emojiId, true);
+      } catch (err) {
+        korrekturFehler.textContent = 'Unerwarteter Fehler. Bitte versuche es erneut.';
+        korrekturFehler.classList.remove('hidden');
+        console.error(err);
+      } finally {
+        korrekturBtn.disabled = false;
+        korrekturBtn.textContent = 'Gebot ersetzen';
+      }
     });
   }
 

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -175,9 +175,14 @@ import Layout from '../../../../layouts/Layout.astro';
       return;
     }
 
+    // Deduplizierung: pro emojiHmac das neueste Gebot behalten (Korrekturen überschreiben alte)
+    const latestByHmac = new Map<string, { emojiHmac: string; encGebot: string }>();
+    for (const g of blobData.gebote) latestByHmac.set(g.emojiHmac, g);
+    const dedupGebote = [...latestByHmac.values()];
+
     // Gebote entschlüsseln
     const gebote: Gebot[] = [];
-    for (const { encGebot } of blobData.gebote) {
+    for (const { encGebot } of dedupGebote) {
       try {
         const g = JSON.parse(await decryptGebot(adminPrivKey, encGebot)) as Gebot;
         gebote.push(g);


### PR DESCRIPTION
- POST /api/runde/:id/gebot accepts isCorrection flag; returns 404 if no matching emojiHmac exists, 409 if duplicate on new bids
- Admin page deduplicates bids by emojiHmac before evaluation, keeping only the latest entry per participant
- Teilnehmer page: two-tab UI (Gebot abgeben / Gebot korrigieren)
- Correction form: emoji-ID input, slot selection, new amount
- Duplicate warning now has a third button jumping to correction tab
- Auto-retry (max 3x) on 409 to handle rare emoji-ID collisions