### PR TITLE
UX: Apple-inspiriertes Polish für alle Seiten

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,7 @@ interface Props {
   title: string;
 }
 const { title } = Astro.props;
+const pathname = Astro.url.pathname;
 ---
 
 <!doctype html>
@@ -26,21 +27,31 @@ const { title } = Astro.props;
           </span>
         </a>
         <nav class="flex items-center gap-1">
-          <a href="/neu" class="px-3 py-1.5 rounded-lg text-sm text-slate-600 hover:bg-slate-200 transition-colors">Neue Runde</a>
-          <a id="nav-meine-runden" href="/meine-runden" class="hidden px-3 py-1.5 rounded-lg text-sm text-slate-600 hover:bg-slate-200 transition-colors">Meine Runden</a>
+          <a href="/neu" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-slate-200 ${pathname === '/neu' ? 'text-brand font-semibold' : 'text-slate-600'}`}>Neue Runde</a>
+          <a id="nav-meine-runden" href="/meine-runden" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-slate-200 ${pathname === '/meine-runden' ? 'text-brand font-semibold' : 'text-slate-600 hidden'}`}>Meine Runden</a>
         </nav>
       </div>
     </div>
     <script>
       try {
-        const runden = JSON.parse(localStorage.getItem('fairshare_runden') || '[]');
-        if (Array.isArray(runden) && runden.length > 0) {
-          document.getElementById('nav-meine-runden')?.classList.remove('hidden');
+        const navLink = document.getElementById('nav-meine-runden');
+        if (navLink) {
+          const runden = JSON.parse(localStorage.getItem('fairshare_runden') || '[]');
+          if (Array.isArray(runden) && runden.length > 0) {
+            navLink.classList.remove('hidden');
+          }
+          // Always show when on the page itself
+          if (window.location.pathname === '/meine-runden') {
+            navLink.classList.remove('hidden');
+          }
         }
       } catch { /* ignore */ }
     </script>
     <main class="mx-auto max-w-2xl px-4 py-6">
       <slot />
     </main>
+    <footer class="mx-auto max-w-2xl px-4 py-4 text-center">
+      <a href="/ueber" class="text-xs text-slate-400 hover:text-slate-600 transition-colors">Über FairShare</a>
+    </footer>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,66 +41,8 @@ import Layout from '../layouts/Layout.astro';
     </ol>
   </div>
 
-  <!-- Zero-Knowledge -->
-  <div class="mb-6 rounded-xl border border-slate-200 bg-white p-6">
-    <h2 class="text-lg font-semibold text-slate-900 mb-2">Zero-Knowledge-Prinzip</h2>
-    <p class="text-sm text-slate-600 leading-relaxed mb-4">
-      Alle Inhalte werden im Browser verschlüsselt, bevor sie den Server erreichen.
-      Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-slate-100 px-1 py-0.5 rounded">#…</code>)
-      — diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
-      Die App folgt dem <strong>Zero-Knowledge-Prinzip</strong>: mit einigen
-      bewussten Einschränkungen, die wir transparent machen.
-    </p>
-
-    <details class="group">
-      <summary class="cursor-pointer text-sm font-medium text-brand hover:text-brand-dark flex items-center gap-1 select-none">
-        <span class="transition-transform group-open:rotate-90 inline-block">›</span>
-        Was der Server theoretisch inferieren kann (Threat Model)
-      </summary>
-      <div class="mt-3 text-sm text-slate-600 space-y-3 pl-4 border-l-2 border-slate-200">
-        <div>
-          <p class="font-medium text-slate-800">Anzahl der Teilnehmer*innen</p>
-          <p class="mt-0.5">Jedes Gebot ist ein separater verschlüsselter Eintrag im Server-Store — der Server kann Einträge zählen und so die ungefähre Teilnehmerzahl inferieren.</p>
-        </div>
-        <div>
-          <p class="font-medium text-slate-800">Zeitpunkte der Gebots-Einreichung</p>
-          <p class="mt-0.5">Der Server sieht, wann ein Gebot einging. Muster (z.&nbsp;B. alle binnen 5 Minuten) können auf Gruppenverhalten hindeuten.</p>
-        </div>
-        <div>
-          <p class="font-medium text-slate-800">Existenz einer Runde</p>
-          <p class="mt-0.5">Eine Runden-ID existiert auf dem Server und ist aktiv oder nicht — ohne Klartext-Bezug zum Inhalt.</p>
-        </div>
-        <div class="pt-1">
-          <p class="font-medium text-slate-800">Was der Server <em>nicht</em> sieht</p>
-          <p class="mt-0.5">Namen, Gebotsbeträge, Slot-Auswahl, Emoji-IDs, Admin-Schlüssel — all das bleibt verschlüsselt.</p>
-        </div>
-      </div>
-    </details>
-  </div>
-
-  <!-- Kein Zero-Trust -->
-  <div class="mb-10 rounded-xl border border-slate-200 bg-white p-6">
-    <h2 class="text-lg font-semibold text-slate-900 mb-2">Vertrauen in die Organisator*in</h2>
-    <p class="text-sm text-slate-600 leading-relaxed mb-3">
-      Die App ist <strong>kein Zero-Trust-System</strong>. Die Organisator*in hat den
-      privaten Admin-Schlüssel und kann damit technisch alle Gebote entschlüsseln —
-      das Frontend zeigt ihr nur die Auswertungstabelle, aber der Zugriff auf Rohwerte
-      wäre im Code möglich.
-    </p>
-    <p class="text-sm text-slate-600 leading-relaxed mb-3">
-      Teilnehmer*innen hingegen können <strong>keine</strong> Gebote anderer sehen:
-      Gebote sind mit dem öffentlichen Admin-Schlüssel verschlüsselt und nur mit dem
-      privaten Schlüssel der Organisator*in lesbar.
-    </p>
-    <p class="text-sm text-slate-500 leading-relaxed">
-      Vertrauen in die Organisator*in ist Teil des Modells — vergleichbar mit einem
-      Kassenprüfer in einer Genossenschaft: Kontrolle durch Transparenz, nicht durch
-      technische Sperre.
-    </p>
-  </div>
-
   <!-- CTA -->
-  <div class="flex flex-col sm:flex-row items-center gap-3">
+  <div class="flex flex-col sm:flex-row items-center gap-3 mb-8">
     <a
       href="/neu"
       class="w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-lg bg-brand text-white font-semibold hover:bg-brand-dark transition-colors"
@@ -115,13 +57,23 @@ import Layout from '../layouts/Layout.astro';
       Meine gespeicherten Runden
     </a>
   </div>
+
+  <div class="text-center">
+    <a href="/ueber" class="text-sm text-slate-400 hover:text-brand transition-colors underline underline-offset-2">
+      Wie funktioniert das genau? →
+    </a>
+  </div>
 </Layout>
 
 <script>
   try {
     const runden = JSON.parse(localStorage.getItem('fairshare_runden') || '[]');
     if (Array.isArray(runden) && runden.length > 0) {
-      document.getElementById('cta-meine-runden')?.classList.remove('hidden');
+      const el = document.getElementById('cta-meine-runden');
+      if (el) {
+        el.classList.remove('hidden');
+        el.classList.add('animate-fade-in');
+      }
     }
   } catch { /* ignore */ }
 </script>

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -9,21 +9,24 @@ import Layout from '../layouts/Layout.astro';
         <h1 class="text-2xl font-semibold mb-1">Meine Runden</h1>
         <p class="text-slate-500 text-sm">Gespeichert in deinem Browser.</p>
       </div>
-      <div class="flex gap-2">
-        <button
-          id="export-btn"
-          class="border border-slate-300 rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
-        >
-          Exportieren
-        </button>
-        <button
-          id="import-btn"
-          class="border border-slate-300 rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
-        >
-          Importieren
-        </button>
-        <input type="file" id="import-file" accept=".json" class="hidden" />
-      </div>
+      <details class="relative">
+        <summary class="cursor-pointer text-slate-400 hover:text-slate-600 transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
+        <div class="absolute right-0 top-9 bg-white border border-slate-200 rounded-xl shadow-lg z-10 min-w-36 p-1">
+          <button
+            id="export-btn"
+            class="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 rounded-lg transition-colors"
+          >
+            Exportieren
+          </button>
+          <button
+            id="import-btn"
+            class="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 rounded-lg transition-colors"
+          >
+            Importieren
+          </button>
+        </div>
+      </details>
+      <input type="file" id="import-file" accept=".json" class="hidden" />
     </div>
 
     <div id="import-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm"></div>
@@ -31,7 +34,7 @@ import Layout from '../layouts/Layout.astro';
     <!-- Leer-Zustand -->
     <div id="leer-zustand" class="hidden text-center py-16 text-slate-500">
       <p class="mb-4">Noch keine Runden gespeichert.</p>
-      <a href="/neu" class="inline-block bg-green-700 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-green-800 transition-colors">
+      <a href="/neu" class="inline-block bg-brand text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-brand-dark transition-colors">
         Neue Runde erstellen
       </a>
     </div>
@@ -39,6 +42,16 @@ import Layout from '../layouts/Layout.astro';
     <!-- Runden-Liste -->
     <div id="runden-liste" class="space-y-3"></div>
   </div>
+
+  <!-- Löschen-Bestätigung -->
+  <dialog id="loeschen-dialog" class="rounded-xl p-6 shadow-xl max-w-sm w-full backdrop:bg-black/30">
+    <p class="font-medium text-slate-800 mb-1">Runde wirklich löschen?</p>
+    <p class="text-sm text-slate-500 mb-5">Diese Aktion kann nicht rückgängig gemacht werden.</p>
+    <div class="flex gap-3 justify-end">
+      <button id="loeschen-abbrechen" class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-50 transition-colors">Abbrechen</button>
+      <button id="loeschen-bestaetigen" class="bg-red-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-red-700 transition-colors">Ja, löschen</button>
+    </div>
+  </dialog>
 </Layout>
 
 <script>
@@ -48,6 +61,8 @@ import Layout from '../layouts/Layout.astro';
   const rundenListe = document.getElementById('runden-liste')!;
   const leerZustand = document.getElementById('leer-zustand')!;
   const importFehler = document.getElementById('import-fehler')!;
+  const loeschenDialog = document.getElementById('loeschen-dialog') as HTMLDialogElement;
+  let pendingDeleteId: string | null = null;
 
   function formatDatum(iso: string): string {
     return new Date(iso).toLocaleDateString('de-DE', {
@@ -94,7 +109,7 @@ import Layout from '../layouts/Layout.astro';
             <p class="text-xs text-slate-400">Hinzugefügt am ${formatDatum(runde.hinzugefuegtAm)}</p>
           </div>
         </div>
-        <div class="flex flex-wrap gap-2">
+        <div class="flex flex-wrap items-center gap-2">
           <a
             href="${runde.teilnehmerLink}"
             class="inline-flex items-center gap-1 border border-slate-300 rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
@@ -111,7 +126,7 @@ import Layout from '../layouts/Layout.astro';
           ` : ''}
           <button
             data-id="${runde.id}"
-            class="loeschen-btn ml-auto border border-red-200 rounded-lg px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 transition-colors"
+            class="loeschen-btn ml-auto text-xs text-red-400 hover:text-red-600 transition-colors"
           >
             Löschen
           </button>
@@ -120,15 +135,27 @@ import Layout from '../layouts/Layout.astro';
 
       rundenListe.appendChild(karte);
     }
-
   }
 
-  // Löschen (delegiert)
+  // Löschen (delegiert) — öffnet Bestätigungsdialog
   rundenListe.addEventListener('click', (e) => {
     const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.loeschen-btn');
     if (!btn) return;
-    const id = btn.dataset.id!;
-    deleteRunde(id);
+    pendingDeleteId = btn.dataset.id!;
+    loeschenDialog.showModal();
+  });
+
+  document.getElementById('loeschen-abbrechen')!.addEventListener('click', () => {
+    pendingDeleteId = null;
+    loeschenDialog.close();
+  });
+
+  document.getElementById('loeschen-bestaetigen')!.addEventListener('click', () => {
+    if (pendingDeleteId) {
+      deleteRunde(pendingDeleteId);
+      pendingDeleteId = null;
+    }
+    loeschenDialog.close();
     renderRunden();
   });
 

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -8,21 +8,13 @@ import Layout from '../layouts/Layout.astro';
     <h1 class="text-2xl font-semibold mb-1">Neue Runde erstellen</h1>
     <p class="text-slate-500 text-sm mb-6">Alle Daten werden im Browser verschlüsselt — der Server sieht nie Klartext.</p>
 
-    <!-- Splid-Import -->
-    <div class="mb-6 p-4 bg-slate-50 border border-slate-200 rounded-xl">
-      <p class="text-sm font-medium text-slate-700 mb-2">Aus Splid importieren</p>
-      <p class="text-xs text-slate-500 mb-3">Exportiere deine Runde in Splid als XLSX und lade sie hier hoch. Die Datei verlässt deinen Browser nicht.</p>
-      <input type="file" id="splid-file" accept=".xlsx,.xls" class="hidden" />
-      <button
-        type="button"
-        id="splid-import-btn"
-        class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
-      >
-        XLSX-Datei auswählen…
-      </button>
-      <div id="splid-erfolg" class="hidden mt-2 text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2"></div>
-      <div id="splid-fehler" class="hidden mt-2 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2"></div>
-    </div>
+    <!-- Splid-Import (kompakt) -->
+    <p class="mb-6 text-sm text-slate-400">
+      Bereits eine Splid-Abrechnung? <a href="#" id="splid-import-btn" class="underline hover:text-slate-600 transition-colors">XLSX hochladen →</a>
+    </p>
+    <input type="file" id="splid-file" accept=".xlsx,.xls" class="hidden" />
+    <div id="splid-erfolg" class="hidden mb-4 text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2"></div>
+    <div id="splid-fehler" class="hidden mb-4 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2"></div>
 
     <form id="runde-form" class="space-y-6">
       <!-- Runden-Name -->
@@ -85,64 +77,96 @@ import Layout from '../layouts/Layout.astro';
                 placeholder="Label (optional)"
                 class="flex-1 border border-slate-300 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
               />
-              <div class="flex items-center gap-1">
-                <span class="text-xs text-slate-500">Faktor</span>
-                <input
-                  type="number"
-                  name="gewichtung[]"
-                  value="1"
-                  min="0.1"
-                  step="0.1"
-                  required
-                  class="w-16 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
-                />
-              </div>
-              <div class="flex items-center gap-1">
-                <span class="text-xs text-slate-500">Plätze</span>
-                <input
-                  type="number"
-                  name="anzahl[]"
-                  value="1"
-                  min="1"
-                  step="1"
-                  required
-                  class="w-16 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
-                />
-              </div>
               <button
                 type="button"
                 class="slot-entfernen text-slate-400 hover:text-red-500 text-lg leading-none hidden"
                 aria-label="Slot entfernen"
               >×</button>
             </div>
-            <div class="ausgaben-zeile hidden flex items-center gap-2">
-              <span class="text-xs text-slate-500 shrink-0">Ausgaben (€)</span>
-              <input
-                type="number"
-                name="ausgaben[]"
-                min="0"
-                step="0.01"
-                placeholder="0,00"
-                class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
-              />
-            </div>
-            <div class="standardgebot-zeile flex items-center gap-2 flex-wrap">
-              <span class="standardgebot-richtwert text-xs text-slate-400"></span>
-              <label class="flex items-center gap-1 text-xs text-slate-500 cursor-pointer select-none">
-                <input type="checkbox" class="standardgebot-checkbox accent-green-700" />
-                Standardgebot festlegen
-              </label>
-              <div class="standardgebot-eingabe hidden flex items-center gap-1">
-                <input
-                  type="number"
-                  name="standardgebot[]"
-                  min="0"
-                  step="0.01"
-                  data-auto="true"
-                  class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
-                />
+            <span class="standardgebot-richtwert text-xs text-slate-400"></span>
+
+            <!-- Erweiterte Optionen (eingeklappt) -->
+            <details class="slot-erweitert-details">
+              <summary class="text-xs text-slate-400 cursor-pointer hover:text-slate-600 transition-colors select-none list-none flex items-center gap-1">
+                <span class="inline-block transition-transform details-arrow">›</span> Erweitert
+              </summary>
+              <div class="pt-3 space-y-3">
+                <!-- Gewichtungs-Kategorien -->
+                <div class="slot-gewichtung-gruppe">
+                  <p class="text-xs text-slate-500 mb-1.5">Gewichtung</p>
+                  <div class="flex flex-wrap gap-1.5">
+                    <label class="slot-gewichtung-label cursor-pointer">
+                      <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="1.0" checked />
+                      <span class="slot-gewichtung-badge inline-block border border-slate-200 rounded-md px-2.5 py-1 text-xs text-slate-600 hover:border-green-500 transition-colors selected:border-green-600 selected:bg-green-50 selected:text-green-800">Erwachsen</span>
+                    </label>
+                    <label class="slot-gewichtung-label cursor-pointer">
+                      <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.75" />
+                      <span class="slot-gewichtung-badge inline-block border border-slate-200 rounded-md px-2.5 py-1 text-xs text-slate-600 hover:border-green-500 transition-colors">Ermäßigt</span>
+                    </label>
+                    <label class="slot-gewichtung-label cursor-pointer">
+                      <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.5" />
+                      <span class="slot-gewichtung-badge inline-block border border-slate-200 rounded-md px-2.5 py-1 text-xs text-slate-600 hover:border-green-500 transition-colors">Kind</span>
+                    </label>
+                    <label class="slot-gewichtung-label cursor-pointer">
+                      <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="manuell" />
+                      <span class="slot-gewichtung-badge inline-block border border-slate-200 rounded-md px-2.5 py-1 text-xs text-slate-600 hover:border-green-500 transition-colors">Manuell</span>
+                    </label>
+                    <input
+                      type="number"
+                      class="slot-gewichtung-manuell hidden w-16 border border-slate-300 rounded-md px-2 py-1 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
+                      min="0.1"
+                      max="2"
+                      step="0.05"
+                      value="1"
+                      placeholder="0,0–2,0"
+                    />
+                  </div>
+                  <input type="hidden" name="gewichtung[]" value="1" />
+                </div>
+                <!-- Plätze -->
+                <div class="flex items-center gap-2">
+                  <span class="text-xs text-slate-500">Plätze</span>
+                  <input
+                    type="number"
+                    name="anzahl[]"
+                    value="1"
+                    min="1"
+                    step="1"
+                    required
+                    class="w-16 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
+                  />
+                </div>
+                <!-- Ausgaben -->
+                <div class="ausgaben-zeile hidden flex items-center gap-2">
+                  <span class="text-xs text-slate-500 shrink-0">Ausgaben (€)</span>
+                  <input
+                    type="number"
+                    name="ausgaben[]"
+                    min="0"
+                    step="0.01"
+                    placeholder="0,00"
+                    class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                  />
+                </div>
+                <!-- Standardgebot -->
+                <div class="standardgebot-zeile flex items-center gap-2 flex-wrap">
+                  <label class="flex items-center gap-1 text-xs text-slate-500 cursor-pointer select-none">
+                    <input type="checkbox" class="standardgebot-checkbox accent-green-700" />
+                    Standardgebot festlegen
+                  </label>
+                  <div class="standardgebot-eingabe hidden flex items-center gap-1">
+                    <input
+                      type="number"
+                      name="standardgebot[]"
+                      min="0"
+                      step="0.01"
+                      data-auto="true"
+                      class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                    />
+                  </div>
+                </div>
               </div>
-            </div>
+            </details>
           </div>
         </div>
         <p class="text-xs text-slate-400 mt-1">Label ist optional. Ohne Label heißt der Slot „Slot".</p>
@@ -243,6 +267,19 @@ import Layout from '../layouts/Layout.astro';
   </div>
 </Layout>
 
+<style>
+  /* Aktiver Zustand für Gewichtungs-Badges */
+  .slot-gewichtung-radio:checked + .slot-gewichtung-badge {
+    border-color: #3B6D11;
+    background-color: #f0f7eb;
+    color: #27500A;
+  }
+  /* Details-Pfeil drehen wenn offen */
+  details[open] .details-arrow {
+    transform: rotate(90deg);
+  }
+</style>
+
 <script>
   import {
     generatePartKey,
@@ -262,10 +299,19 @@ import Layout from '../layouts/Layout.astro';
   const slotsContainer = document.getElementById('slots-container') as HTMLDivElement;
   const ausgabenToggle = document.getElementById('ausgaben-toggle') as HTMLInputElement;
 
+  // Zähler für eindeutige Radio-Button-Namen
+  let slotCounter = 1;
+
   function setzeAusgabenSichtbarkeit(sichtbar: boolean) {
     slotsContainer.querySelectorAll<HTMLDivElement>('.ausgaben-zeile').forEach((zeile) => {
       zeile.classList.toggle('hidden', !sichtbar);
     });
+    // Erweitert-Panel automatisch öffnen wenn Ausgaben eingeblendet werden
+    if (sichtbar) {
+      slotsContainer.querySelectorAll<HTMLDetailsElement>('.slot-erweitert-details').forEach(d => {
+        d.open = true;
+      });
+    }
   }
 
   ausgabenToggle.addEventListener('change', () => {
@@ -326,20 +372,45 @@ import Layout from '../layouts/Layout.astro';
     const target = e.target as HTMLInputElement;
     if (target.name === 'standardgebot[]') {
       target.dataset.auto = 'false';
-    } else if (target.name === 'gewichtung[]' || target.name === 'anzahl[]') {
+    } else if (target.name === 'anzahl[]') {
       aktualisiereRichtwert();
+    } else if (target.classList.contains('slot-gewichtung-manuell')) {
+      // Manuell-Eingabe → hidden input aktualisieren
+      const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
+      const hiddenInput = eintrag.querySelector<HTMLInputElement>('[name="gewichtung[]"]');
+      if (hiddenInput && target.value) {
+        hiddenInput.value = target.value;
+        aktualisiereRichtwert();
+      }
     }
   });
 
   slotsContainer.addEventListener('change', (e) => {
     const target = e.target as HTMLInputElement;
+
+    // Gewichtungs-Radio
+    if (target.classList.contains('slot-gewichtung-radio')) {
+      const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
+      const hiddenInput = eintrag.querySelector<HTMLInputElement>('[name="gewichtung[]"]');
+      const manuellInput = eintrag.querySelector<HTMLInputElement>('.slot-gewichtung-manuell');
+      if (target.value === 'manuell') {
+        manuellInput?.classList.remove('hidden');
+        if (hiddenInput && manuellInput?.value) hiddenInput.value = manuellInput.value;
+      } else {
+        manuellInput?.classList.add('hidden');
+        if (hiddenInput) hiddenInput.value = target.value;
+        aktualisiereRichtwert();
+      }
+      return;
+    }
+
+    // Standardgebot-Checkbox
     if (!target.classList.contains('standardgebot-checkbox')) return;
     const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
     const eingabe = eintrag.querySelector('.standardgebot-eingabe') as HTMLDivElement;
     const stdInput = eintrag.querySelector<HTMLInputElement>('[name="standardgebot[]"]');
     if (target.checked) {
       eingabe.classList.remove('hidden');
-      // aktualisiereRichtwert hat data-auto-Felder schon befüllt
     } else {
       eingabe.classList.add('hidden');
       if (stdInput) {
@@ -347,6 +418,15 @@ import Layout from '../layouts/Layout.astro';
         stdInput.dataset.auto = 'true';
       }
     }
+  });
+
+  // Slot entfernen (delegiert)
+  slotsContainer.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    if (!target.classList.contains('slot-entfernen')) return;
+    const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
+    eintrag.remove();
+    aktualisiereEntfernenButtons();
   });
 
   // ---------------------------------------------------------------------------
@@ -357,7 +437,8 @@ import Layout from '../layouts/Layout.astro';
   const splidErfolgEl = document.getElementById('splid-erfolg') as HTMLDivElement;
   const splidFehlerEl = document.getElementById('splid-fehler') as HTMLDivElement;
 
-  document.getElementById('splid-import-btn')!.addEventListener('click', () => {
+  document.getElementById('splid-import-btn')!.addEventListener('click', (e) => {
+    e.preventDefault();
     splidFileInput.click();
   });
 
@@ -372,14 +453,9 @@ import Layout from '../layouts/Layout.astro';
       const buffer = await file.arrayBuffer();
       const { rundenname, gesamtkosten, personen } = await parseSplid(buffer);
 
-      // Rundenname befüllen
       (form.querySelector('#rundeName') as HTMLInputElement).value = rundenname;
+      (form.querySelector('#gesamtkosten') as HTMLInputElement).value = gesamtkosten.toFixed(2);
 
-      // Gesamtkosten befüllen
-      (form.querySelector('#gesamtkosten') as HTMLInputElement).value =
-        gesamtkosten.toFixed(2);
-
-      // Slots ersetzen: alle außer dem ersten entfernen, dann Felder befüllen
       const alleSlots = slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag');
       alleSlots.forEach((s, i) => { if (i > 0) s.remove(); });
 
@@ -388,8 +464,10 @@ import Layout from '../layouts/Layout.astro';
       function befuelleSlot(slotEl: HTMLDivElement, label: string, ausgaben: number) {
         (slotEl.querySelector('[name="label[]"]') as HTMLInputElement).value = label;
         (slotEl.querySelector('[name="gewichtung[]"]') as HTMLInputElement).value = '1';
-        (slotEl.querySelector('[name="anzahl[]"]') as HTMLInputElement).value = '1';
         (slotEl.querySelector('[name="ausgaben[]"]') as HTMLInputElement).value = ausgaben.toFixed(2);
+        // Erwachsen-Radio als Standard auswählen
+        const erwachsenRadio = slotEl.querySelector<HTMLInputElement>('.slot-gewichtung-radio[value="1.0"]');
+        if (erwachsenRadio) erwachsenRadio.checked = true;
       }
 
       befuelleSlot(ersterSlot, personen[0].name, personen[0].ausgaben);
@@ -397,6 +475,9 @@ import Layout from '../layouts/Layout.astro';
       for (let i = 1; i < personen.length; i++) {
         const vorlage = slotsContainer.querySelector('.slot-eintrag') as HTMLDivElement;
         const klon = vorlage.cloneNode(true) as HTMLDivElement;
+        // Eindeutigen Namen für Radio-Buttons setzen
+        const uid = `gw-slot-${slotCounter++}`;
+        klon.querySelectorAll<HTMLInputElement>('.slot-gewichtung-radio').forEach(r => { r.name = uid; });
         befuelleSlot(klon, personen[i].name, personen[i].ausgaben);
         slotsContainer.appendChild(klon);
       }
@@ -415,7 +496,6 @@ import Layout from '../layouts/Layout.astro';
       splidFehlerEl.classList.remove('hidden');
     }
 
-    // Input zurücksetzen damit dieselbe Datei nochmals gewählt werden kann
     splidFileInput.value = '';
   });
 
@@ -423,16 +503,24 @@ import Layout from '../layouts/Layout.astro';
   // Slot hinzufügen
   // ---------------------------------------------------------------------------
 
-  // Slot hinzufügen
   document.getElementById('slot-hinzufuegen')!.addEventListener('click', () => {
     const vorlage = slotsContainer.querySelector('.slot-eintrag') as HTMLDivElement;
     const klon = vorlage.cloneNode(true) as HTMLDivElement;
+
     // Felder zurücksetzen
-    klon.querySelectorAll('input').forEach((inp) => {
-      if (inp.name === 'gewichtung[]') inp.value = '1';
-      else if (inp.name === 'anzahl[]') inp.value = '1';
-      else inp.value = '';
+    const uid = `gw-slot-${slotCounter++}`;
+    klon.querySelectorAll<HTMLInputElement>('.slot-gewichtung-radio').forEach((r, i) => {
+      r.name = uid;
+      r.checked = i === 0; // Erwachsen vorauswählen
     });
+    klon.querySelectorAll<HTMLInputElement>('input[name="label[]"]').forEach(el => { el.value = ''; });
+    klon.querySelectorAll<HTMLInputElement>('input[name="anzahl[]"]').forEach(el => { el.value = '1'; });
+    klon.querySelectorAll<HTMLInputElement>('input[name="ausgaben[]"]').forEach(el => { el.value = ''; });
+    klon.querySelectorAll<HTMLInputElement>('[name="gewichtung[]"]').forEach(el => { el.value = '1'; });
+    klon.querySelectorAll<HTMLInputElement>('.slot-gewichtung-manuell').forEach(el => {
+      el.value = '1'; el.classList.add('hidden');
+    });
+
     // Standardgebot zurücksetzen
     const stdCheckbox = klon.querySelector<HTMLInputElement>('.standardgebot-checkbox');
     if (stdCheckbox) stdCheckbox.checked = false;
@@ -442,26 +530,45 @@ import Layout from '../layouts/Layout.astro';
     if (stdInput) { stdInput.value = ''; stdInput.dataset.auto = 'true'; }
     const richtwertAnzeige = klon.querySelector<HTMLSpanElement>('.standardgebot-richtwert');
     if (richtwertAnzeige) richtwertAnzeige.textContent = '';
-    // Ausgaben-Zeile entsprechend Toggle-Zustand ein-/ausblenden
+
+    // Ausgaben-Zeile entsprechend Toggle-Zustand
     const ausgabenZeile = klon.querySelector('.ausgaben-zeile') as HTMLDivElement;
     ausgabenZeile.classList.toggle('hidden', !ausgabenToggle.checked);
+
+    // Details schließen für neuen Slot
+    const details = klon.querySelector<HTMLDetailsElement>('.slot-erweitert-details');
+    if (details) details.open = false;
+
     slotsContainer.appendChild(klon);
+    klon.classList.add('animate-slide-down');
     aktualisiereEntfernenButtons();
     aktualisiereRichtwert();
-  });
-
-  // Slot entfernen (delegiert)
-  slotsContainer.addEventListener('click', (e) => {
-    const target = e.target as HTMLElement;
-    if (!target.classList.contains('slot-entfernen')) return;
-    const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
-    eintrag.remove();
-    aktualisiereEntfernenButtons();
   });
 
   // ---------------------------------------------------------------------------
   // Runde wiederholen (Vorausfüllen aus sessionStorage)
   // ---------------------------------------------------------------------------
+
+  function setzeGewichtungRadio(slotEl: HTMLDivElement, gewichtung: number) {
+    const hiddenInput = slotEl.querySelector<HTMLInputElement>('[name="gewichtung[]"]');
+    if (hiddenInput) hiddenInput.value = String(gewichtung);
+
+    // Passendes Radio auswählen oder Manuell
+    const presets = ['1.0', '0.75', '0.5'];
+    const matchingValue = presets.find(v => Math.abs(parseFloat(v) - gewichtung) < 0.001);
+    if (matchingValue) {
+      const radio = slotEl.querySelector<HTMLInputElement>(`.slot-gewichtung-radio[value="${matchingValue}"]`);
+      if (radio) radio.checked = true;
+    } else {
+      const manuellRadio = slotEl.querySelector<HTMLInputElement>('.slot-gewichtung-radio[value="manuell"]');
+      const manuellInput = slotEl.querySelector<HTMLInputElement>('.slot-gewichtung-manuell');
+      if (manuellRadio) manuellRadio.checked = true;
+      if (manuellInput) {
+        manuellInput.value = String(gewichtung);
+        manuellInput.classList.remove('hidden');
+      }
+    }
+  }
 
   const wiederholenRaw = sessionStorage.getItem('rundeWiederholen');
   if (wiederholenRaw) {
@@ -482,8 +589,8 @@ import Layout from '../layouts/Layout.astro';
       ) {
         (slotEl.querySelector('[name="label[]"]') as HTMLInputElement).value =
           slot.label === 'Slot' ? '' : slot.label;
-        (slotEl.querySelector('[name="gewichtung[]"]') as HTMLInputElement).value = String(slot.gewichtung);
         (slotEl.querySelector('[name="anzahl[]"]') as HTMLInputElement).value = String(slot.anzahl);
+        setzeGewichtungRadio(slotEl, slot.gewichtung);
 
         const checkbox = slotEl.querySelector<HTMLInputElement>('.standardgebot-checkbox')!;
         const eingabe = slotEl.querySelector<HTMLDivElement>('.standardgebot-eingabe')!;
@@ -502,7 +609,6 @@ import Layout from '../layouts/Layout.astro';
         }
       }
 
-      // Alle außer dem ersten Slot entfernen
       slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag').forEach((s, i) => {
         if (i > 0) s.remove();
       });
@@ -512,6 +618,8 @@ import Layout from '../layouts/Layout.astro';
 
       for (let i = 1; i < config.slots.length; i++) {
         const klon = ersterSlot.cloneNode(true) as HTMLDivElement;
+        const uid = `gw-slot-${slotCounter++}`;
+        klon.querySelectorAll<HTMLInputElement>('.slot-gewichtung-radio').forEach(r => { r.name = uid; });
         slotsContainer.appendChild(klon);
         befuelleWiederholSlot(klon, config.slots[i]);
       }
@@ -604,16 +712,13 @@ import Layout from '../layouts/Layout.astro';
 
       const { id, adminToken } = (await res.json()) as { id: string; adminToken: string };
 
-      // Schlüssel exportieren
       const partKeyB64 = await exportKey(partKey);
       const adminPrivKeyB64 = await exportKey(adminPrivKey);
 
-      // Links zusammensetzen
       const origin = window.location.origin;
       const teilnehmerLink = `${origin}/runde/${id}#pk=${partKeyB64}`;
       const adminLink = `${origin}/runde/${id}/admin/${adminToken}#pk=${partKeyB64}&bk=${adminPrivKeyB64}`;
 
-      // Runde im localStorage speichern
       saveRunde({
         id,
         name: rundeName,
@@ -623,13 +728,13 @@ import Layout from '../layouts/Layout.astro';
         slots: slots.map(({ label, gewichtung, anzahl }) => ({ label, gewichtung, anzahl })),
       });
 
-      // Anzeigen
       (document.getElementById('teilnehmer-link') as HTMLInputElement).value = teilnehmerLink;
       (document.getElementById('admin-link') as HTMLInputElement).value = adminLink;
       (document.getElementById('teilnehmer-link-oeffnen') as HTMLAnchorElement).href = teilnehmerLink;
       (document.getElementById('admin-link-oeffnen') as HTMLAnchorElement).href = adminLink;
       formBereich.classList.add('hidden');
       ergebnisBereich.classList.remove('hidden');
+      ergebnisBereich.classList.add('animate-fade-in');
     } catch (err) {
       zeigeFehler('Fehler beim Erstellen der Runde. Bitte versuche es erneut.');
       console.error(err);

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -33,7 +33,7 @@ import Layout from '../../layouts/Layout.astro';
       </button>
       <button
         id="tab-korrigieren"
-        class="px-4 py-2 text-sm font-medium border-b-2 border-transparent text-slate-500 -mb-px hover:text-slate-700 transition-colors"
+        class="hidden px-4 py-2 text-sm font-medium border-b-2 border-transparent text-slate-500 -mb-px hover:text-slate-700 transition-colors"
       >
         Gebot korrigieren
       </button>
@@ -151,13 +151,9 @@ import Layout from '../../layouts/Layout.astro';
 
   <!-- Bestätigung -->
   <div id="zustand-bestaetigung" class="hidden text-center space-y-4 py-8">
-    <div class="text-6xl mb-2" id="emoji-anzeige"></div>
     <h2 id="bestaetigung-titel" class="text-xl font-semibold">Gebot abgegeben</h2>
-    <p id="bestaetigung-text" class="text-slate-500 text-sm max-w-sm mx-auto">
-      Das ist dein persönlicher Beleg. Merke dir diese Emoji-Kombination —
-      sie beweist, dass dein Gebot registriert wurde.
-    </p>
-    <div class="bg-slate-100 rounded-xl px-6 py-4 inline-block">
+    <p id="bestaetigung-text" class="text-slate-500 text-sm max-w-sm mx-auto"></p>
+    <div id="emoji-box" class="bg-slate-100 rounded-xl px-6 py-4 inline-block">
       <p class="text-xs text-slate-500 mb-1">Deine Emoji-ID</p>
       <p id="emoji-id-text" class="text-3xl tracking-widest"></p>
     </div>
@@ -283,8 +279,7 @@ import Layout from '../../layouts/Layout.astro';
           <input type="radio" name="${nameAttr}" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
           <span class="flex-1">
             <span class="text-sm font-medium text-slate-800">${slot.label}</span>
-            <span class="text-xs text-slate-500 ml-2">Faktor ${slot.gewichtung} · ${slot.anzahl} Platz/Plätze · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
-            ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-xs text-amber-600 ml-1">(bereits abgegeben)</span>' : ''}
+            <span class="text-xs text-slate-500 ml-2">Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
           </span>
         `;
         container.appendChild(label);
@@ -347,7 +342,14 @@ import Layout from '../../layouts/Layout.astro';
 
     // Formular anzeigen
     document.getElementById('zustand-laden')!.classList.add('hidden');
-    document.getElementById('zustand-formular')!.classList.remove('hidden');
+    const zustandFormular = document.getElementById('zustand-formular')!;
+    zustandFormular.classList.remove('hidden');
+    zustandFormular.classList.add('animate-fade-in');
+
+    // Korrektur-Tab einblenden falls bereits geboten
+    if (blob.slots.some(s => slotBereitsGeboten(s.label))) {
+      document.getElementById('tab-korrigieren')!.classList.remove('hidden');
+    }
 
     // ── Tab 1: Gebot abgeben ──────────────────────────────────────────────────
     const gebotForm = document.getElementById('gebot-form') as HTMLFormElement;
@@ -359,14 +361,16 @@ import Layout from '../../layouts/Layout.astro';
     const duplikatBestaetigen = document.getElementById('duplikat-bestaetigen') as HTMLButtonElement;
 
     function zeigeBestaetigung(emojiId: string, istKorrektur: boolean) {
-      document.getElementById('emoji-anzeige')!.textContent = emojiId;
       document.getElementById('emoji-id-text')!.textContent = emojiId;
       document.getElementById('bestaetigung-titel')!.textContent = istKorrektur ? 'Gebot korrigiert' : 'Gebot abgegeben';
       document.getElementById('bestaetigung-text')!.textContent = istKorrektur
         ? 'Dein Gebot wurde erfolgreich ersetzt. Deine Emoji-ID bleibt dieselbe.'
-        : 'Das ist dein persönlicher Beleg. Merke dir diese Emoji-Kombination — sie beweist, dass dein Gebot registriert wurde.';
+        : 'Speichere sie — du brauchst sie, um dein Gebot zu korrigieren und deinen Eintrag in der Auswertung wiederzufinden.';
       document.getElementById('zustand-formular')!.classList.add('hidden');
-      document.getElementById('zustand-bestaetigung')!.classList.remove('hidden');
+      const zustandBestaetigung = document.getElementById('zustand-bestaetigung')!;
+      zustandBestaetigung.classList.remove('hidden');
+      zustandBestaetigung.classList.add('animate-fade-in');
+      document.getElementById('emoji-box')!.classList.add('animate-pop-in');
     }
 
     // Kernfunktion: Gebot tatsächlich einreichen (mit Auto-Retry bei Emoji-Kollision)
@@ -418,6 +422,7 @@ import Layout from '../../layouts/Layout.astro';
         }
 
         slotAlsGebotenMarkieren(selectedSlot.label);
+        document.getElementById('tab-korrigieren')!.classList.remove('hidden');
         zeigeBestaetigung(emojiId!, false);
       } catch (err) {
         gebotFehler.textContent = 'Unerwarteter Fehler. Bitte versuche es erneut.';

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -55,9 +55,12 @@ import Layout from '../../../../layouts/Layout.astro';
       <p id="ueberschuss-text" class="text-2xl font-bold text-green-700 print:text-xl"></p>
     </div>
 
+    <!-- Status-Banner -->
+    <div id="status-banner" class="hidden rounded-xl px-4 py-3 text-sm font-medium print:hidden"></div>
+
     <!-- Tabelle -->
     <div class="overflow-x-auto">
-      <table class="w-full text-sm border-collapse">
+      <table class="results-table w-full text-sm border-collapse">
         <thead>
           <tr class="border-b border-slate-200 text-left text-xs text-slate-500">
             <th class="pb-2 pr-4 font-medium emoji-spalte">Emoji-ID</th>
@@ -65,8 +68,8 @@ import Layout from '../../../../layouts/Layout.astro';
             <th class="pb-2 pr-4 font-medium text-right">Faktor</th>
             <th class="pb-2 pr-4 font-medium text-right">Richtwert</th>
             <th class="pb-2 pr-4 font-medium text-right splid-spalte vollstaendig-spalte hidden">Ausgaben</th>
-            <th class="pb-2 pr-4 font-medium text-right vollstaendig-spalte hidden">Beitrag</th>
-            <th class="pb-2 pr-4 font-medium text-right splid-spalte vollstaendig-spalte hidden">Noch zu zahlen</th>
+            <th class="pb-2 pr-4 font-semibold text-right vollstaendig-spalte hidden">Beitrag</th>
+            <th class="pb-2 pr-4 font-semibold text-right splid-spalte vollstaendig-spalte hidden">Noch zu zahlen</th>
             <th class="pb-2 font-medium">Status</th>
           </tr>
         </thead>
@@ -77,23 +80,23 @@ import Layout from '../../../../layouts/Layout.astro';
     <!-- Ausgleichszahlungen -->
     <div id="ausgleich-section" class="hidden space-y-2">
       <h2 class="text-sm font-medium text-slate-700 print:text-xs">Ausgleichszahlungen</h2>
-      <ul id="ausgleich-liste" class="space-y-1 text-sm print:text-xs"></ul>
+      <div id="ausgleich-liste" class="rounded-xl border border-slate-200 bg-white overflow-hidden print:text-xs"></div>
     </div>
 
-    <!-- Status -->
+    <!-- Status (klein, ergänzend zum Banner) -->
     <p id="gebote-anzahl" class="text-xs text-slate-400 print:hidden"></p>
 
     <!-- Drucken / Wiederholen -->
     <div class="flex gap-3 print:hidden">
       <button
         onclick="window.print()"
-        class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+        class="bg-brand text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-brand-dark transition-colors"
       >
         Als PDF drucken
       </button>
       <button
         id="wiederholen-btn"
-        class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors"
+        class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
       >
         Runde wiederholen
       </button>
@@ -126,6 +129,17 @@ import Layout from '../../../../layouts/Layout.astro';
     document.getElementById('zustand-laden')!.classList.add('hidden');
     document.getElementById('zustand-fehler')!.classList.remove('hidden');
     document.getElementById('fehler-text')!.textContent = msg;
+  }
+
+  function zeigeBanner(text: string, farbe: 'green' | 'amber' | 'red') {
+    const banner = document.getElementById('status-banner')!;
+    const farbenKlassen: Record<string, string> = {
+      green: 'bg-green-50 border border-green-200 text-green-800',
+      amber: 'bg-amber-50 border border-amber-200 text-amber-800',
+      red:   'bg-red-50 border border-red-200 text-red-800',
+    };
+    banner.className = `rounded-xl px-4 py-3 text-sm font-medium print:hidden ${farbenKlassen[farbe]}`;
+    banner.textContent = text;
   }
 
   async function init() {
@@ -312,38 +326,38 @@ import Layout from '../../../../layouts/Layout.astro';
         }
 
         const emojiZelle = hatGebot
-          ? `<td class="py-2 pr-4 text-lg emoji-spalte">${e.emojiId}</td>`
-          : `<td class="py-2 pr-4 emoji-spalte">—</td>`;
+          ? `<td data-label="Emoji-ID" class="py-2 pr-4 text-lg emoji-spalte">${e.emojiId}</td>`
+          : `<td data-label="Emoji-ID" class="py-2 pr-4 emoji-spalte">—</td>`;
 
         const ausgabenZelle = hatSplidDaten
-          ? `<td class="py-2 pr-4 text-right splid-spalte vollstaendig-spalte hidden">${fehlt ? '—' : eur(ausgaben)}</td>`
+          ? `<td data-label="Ausgaben" class="py-2 pr-4 text-right splid-spalte vollstaendig-spalte hidden">${fehlt ? '—' : eur(ausgaben)}</td>`
           : '';
 
         const beitragZelle = fehlt
-          ? `<td class="py-2 pr-4 text-right vollstaendig-spalte hidden">—</td>`
-          : `<td class="py-2 pr-4 text-right font-medium vollstaendig-spalte hidden">${eur(e.solidarischerBeitrag)}</td>`;
+          ? `<td data-label="Beitrag" class="py-2 pr-4 text-right vollstaendig-spalte hidden">—</td>`
+          : `<td data-label="Beitrag" class="py-2 pr-4 text-right font-bold text-slate-900 vollstaendig-spalte hidden">${eur(e.solidarischerBeitrag)}</td>`;
 
         let nochZuZahlenZelle = '';
         if (hatSplidDaten) {
           if (fehlt) {
-            nochZuZahlenZelle = `<td class="py-2 pr-4 text-right splid-spalte vollstaendig-spalte hidden">—</td>`;
+            nochZuZahlenZelle = `<td data-label="Noch zu zahlen" class="py-2 pr-4 text-right splid-spalte vollstaendig-spalte hidden">—</td>`;
           } else {
             const nochZuZahlen = e.solidarischerBeitrag - ausgaben;
             const nochSign = nochZuZahlen > 0.005 ? '+' : '';
             const nochClass = istStandard ? '' : (nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700');
-            nochZuZahlenZelle = `<td class="py-2 pr-4 text-right font-medium splid-spalte vollstaendig-spalte hidden ${nochClass}">${nochSign}${eur(nochZuZahlen)}</td>`;
+            nochZuZahlenZelle = `<td data-label="Noch zu zahlen" class="py-2 pr-4 text-right font-bold splid-spalte vollstaendig-spalte hidden ${nochClass}">${nochSign}${eur(nochZuZahlen)}</td>`;
           }
         }
 
         tr.innerHTML = `
           ${emojiZelle}
-          <td class="py-2 pr-4">${slot.label}</td>
-          <td class="py-2 pr-4 text-right">${slot.gewichtung}</td>
-          <td class="py-2 pr-4 text-right">${fehlt ? eur(richtwertAnteil) : eur(e.richtwertAnteil)}</td>
+          <td data-label="Slot" class="py-2 pr-4">${slot.label}</td>
+          <td data-label="Faktor" class="py-2 pr-4 text-right">${slot.gewichtung}</td>
+          <td data-label="Richtwert" class="py-2 pr-4 text-right">${fehlt ? eur(richtwertAnteil) : eur(e.richtwertAnteil)}</td>
           ${ausgabenZelle}
           ${beitragZelle}
           ${nochZuZahlenZelle}
-          <td class="py-2 pr-4">${statusBadge}</td>
+          <td data-label="Status" class="py-2 pr-4">${statusBadge}</td>
         `;
         tbody.appendChild(tr);
       }
@@ -359,13 +373,17 @@ import Layout from '../../../../layouts/Layout.astro';
           if (!e.istStandard) emojiZuLabel.set(e.emojiId, e.slotLabel);
         }
         const liste = document.getElementById('ausgleich-liste')!;
-        for (const z of zahlungen) {
-          const li = document.createElement('li');
+        zahlungen.forEach((z, idx) => {
+          const zeile = document.createElement('div');
           const vonLabel = emojiZuLabel.get(z.von) ?? z.von;
           const anLabel = emojiZuLabel.get(z.an) ?? z.an;
-          li.textContent = `${vonLabel} → ${anLabel}   ${eur(z.betrag)}`;
-          liste.appendChild(li);
-        }
+          zeile.className = `flex justify-between items-center px-4 py-2.5 ${idx < zahlungen.length - 1 ? 'border-b border-slate-100' : ''}`;
+          zeile.innerHTML = `
+            <span class="text-sm text-slate-700">${vonLabel} → ${anLabel}</span>
+            <span class="text-sm font-semibold text-slate-900">${eur(z.betrag)}</span>
+          `;
+          liste.appendChild(zeile);
+        });
         document.getElementById('ausgleich-section')!.classList.remove('hidden');
       }
     }
@@ -391,20 +409,22 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Statuszeile (nur Gebote für Slots ohne standardgebot zählen)
+    // Status-Banner + Statuszeile (nur Gebote für Slots ohne standardgebot zählen)
     if (hatDuplikate) {
+      zeigeBanner('Doppelgebote vorhanden — bitte klären.', 'amber');
       document.getElementById('gebote-anzahl')!.textContent =
-        `${geboteOhneStandard.length} Gebote eingegangen, ${totalErwartet} erwartet — bitte Doppelgebote klären`;
+        `${geboteOhneStandard.length} Gebote eingegangen, ${totalErwartet} erwartet`;
     } else if (allesDa) {
       const fehlbetragVorhanden = auswertung && auswertung.fehlbetrag > 0.005;
-      document.getElementById('gebote-anzahl')!.textContent =
-        totalErwartet === 0
-          ? 'Auswertung vollständig (alle Slots mit Standardgebot)'
-          : fehlbetragVorhanden
-            ? `Alle ${totalErwartet} Gebote eingegangen — Fehlbetrag, Runde muss wiederholt werden`
-            : `Alle ${totalErwartet} Gebote eingegangen — Auswertung vollständig`;
+      if (totalErwartet === 0) {
+        zeigeBanner('Auswertung vollständig (alle Slots mit Standardgebot).', 'green');
+      } else if (fehlbetragVorhanden) {
+        zeigeBanner(`Fehlbetrag: ${eur(auswertung!.fehlbetrag)} — Runde muss wiederholt werden.`, 'red');
+      } else {
+        zeigeBanner('Alle Gebote eingegangen. Auswertung abgeschlossen.', 'green');
+      }
     } else {
-      document.getElementById('gebote-anzahl')!.textContent = `${geboteOhneStandard.length} von ${totalErwartet} Geboten eingegangen`;
+      zeigeBanner(`${geboteOhneStandard.length} von ${totalErwartet} Geboten eingegangen.`, 'amber');
     }
 
     document.getElementById('zustand-laden')!.classList.add('hidden');

--- a/src/pages/ueber.astro
+++ b/src/pages/ueber.astro
@@ -1,0 +1,82 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Über FairShare">
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold text-slate-900 mb-2">Über FairShare</h1>
+    <p class="text-slate-600">Wie FairShare funktioniert, was der Server sieht — und was nicht.</p>
+  </div>
+
+  <!-- Zero-Knowledge -->
+  <div class="mb-6 rounded-xl border border-slate-200 bg-white p-6">
+    <h2 class="text-lg font-semibold text-slate-900 mb-2">Zero-Knowledge-Prinzip</h2>
+    <p class="text-sm text-slate-600 leading-relaxed mb-4">
+      Alle Inhalte werden im Browser verschlüsselt, bevor sie den Server erreichen.
+      Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-slate-100 px-1 py-0.5 rounded">#…</code>)
+      — diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
+      Die App folgt dem <strong>Zero-Knowledge-Prinzip</strong>: mit einigen
+      bewussten Einschränkungen, die wir transparent machen.
+    </p>
+
+    <details class="group">
+      <summary class="cursor-pointer text-sm font-medium text-brand hover:text-brand-dark flex items-center gap-1 select-none">
+        <span class="transition-transform group-open:rotate-90 inline-block">›</span>
+        Was der Server theoretisch inferieren kann (Threat Model)
+      </summary>
+      <div class="mt-3 text-sm text-slate-600 space-y-3 pl-4 border-l-2 border-slate-200">
+        <div>
+          <p class="font-medium text-slate-800">Anzahl der Teilnehmer*innen</p>
+          <p class="mt-0.5">Jedes Gebot ist ein separater verschlüsselter Eintrag im Server-Store — der Server kann Einträge zählen und so die ungefähre Teilnehmerzahl inferieren.</p>
+        </div>
+        <div>
+          <p class="font-medium text-slate-800">Zeitpunkte der Gebots-Einreichung</p>
+          <p class="mt-0.5">Der Server sieht, wann ein Gebot einging. Muster (z.&nbsp;B. alle binnen 5 Minuten) können auf Gruppenverhalten hindeuten.</p>
+        </div>
+        <div>
+          <p class="font-medium text-slate-800">Existenz einer Runde</p>
+          <p class="mt-0.5">Eine Runden-ID existiert auf dem Server und ist aktiv oder nicht — ohne Klartext-Bezug zum Inhalt.</p>
+        </div>
+        <div class="pt-1">
+          <p class="font-medium text-slate-800">Was der Server <em>nicht</em> sieht</p>
+          <p class="mt-0.5">Namen, Gebotsbeträge, Slot-Auswahl, Emoji-IDs, Admin-Schlüssel — all das bleibt verschlüsselt.</p>
+        </div>
+      </div>
+    </details>
+  </div>
+
+  <!-- Vertrauen -->
+  <div class="mb-6 rounded-xl border border-slate-200 bg-white p-6">
+    <h2 class="text-lg font-semibold text-slate-900 mb-2">Vertrauen in die Organisator*in</h2>
+    <p class="text-sm text-slate-600 leading-relaxed mb-3">
+      Die App ist <strong>kein Zero-Trust-System</strong>. Die Organisator*in hat den
+      privaten Admin-Schlüssel und kann damit technisch alle Gebote entschlüsseln —
+      das Frontend zeigt ihr nur die Auswertungstabelle, aber der Zugriff auf Rohwerte
+      wäre im Code möglich.
+    </p>
+    <p class="text-sm text-slate-600 leading-relaxed mb-3">
+      Teilnehmer*innen hingegen können <strong>keine</strong> Gebote anderer sehen:
+      Gebote sind mit dem öffentlichen Admin-Schlüssel verschlüsselt und nur mit dem
+      privaten Schlüssel der Organisator*in lesbar.
+    </p>
+    <p class="text-sm text-slate-500 leading-relaxed">
+      Vertrauen in die Organisator*in ist Teil des Modells — vergleichbar mit einem
+      Kassenprüfer in einer Genossenschaft: Kontrolle durch Transparenz, nicht durch
+      technische Sperre.
+    </p>
+  </div>
+
+  <!-- Datenschutz -->
+  <div class="rounded-xl border border-slate-200 bg-white p-6">
+    <h2 class="text-lg font-semibold text-slate-900 mb-2">Datenschutz</h2>
+    <p class="text-sm text-slate-600 leading-relaxed mb-3">
+      FairShare speichert keine personenbezogenen Daten. Es gibt keine Nutzerkonten,
+      keine E-Mail-Adressen, keine Tracking-Cookies. Runden-IDs sind zufällig generiert
+      und enthalten keine Nutzerinformationen.
+    </p>
+    <p class="text-sm text-slate-600 leading-relaxed">
+      Gespeicherte Runden-Links werden ausschließlich in deinem Browser (localStorage)
+      gespeichert — nie auf dem Server.
+    </p>
+  </div>
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,58 @@
+@import url('https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap');
 @import "tailwindcss";
 
 @theme {
   --color-brand: #3B6D11;
   --color-brand-dark: #27500A;
+}
+
+@layer base {
+  body {
+    font-family: 'Satoshi', system-ui, sans-serif;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes popIn {
+  from { opacity: 0; transform: scale(0.8); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.animate-fade-in    { animation: fadeIn    150ms ease-out forwards; }
+.animate-slide-down { animation: slideDown 200ms ease-out forwards; }
+.animate-pop-in     { animation: popIn     300ms ease-out forwards; }
+
+/* Responsive Tabelle — Mobile Card Stack */
+@media (max-width: 639px) {
+  .results-table thead { display: none; }
+  .results-table tr {
+    display: block;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
+  }
+  .results-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.2rem 0;
+    font-size: 0.875rem;
+  }
+  .results-table td::before {
+    content: attr(data-label);
+    color: #94a3b8;
+    font-size: 0.75rem;
+    flex-shrink: 0;
+    margin-right: 0.5rem;
+  }
 }


### PR DESCRIPTION
## Was wurde gebaut

Umsetzung aller 21 Maßnahmen aus dem UX-Review (`fairshare-zk-ux-review-v2.md`). Ziel: Progressive Disclosure, Apple-inspiriertes Feeling, klarere Hierarchien und subtile Micro-Animations — ohne Änderungen am Tech Stack.

### Globale Änderungen
- **Satoshi Font** (Fontshare CDN) als neue App-Schrift
- **CSS-Animationen**: `fadeIn` (150ms), `slideDown` (200ms), `popIn` (300ms) als globale Utility-Klassen
- **Aktiver Nav-Zustand**: aktive Seite wird serverseitig hervorgehoben (`text-brand font-semibold`)
- **Footer-Link** zu `/ueber`

### Neue Seite: `/ueber`
- ZK-Erklärung, Threat Model, Vertrauen-Abschnitt und Datenschutz ausgelagert
- Startseite stark vereinfacht: Hero + 3 Schritte + CTA + Link „Wie funktioniert das genau? →"

### `/neu` — Neue Runde erstellen
- **Splid-Import** reduziert auf kleinen Inline-Link (kein Block-Element mehr)
- **Slot-Gewichtung** als Radio-Gruppe: Erwachsen (1,0) / Ermäßigt (0,75) / Kind (0,5) / Manuell
- **Advanced-Felder** (Gewichtung, Plätze, Ausgaben, Standardgebot) per `<details>` standardmäßig eingeklappt — Richtwert bleibt immer sichtbar
- **Slide-down-Animation** beim Hinzufügen eines neuen Slots
- **Fade-in** beim Übergang Formular → Ergebnisbereich

### `/runde/[id]` — Gebot abgeben
- Tab „Gebot korrigieren" erst nach dem ersten abgegebenen Gebot sichtbar
- Slot-Karte zeigt nur noch Label + Richtwert (kein Faktor, keine Plätze)
- Emoji-ID: keine Dopplung mehr; nur eine Anzeige mit Beschriftung „Deine Emoji-ID"
- Bestätigungstext um Korrektur- und Auswertungs-Funktion erweitert
- **Pop-in-Animation** für die Emoji-Box; **Fade-in** für den Bestätigungsscreen

### `/runde/[id]/admin/[token]` — Auswertung
- **Status-Banner** oberhalb der Tabelle (grün/amber/rot je nach Zustand)
- **Responsive Card-Stack**: Tabelle wird auf Mobile (`< 640px`) zu gestapelten Karten mit `data-label`-Beschriftung
- Spalten „Beitrag" und „Noch zu zahlen" visuell hervorgehoben (`font-bold text-slate-900`)
- **Ausgleichszahlungen** als strukturierte Liste mit rechtsbündigem Betrag
- Button-Hierarchie: „Als PDF drucken" primär (grün), „Runde wiederholen" sekundär (Outline)

### `/meine-runden`
- Export/Import in **Overflow-Menü** (`⋯`) ausgelagert
- **Löschen-Bestätigung** via nativem `<dialog>`-Element
- Löschen-Button als Ghost-Link (`text-xs text-red-400`), nicht mehr gleichwertig mit Aktions-Buttons

## Wie wurde getestet

- Alle 50 bestehenden Unit-Tests grün (`npm run test`): `crypto.ts`, `solidarisch.ts`, `splid.ts`
- Keine Logik-Änderungen an Bibliothekscode — nur HTML/CSS/UI-Schicht

## Was kommt als nächstes

Feature 2 gemäß BACKLOG.md