### PR TITLE
feat: Landing Page mit Zero-Knowledge-Erklärung und Threat Model

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,127 @@
 ---
-return Astro.redirect('/neu');
+import Layout from '../layouts/Layout.astro';
 ---
+
+<Layout title="Solidarische Gruppenfinanzierung">
+  <!-- Hero -->
+  <div class="mb-10">
+    <h1 class="text-3xl font-bold text-slate-900 mb-3">Solidarische Gruppenfinanzierung</h1>
+    <p class="text-lg text-slate-600 leading-relaxed">
+      FairShare hilft Gruppen dabei, gemeinsame Kosten solidarisch aufzuteilen —
+      jede Person bietet, was sie tragen kann. Anonym, ohne Registrierung, ohne dass
+      der Server eure Daten je zu sehen bekommt.
+    </p>
+  </div>
+
+  <!-- Wie es funktioniert -->
+  <div class="mb-10">
+    <h2 class="text-base font-semibold text-slate-500 uppercase tracking-wide mb-4">So funktioniert's</h2>
+    <ol class="space-y-4">
+      <li class="flex gap-4">
+        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-brand text-white text-sm font-bold flex items-center justify-center">1</span>
+        <div>
+          <p class="font-medium text-slate-900">Runde erstellen</p>
+          <p class="text-sm text-slate-600 mt-0.5">Die Organisator*in legt Gesamtkosten und Slot-Typen fest (z.&nbsp;B. Erwachsene, Kinder). Die App generiert Links für Teilnehmende und einen Admin-Link.</p>
+        </div>
+      </li>
+      <li class="flex gap-4">
+        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-brand text-white text-sm font-bold flex items-center justify-center">2</span>
+        <div>
+          <p class="font-medium text-slate-900">Gebot abgeben</p>
+          <p class="text-sm text-slate-600 mt-0.5">Jede Person öffnet ihren persönlichen Link und gibt an, was sie zahlen kann — anonym, nur mit einer zufälligen Emoji-ID erkennbar.</p>
+        </div>
+      </li>
+      <li class="flex gap-4">
+        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-brand text-white text-sm font-bold flex items-center justify-center">3</span>
+        <div>
+          <p class="font-medium text-slate-900">Auswertung im Browser</p>
+          <p class="text-sm text-slate-600 mt-0.5">Die Organisator*in öffnet den Admin-Link — die Gebote werden direkt im Browser entschlüsselt und ausgewertet. Der Server sieht nie Klartext.</p>
+        </div>
+      </li>
+    </ol>
+  </div>
+
+  <!-- Zero-Knowledge -->
+  <div class="mb-6 rounded-xl border border-slate-200 bg-white p-6">
+    <h2 class="text-lg font-semibold text-slate-900 mb-2">Zero-Knowledge-Prinzip</h2>
+    <p class="text-sm text-slate-600 leading-relaxed mb-4">
+      Alle Inhalte werden im Browser verschlüsselt, bevor sie den Server erreichen.
+      Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-slate-100 px-1 py-0.5 rounded">#…</code>)
+      — diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
+      Die App folgt dem <strong>Zero-Knowledge-Prinzip</strong>: mit einigen
+      bewussten Einschränkungen, die wir transparent machen.
+    </p>
+
+    <details class="group">
+      <summary class="cursor-pointer text-sm font-medium text-brand hover:text-brand-dark flex items-center gap-1 select-none">
+        <span class="transition-transform group-open:rotate-90 inline-block">›</span>
+        Was der Server theoretisch inferieren kann (Threat Model)
+      </summary>
+      <div class="mt-3 text-sm text-slate-600 space-y-3 pl-4 border-l-2 border-slate-200">
+        <div>
+          <p class="font-medium text-slate-800">Anzahl der Teilnehmer*innen</p>
+          <p class="mt-0.5">Jedes Gebot ist ein separater verschlüsselter Eintrag im Server-Store — der Server kann Einträge zählen und so die ungefähre Teilnehmerzahl inferieren.</p>
+        </div>
+        <div>
+          <p class="font-medium text-slate-800">Zeitpunkte der Gebots-Einreichung</p>
+          <p class="mt-0.5">Der Server sieht, wann ein Gebot einging. Muster (z.&nbsp;B. alle binnen 5 Minuten) können auf Gruppenverhalten hindeuten.</p>
+        </div>
+        <div>
+          <p class="font-medium text-slate-800">Existenz einer Runde</p>
+          <p class="mt-0.5">Eine Runden-ID existiert auf dem Server und ist aktiv oder nicht — ohne Klartext-Bezug zum Inhalt.</p>
+        </div>
+        <div class="pt-1">
+          <p class="font-medium text-slate-800">Was der Server <em>nicht</em> sieht</p>
+          <p class="mt-0.5">Namen, Gebotsbeträge, Slot-Auswahl, Emoji-IDs, Admin-Schlüssel — all das bleibt verschlüsselt.</p>
+        </div>
+      </div>
+    </details>
+  </div>
+
+  <!-- Kein Zero-Trust -->
+  <div class="mb-10 rounded-xl border border-slate-200 bg-white p-6">
+    <h2 class="text-lg font-semibold text-slate-900 mb-2">Vertrauen in die Organisator*in</h2>
+    <p class="text-sm text-slate-600 leading-relaxed mb-3">
+      Die App ist <strong>kein Zero-Trust-System</strong>. Die Organisator*in hat den
+      privaten Admin-Schlüssel und kann damit technisch alle Gebote entschlüsseln —
+      das Frontend zeigt ihr nur die Auswertungstabelle, aber der Zugriff auf Rohwerte
+      wäre im Code möglich.
+    </p>
+    <p class="text-sm text-slate-600 leading-relaxed mb-3">
+      Teilnehmer*innen hingegen können <strong>keine</strong> Gebote anderer sehen:
+      Gebote sind mit dem öffentlichen Admin-Schlüssel verschlüsselt und nur mit dem
+      privaten Schlüssel der Organisator*in lesbar.
+    </p>
+    <p class="text-sm text-slate-500 leading-relaxed">
+      Vertrauen in die Organisator*in ist Teil des Modells — vergleichbar mit einem
+      Kassenprüfer in einer Genossenschaft: Kontrolle durch Transparenz, nicht durch
+      technische Sperre.
+    </p>
+  </div>
+
+  <!-- CTA -->
+  <div class="flex flex-col sm:flex-row items-center gap-3">
+    <a
+      href="/neu"
+      class="w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-lg bg-brand text-white font-semibold hover:bg-brand-dark transition-colors"
+    >
+      Neue Runde erstellen
+    </a>
+    <a
+      id="cta-meine-runden"
+      href="/meine-runden"
+      class="hidden w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-lg border border-slate-300 text-slate-700 font-medium hover:bg-slate-100 transition-colors"
+    >
+      Meine gespeicherten Runden
+    </a>
+  </div>
+</Layout>
+
+<script>
+  try {
+    const runden = JSON.parse(localStorage.getItem('fairshare_runden') || '[]');
+    if (Array.isArray(runden) && runden.length > 0) {
+      document.getElementById('cta-meine-runden')?.classList.remove('hidden');
+    }
+  } catch { /* ignore */ }
+</script>


### PR DESCRIPTION
## Was wurde gebaut

Landing Page unter `/` (Feature 7 aus dem Backlog).

**Aufbau:**
- **Hero** mit Tagline und Kurzbeschreibung der App
- **3-Schritte-Erklärung**: Runde erstellen → Gebot abgeben → Auswertung im Browser
- **Zero-Knowledge-Block** mit aufklappbarem Threat-Model-Abschnitt (natives HTML `<details>`, kein JS): Was der Server inferieren kann (Teilnehmerzahl, Zeitstempel, Rundenexistenz) vs. was er nicht sieht
- **Transparenz-Abschnitt zur Admin-Rolle**: Kein Zero-Trust-System — die Organisator\*in kann technisch alle Gebote entschlüsseln; Teilnehmende können keine fremden Gebote sehen
- **CTA**: „Neue Runde erstellen" + „Meine gespeicherten Runden" (nur sichtbar wenn localStorage-Einträge vorhanden)

## Wie wurde getestet

- Manuell im Browser geprüft (`npm run dev`, `http://localhost:4321`)
- Landing Page erscheint (kein Redirect mehr auf `/neu`)
- Aufklappbarer Threat-Model-Bereich funktioniert
- CTA-Buttons navigieren korrekt

## Was kommt als nächstes

Feature 8 — Diagramme (visuelle Darstellung der Gebote vs. Solidarbeiträge)