### PR TITLE
feat: Runde wiederholen (Feature 6)

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -459,6 +459,70 @@ import Layout from '../layouts/Layout.astro';
     aktualisiereEntfernenButtons();
   });
 
+  // ---------------------------------------------------------------------------
+  // Runde wiederholen (Vorausfüllen aus sessionStorage)
+  // ---------------------------------------------------------------------------
+
+  const wiederholenRaw = sessionStorage.getItem('rundeWiederholen');
+  if (wiederholenRaw) {
+    sessionStorage.removeItem('rundeWiederholen');
+    try {
+      const config = JSON.parse(wiederholenRaw) as {
+        name: string;
+        kosten: number;
+        slots: { label: string; gewichtung: number; anzahl: number; standardgebot?: number }[];
+      };
+
+      (form.querySelector('#rundeName') as HTMLInputElement).value = config.name;
+      (form.querySelector('#gesamtkosten') as HTMLInputElement).value = String(config.kosten);
+
+      function befuelleWiederholSlot(
+        slotEl: HTMLDivElement,
+        slot: { label: string; gewichtung: number; anzahl: number; standardgebot?: number },
+      ) {
+        (slotEl.querySelector('[name="label[]"]') as HTMLInputElement).value =
+          slot.label === 'Slot' ? '' : slot.label;
+        (slotEl.querySelector('[name="gewichtung[]"]') as HTMLInputElement).value = String(slot.gewichtung);
+        (slotEl.querySelector('[name="anzahl[]"]') as HTMLInputElement).value = String(slot.anzahl);
+
+        const checkbox = slotEl.querySelector<HTMLInputElement>('.standardgebot-checkbox')!;
+        const eingabe = slotEl.querySelector<HTMLDivElement>('.standardgebot-eingabe')!;
+        const stdInput = slotEl.querySelector<HTMLInputElement>('[name="standardgebot[]"]')!;
+
+        if (slot.standardgebot !== undefined) {
+          checkbox.checked = true;
+          eingabe.classList.remove('hidden');
+          stdInput.value = slot.standardgebot.toFixed(2);
+          stdInput.dataset.auto = 'false';
+        } else {
+          checkbox.checked = false;
+          eingabe.classList.add('hidden');
+          stdInput.value = '';
+          stdInput.dataset.auto = 'true';
+        }
+      }
+
+      // Alle außer dem ersten Slot entfernen
+      slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag').forEach((s, i) => {
+        if (i > 0) s.remove();
+      });
+
+      const ersterSlot = slotsContainer.querySelector('.slot-eintrag') as HTMLDivElement;
+      befuelleWiederholSlot(ersterSlot, config.slots[0]);
+
+      for (let i = 1; i < config.slots.length; i++) {
+        const klon = ersterSlot.cloneNode(true) as HTMLDivElement;
+        slotsContainer.appendChild(klon);
+        befuelleWiederholSlot(klon, config.slots[i]);
+      }
+
+      aktualisiereEntfernenButtons();
+      aktualisiereRichtwert();
+    } catch {
+      // Ungültiger sessionStorage-Eintrag — ignorieren
+    }
+  }
+
   // Kopieren
   function kopieren(inputId: string) {
     const el = document.getElementById(inputId) as HTMLInputElement;

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -83,14 +83,21 @@ import Layout from '../../../../layouts/Layout.astro';
     <!-- Status -->
     <p id="gebote-anzahl" class="text-xs text-slate-400 print:hidden"></p>
 
-    <!-- Drucken -->
-    <button
-      id="drucken-btn"
-      onclick="window.print()"
-      class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors print:hidden"
-    >
-      Als PDF drucken
-    </button>
+    <!-- Drucken / Wiederholen -->
+    <div class="flex gap-3 print:hidden">
+      <button
+        onclick="window.print()"
+        class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+      >
+        Als PDF drucken
+      </button>
+      <button
+        id="wiederholen-btn"
+        class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+      >
+        Runde wiederholen
+      </button>
+    </div>
   </div>
 </Layout>
 
@@ -402,6 +409,21 @@ import Layout from '../../../../layouts/Layout.astro';
 
     document.getElementById('zustand-laden')!.classList.add('hidden');
     document.getElementById('zustand-auswertung')!.classList.remove('hidden');
+
+    // Runde wiederholen: Slot-Konfiguration in sessionStorage speichern und zu /neu navigieren
+    document.getElementById('wiederholen-btn')!.addEventListener('click', () => {
+      sessionStorage.setItem('rundeWiederholen', JSON.stringify({
+        name: blob.rundeName,
+        kosten: blob.gesamtkosten,
+        slots: blob.slots.map(({ label, gewichtung, anzahl, standardgebot }) => ({
+          label,
+          gewichtung,
+          anzahl,
+          ...(standardgebot !== undefined ? { standardgebot } : {}),
+        })),
+      }));
+      location.href = '/neu';
+    });
   }
 
   init();


### PR DESCRIPTION
## Was wurde gebaut

Button „Runde wiederholen" auf der Admin-Auswertungsseite. Nach dem Klick wird die Slot-Konfiguration der aktuellen Runde (Name, Gesamtkosten, Slot-Typen inkl. Standardgebote) in `sessionStorage` gespeichert und das Formular auf `/neu` vorausgefüllt geöffnet. Gebote und Splid-Ausgaben werden nicht übertragen.

**Geänderte Dateien:**
- `src/pages/runde/[id]/admin/[token].astro` — Button neben „Als PDF drucken", Handler speichert Blob-Konfiguration in sessionStorage
- `src/pages/neu.astro` — liest `rundeWiederholen` aus sessionStorage beim Laden, füllt Formular vor, löscht Eintrag sofort

## Wie wurde getestet

- Bestehende Runde als Admin geöffnet → Button sichtbar
- Klick → `/neu` öffnet sich mit vorausgefüllten Feldern (Name, Kosten, alle Slots inkl. Standardgebot-Checkboxen)
- sessionStorage nach dem Laden leer
- Neue Runde erstellen funktioniert normal

## Was kommt als nächstes

Feature 7 — Landing Page

🤖 Generated with [Claude Code](https://claude.com/claude-code)