### PR TITLE
UX-Refinements Round 2: Apple-like Polish

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,62 +3,32 @@ import Layout from '../layouts/Layout.astro';
 ---
 
 <Layout title="Solidarische Gruppenfinanzierung">
-  <!-- Hero -->
-  <div class="mb-10">
-    <h1 class="text-3xl font-bold text-slate-900 mb-3">Solidarische Gruppenfinanzierung</h1>
-    <p class="text-lg text-slate-600 leading-relaxed">
-      FairShare hilft Gruppen dabei, gemeinsame Kosten solidarisch aufzuteilen —
-      jede Person bietet, was sie tragen kann. Anonym, ohne Registrierung, ohne dass
-      der Server eure Daten je zu sehen bekommt.
-    </p>
-  </div>
+  <div class="flex flex-col items-center text-center py-12 space-y-8">
+    <!-- Hero -->
+    <div class="space-y-3 max-w-sm">
+      <h1 class="text-3xl font-bold text-slate-900 leading-tight">
+        Teilt Kosten solidarisch —<br />jede Person zahlt, was sie kann.
+      </h1>
+    </div>
 
-  <!-- Wie es funktioniert -->
-  <div class="mb-10">
-    <h2 class="text-base font-semibold text-slate-500 uppercase tracking-wide mb-4">So funktioniert's</h2>
-    <ol class="space-y-4">
-      <li class="flex gap-4">
-        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-brand text-white text-sm font-bold flex items-center justify-center">1</span>
-        <div>
-          <p class="font-medium text-slate-900">Runde erstellen</p>
-          <p class="text-sm text-slate-600 mt-0.5">Die Organisator*in legt Gesamtkosten und Slot-Typen fest (z.&nbsp;B. Erwachsene, Kinder). Die App generiert Links für Teilnehmende und einen Admin-Link.</p>
-        </div>
-      </li>
-      <li class="flex gap-4">
-        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-brand text-white text-sm font-bold flex items-center justify-center">2</span>
-        <div>
-          <p class="font-medium text-slate-900">Gebot abgeben</p>
-          <p class="text-sm text-slate-600 mt-0.5">Jede Person öffnet ihren persönlichen Link und gibt an, was sie zahlen kann — anonym, nur mit einer zufälligen Emoji-ID erkennbar.</p>
-        </div>
-      </li>
-      <li class="flex gap-4">
-        <span class="flex-shrink-0 w-8 h-8 rounded-full bg-brand text-white text-sm font-bold flex items-center justify-center">3</span>
-        <div>
-          <p class="font-medium text-slate-900">Auswertung im Browser</p>
-          <p class="text-sm text-slate-600 mt-0.5">Die Organisator*in öffnet den Admin-Link — die Gebote werden direkt im Browser entschlüsselt und ausgewertet. Der Server sieht nie Klartext.</p>
-        </div>
-      </li>
-    </ol>
-  </div>
+    <!-- CTA -->
+    <div class="flex flex-col items-center gap-3 w-full max-w-xs">
+      <a
+        href="/neu"
+        class="w-full inline-flex items-center justify-center px-6 py-3 rounded-xl bg-brand text-white font-semibold hover:bg-brand-dark transition-colors text-base"
+      >
+        Neue Runde erstellen
+      </a>
+      <a
+        id="cta-meine-runden"
+        href="/meine-runden"
+        class="hidden w-full inline-flex items-center justify-center px-6 py-3 rounded-xl border border-slate-300 text-slate-700 font-medium hover:bg-slate-100 transition-colors"
+      >
+        Meine gespeicherten Runden
+      </a>
+    </div>
 
-  <!-- CTA -->
-  <div class="flex flex-col sm:flex-row items-center gap-3 mb-8">
-    <a
-      href="/neu"
-      class="w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-lg bg-brand text-white font-semibold hover:bg-brand-dark transition-colors"
-    >
-      Neue Runde erstellen
-    </a>
-    <a
-      id="cta-meine-runden"
-      href="/meine-runden"
-      class="hidden w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-lg border border-slate-300 text-slate-700 font-medium hover:bg-slate-100 transition-colors"
-    >
-      Meine gespeicherten Runden
-    </a>
-  </div>
-
-  <div class="text-center">
+    <!-- Mehr erfahren -->
     <a href="/ueber" class="text-sm text-slate-400 hover:text-brand transition-colors underline underline-offset-2">
       Wie funktioniert das genau? →
     </a>

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -8,9 +8,10 @@ import Layout from '../layouts/Layout.astro';
     <h1 class="text-2xl font-semibold mb-1">Neue Runde erstellen</h1>
     <p class="text-slate-500 text-sm mb-6">Alle Daten werden im Browser verschlüsselt — der Server sieht nie Klartext.</p>
 
-    <!-- Splid-Import (kompakt) -->
+    <!-- Import (kompakt) -->
     <p class="mb-6 text-sm text-slate-400">
-      Bereits eine Splid-Abrechnung? <a href="#" id="splid-import-btn" class="underline hover:text-slate-600 transition-colors">XLSX hochladen →</a>
+      <a href="#" id="splid-import-btn" class="underline hover:text-slate-600 transition-colors">Abrechnung importieren →</a>
+      <span class="block text-xs mt-0.5">Derzeit wird Splid (XLSX) unterstützt.</span>
     </p>
     <input type="file" id="splid-file" accept=".xlsx,.xls" class="hidden" />
     <div id="splid-erfolg" class="hidden mb-4 text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2"></div>
@@ -52,7 +53,7 @@ import Layout from '../layouts/Layout.astro';
       <!-- Slot-Typen -->
       <div>
         <div class="flex items-center justify-between mb-2">
-          <label class="block text-sm font-medium text-slate-700">Slot-Typen</label>
+          <label class="block text-sm font-medium text-slate-700">Typen</label>
           <div class="flex items-center gap-3">
             <label class="flex items-center gap-1.5 text-sm text-slate-500 cursor-pointer select-none">
               <input type="checkbox" id="ausgaben-toggle" class="accent-green-700" />
@@ -77,6 +78,18 @@ import Layout from '../layouts/Layout.astro';
                 placeholder="Label (optional)"
                 class="flex-1 border border-slate-300 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
               />
+              <!-- Ausgaben inline (nur sichtbar wenn Toggle aktiv) -->
+              <div class="ausgaben-inline hidden flex items-center gap-1">
+                <span class="text-xs text-slate-400 shrink-0">€</span>
+                <input
+                  type="number"
+                  name="ausgaben[]"
+                  min="0"
+                  step="0.01"
+                  placeholder="0,00"
+                  class="w-24 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                />
+              </div>
               <button
                 type="button"
                 class="slot-entfernen text-slate-400 hover:text-red-500 text-lg leading-none hidden"
@@ -113,19 +126,20 @@ import Layout from '../layouts/Layout.astro';
                     </label>
                     <input
                       type="number"
-                      class="slot-gewichtung-manuell hidden w-16 border border-slate-300 rounded-md px-2 py-1 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="slot-gewichtung-manuell w-16 border border-slate-300 rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-green-600"
                       min="0.1"
                       max="2"
                       step="0.05"
                       value="1"
                       placeholder="0,0–2,0"
+                      readonly
                     />
                   </div>
                   <input type="hidden" name="gewichtung[]" value="1" />
                 </div>
-                <!-- Plätze -->
+                <!-- Anzahl -->
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-slate-500">Plätze</span>
+                  <span class="text-xs text-slate-500">Anzahl</span>
                   <input
                     type="number"
                     name="anzahl[]"
@@ -134,18 +148,6 @@ import Layout from '../layouts/Layout.astro';
                     step="1"
                     required
                     class="w-16 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
-                  />
-                </div>
-                <!-- Ausgaben -->
-                <div class="ausgaben-zeile hidden flex items-center gap-2">
-                  <span class="text-xs text-slate-500 shrink-0">Ausgaben (€)</span>
-                  <input
-                    type="number"
-                    name="ausgaben[]"
-                    min="0"
-                    step="0.01"
-                    placeholder="0,00"
-                    class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                   />
                 </div>
                 <!-- Standardgebot -->
@@ -169,7 +171,7 @@ import Layout from '../layouts/Layout.astro';
             </details>
           </div>
         </div>
-        <p class="text-xs text-slate-400 mt-1">Label ist optional. Ohne Label heißt der Slot „Slot".</p>
+        <p class="text-xs text-slate-400 mt-1">Label ist optional. Ohne Label wird der Preset-Name verwendet (z.&nbsp;B. „Erwachsen").</p>
       </div>
 
       <!-- Fehler -->
@@ -188,73 +190,75 @@ import Layout from '../layouts/Layout.astro';
 
   <!-- Ergebnis-Bereich -->
   <div id="ergebnis-bereich" class="hidden space-y-6">
-    <div>
-      <h1 class="text-2xl font-semibold mb-1">Runde erstellt</h1>
-      <p class="text-slate-500 text-sm">Speichere beide Links — sie werden hier nicht gespeichert.</p>
+    <!-- Header -->
+    <div class="text-center pt-4 pb-2">
+      <div class="text-5xl text-brand mb-3">✓</div>
+      <h1 class="text-2xl font-bold text-slate-900 mb-1">Runde erstellt!</h1>
+      <p class="text-sm text-slate-500">Speichere beide Links — sie werden hier nicht erneut angezeigt.</p>
     </div>
 
-    <!-- Teilnehmer-Link -->
-    <div class="bg-white border border-slate-200 rounded-xl p-4 space-y-2">
-      <div class="flex items-center justify-between">
-        <p class="text-sm font-medium text-slate-700">Teilnehmer-Link</p>
-        <span class="text-xs text-slate-400">zum Teilen mit der Gruppe</span>
+    <!-- Teilnehmer-Link (primär) -->
+    <div class="bg-white border border-brand/30 rounded-xl p-5 space-y-3">
+      <div>
+        <p class="text-sm font-semibold text-slate-900">Teilnehmer:innen-Link</p>
+        <p class="text-xs text-slate-500 mt-0.5">Diesen Link mit allen Teilnehmenden teilen</p>
       </div>
+      <input
+        id="teilnehmer-link"
+        type="text"
+        readonly
+        class="w-full border border-slate-200 rounded-md px-2 py-1.5 text-xs text-slate-600 bg-slate-50 font-mono"
+      />
       <div class="flex gap-2">
-        <input
-          id="teilnehmer-link"
-          type="text"
-          readonly
-          class="flex-1 border border-slate-300 rounded-md px-2 py-1.5 text-xs text-slate-600 bg-slate-50 font-mono"
-        />
         <button
           id="copy-teilnehmer"
-          class="border border-slate-300 rounded-md px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-100 transition-colors whitespace-nowrap"
+          class="flex-1 bg-brand text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-brand-dark transition-colors"
         >
-          Kopieren
+          Link kopieren
         </button>
+        <a
+          id="teilnehmer-link-oeffnen"
+          href="#"
+          target="_blank"
+          rel="noopener"
+          class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors whitespace-nowrap"
+        >
+          Öffnen ↗
+        </a>
       </div>
-      <a
-        id="teilnehmer-link-oeffnen"
-        href="#"
-        target="_blank"
-        rel="noopener"
-        class="inline-block text-xs text-green-700 hover:underline"
-      >
-        Link öffnen ↗
-      </a>
     </div>
 
-    <!-- Admin-Link -->
-    <div class="bg-amber-50 border border-amber-200 rounded-xl p-4 space-y-2">
-      <div class="flex items-center justify-between">
-        <p class="text-sm font-medium text-amber-800">Admin-Link</p>
-        <span class="text-xs text-amber-600">nur für dich — sicher aufbewahren</span>
+    <!-- Admin-Link (sekundär) -->
+    <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 space-y-3">
+      <div>
+        <p class="text-sm font-semibold text-amber-900">⚠ Admin-Link</p>
+        <p class="text-xs text-amber-700 mt-0.5">Nur für dich — sicher aufbewahren</p>
       </div>
+      <input
+        id="admin-link"
+        type="text"
+        readonly
+        class="w-full border border-amber-300 rounded-md px-2 py-1.5 text-xs text-amber-900 bg-amber-100 font-mono"
+      />
       <div class="flex gap-2">
-        <input
-          id="admin-link"
-          type="text"
-          readonly
-          class="flex-1 border border-amber-300 rounded-md px-2 py-1.5 text-xs text-amber-900 bg-amber-100 font-mono"
-        />
         <button
           id="copy-admin"
-          class="border border-amber-300 rounded-md px-3 py-1.5 text-xs text-amber-800 hover:bg-amber-200 transition-colors whitespace-nowrap"
+          class="flex-1 border border-amber-300 rounded-lg px-4 py-2 text-sm text-amber-800 hover:bg-amber-200 transition-colors"
         >
           Kopieren
         </button>
+        <a
+          id="admin-link-oeffnen"
+          href="#"
+          target="_blank"
+          rel="noopener"
+          class="border border-amber-300 rounded-lg px-4 py-2 text-sm text-amber-800 hover:bg-amber-200 transition-colors whitespace-nowrap"
+        >
+          Öffnen ↗
+        </a>
       </div>
-      <a
-        id="admin-link-oeffnen"
-        href="#"
-        target="_blank"
-        rel="noopener"
-        class="inline-block text-xs text-amber-700 hover:underline"
-      >
-        Link öffnen ↗
-      </a>
       <p class="text-xs text-amber-700">
-        ⚠️ Dieser Link enthält deinen privaten Schlüssel. Wer ihn hat, kann alle Gebote einsehen.
+        Dieser Link enthält deinen privaten Schlüssel. Wer ihn hat, kann alle Gebote einsehen.
       </p>
     </div>
 
@@ -262,7 +266,7 @@ import Layout from '../layouts/Layout.astro';
       href="/neu"
       class="block text-center text-sm text-slate-500 hover:text-slate-700 transition-colors"
     >
-      Weitere Runde erstellen
+      Weitere Runde erstellen →
     </a>
   </div>
 </Layout>
@@ -303,15 +307,9 @@ import Layout from '../layouts/Layout.astro';
   let slotCounter = 1;
 
   function setzeAusgabenSichtbarkeit(sichtbar: boolean) {
-    slotsContainer.querySelectorAll<HTMLDivElement>('.ausgaben-zeile').forEach((zeile) => {
+    slotsContainer.querySelectorAll<HTMLDivElement>('.ausgaben-inline').forEach((zeile) => {
       zeile.classList.toggle('hidden', !sichtbar);
     });
-    // Erweitert-Panel automatisch öffnen wenn Ausgaben eingeblendet werden
-    if (sichtbar) {
-      slotsContainer.querySelectorAll<HTMLDetailsElement>('.slot-erweitert-details').forEach(d => {
-        d.open = true;
-      });
-    }
   }
 
   ausgabenToggle.addEventListener('change', () => {
@@ -394,10 +392,17 @@ import Layout from '../layouts/Layout.astro';
       const hiddenInput = eintrag.querySelector<HTMLInputElement>('[name="gewichtung[]"]');
       const manuellInput = eintrag.querySelector<HTMLInputElement>('.slot-gewichtung-manuell');
       if (target.value === 'manuell') {
-        manuellInput?.classList.remove('hidden');
-        if (hiddenInput && manuellInput?.value) hiddenInput.value = manuellInput.value;
+        if (manuellInput) {
+          manuellInput.readOnly = false;
+          manuellInput.classList.remove('opacity-50', 'cursor-not-allowed');
+          if (hiddenInput && manuellInput.value) hiddenInput.value = manuellInput.value;
+        }
       } else {
-        manuellInput?.classList.add('hidden');
+        if (manuellInput) {
+          manuellInput.value = target.value;
+          manuellInput.readOnly = true;
+          manuellInput.classList.add('opacity-50', 'cursor-not-allowed');
+        }
         if (hiddenInput) hiddenInput.value = target.value;
         aktualisiereRichtwert();
       }
@@ -517,8 +522,11 @@ import Layout from '../layouts/Layout.astro';
     klon.querySelectorAll<HTMLInputElement>('input[name="anzahl[]"]').forEach(el => { el.value = '1'; });
     klon.querySelectorAll<HTMLInputElement>('input[name="ausgaben[]"]').forEach(el => { el.value = ''; });
     klon.querySelectorAll<HTMLInputElement>('[name="gewichtung[]"]').forEach(el => { el.value = '1'; });
+    // Gewichtung-Feld: Erwachsen vorauswählen → readonly + ausgegraut
     klon.querySelectorAll<HTMLInputElement>('.slot-gewichtung-manuell').forEach(el => {
-      el.value = '1'; el.classList.add('hidden');
+      el.value = '1';
+      el.readOnly = true;
+      el.classList.add('opacity-50', 'cursor-not-allowed');
     });
 
     // Standardgebot zurücksetzen
@@ -531,9 +539,9 @@ import Layout from '../layouts/Layout.astro';
     const richtwertAnzeige = klon.querySelector<HTMLSpanElement>('.standardgebot-richtwert');
     if (richtwertAnzeige) richtwertAnzeige.textContent = '';
 
-    // Ausgaben-Zeile entsprechend Toggle-Zustand
-    const ausgabenZeile = klon.querySelector('.ausgaben-zeile') as HTMLDivElement;
-    ausgabenZeile.classList.toggle('hidden', !ausgabenToggle.checked);
+    // Ausgaben-Inline entsprechend Toggle-Zustand
+    const ausgabenInline = klon.querySelector('.ausgaben-inline') as HTMLDivElement;
+    ausgabenInline.classList.toggle('hidden', !ausgabenToggle.checked);
 
     // Details schließen für neuen Slot
     const details = klon.querySelector<HTMLDetailsElement>('.slot-erweitert-details');
@@ -559,13 +567,20 @@ import Layout from '../layouts/Layout.astro';
     if (matchingValue) {
       const radio = slotEl.querySelector<HTMLInputElement>(`.slot-gewichtung-radio[value="${matchingValue}"]`);
       if (radio) radio.checked = true;
+      const manuellInput = slotEl.querySelector<HTMLInputElement>('.slot-gewichtung-manuell');
+      if (manuellInput) {
+        manuellInput.value = matchingValue;
+        manuellInput.readOnly = true;
+        manuellInput.classList.add('opacity-50', 'cursor-not-allowed');
+      }
     } else {
       const manuellRadio = slotEl.querySelector<HTMLInputElement>('.slot-gewichtung-radio[value="manuell"]');
       const manuellInput = slotEl.querySelector<HTMLInputElement>('.slot-gewichtung-manuell');
       if (manuellRadio) manuellRadio.checked = true;
       if (manuellInput) {
         manuellInput.value = String(gewichtung);
-        manuellInput.classList.remove('hidden');
+        manuellInput.readOnly = false;
+        manuellInput.classList.remove('opacity-50', 'cursor-not-allowed');
       }
     }
   }
@@ -587,8 +602,10 @@ import Layout from '../layouts/Layout.astro';
         slotEl: HTMLDivElement,
         slot: { label: string; gewichtung: number; anzahl: number; standardgebot?: number },
       ) {
+        const presetNamenWiederhol: Record<string, string> = { 'Erwachsen': '', 'Ermäßigt': '', 'Kind': '', 'Beitrag': '' };
+        // Labels die reine Preset-Namen sind, als leer behandeln (Preset-Name wird beim Absenden wieder gesetzt)
         (slotEl.querySelector('[name="label[]"]') as HTMLInputElement).value =
-          slot.label === 'Slot' ? '' : slot.label;
+          (slot.label in presetNamenWiederhol) ? '' : slot.label;
         (slotEl.querySelector('[name="anzahl[]"]') as HTMLInputElement).value = String(slot.anzahl);
         setzeGewichtungRadio(slotEl, slot.gewichtung);
 
@@ -652,9 +669,16 @@ import Layout from '../layouts/Layout.astro';
         (form.querySelector('#gesamtkosten') as HTMLInputElement).value,
       );
 
-      const labels = [...form.querySelectorAll<HTMLInputElement>('[name="label[]"]')].map(
-        (el) => el.value.trim() || 'Slot',
-      );
+      const presetNamen: Record<string, string> = { '1.0': 'Erwachsen', '0.75': 'Ermäßigt', '0.5': 'Kind' };
+      const labels = [...slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag')].map((slotEl) => {
+        const labelEl = slotEl.querySelector<HTMLInputElement>('[name="label[]"]');
+        const labelVal = labelEl?.value.trim() ?? '';
+        if (labelVal) return labelVal;
+        // Fallback: Preset-Name aus aktivem Radio
+        const checkedRadio = slotEl.querySelector<HTMLInputElement>('.slot-gewichtung-radio:checked');
+        const radioVal = checkedRadio?.value ?? '';
+        return presetNamen[radioVal] ?? 'Beitrag';
+      });
       const gewichtungen = [...form.querySelectorAll<HTMLInputElement>('[name="gewichtung[]"]')].map(
         (el) => parseFloat(el.value),
       );

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -44,7 +44,7 @@ import Layout from '../../layouts/Layout.astro';
       <form id="gebot-form" class="space-y-5">
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Wähle deinen Slot-Typ</p>
+          <p class="text-sm font-medium text-slate-700 mb-2">Wähle deinen Typ</p>
           <div id="slot-auswahl" class="space-y-2"></div>
         </div>
 
@@ -69,14 +69,23 @@ import Layout from '../../layouts/Layout.astro';
         <!-- Fehler -->
         <div id="gebot-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm"></div>
 
-        <!-- Duplikat-Warnung (Soft-Warning, kein Hard-Block) -->
-        <div id="duplikat-warnung" class="hidden bg-amber-50 border border-amber-300 text-amber-800 rounded-lg p-3 text-sm space-y-2">
-          <p class="font-medium">Von diesem Gerät wurde für diesen Slot bereits ein Gebot abgegeben.</p>
-          <p class="text-xs text-amber-700">Möchtest du trotzdem ein weiteres Gebot einreichen? Oder willst du dein bestehendes Gebot korrigieren?</p>
-          <div class="flex gap-2 pt-1 flex-wrap">
-            <button type="button" id="duplikat-abbrechen" class="border border-amber-400 text-amber-800 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 transition-colors">Abbrechen</button>
-            <button type="button" id="duplikat-korrigieren" class="border border-amber-500 bg-amber-100 text-amber-900 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 transition-colors">Gebot korrigieren</button>
-            <button type="button" id="duplikat-bestaetigen" class="bg-amber-600 text-white rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-700 transition-colors">Trotzdem abgeben</button>
+        <!-- Duplikat-Warnung Two-Step (Soft-Warning, kein Hard-Block) -->
+        <div id="duplikat-warnung" class="hidden bg-amber-50 border border-amber-300 text-amber-800 rounded-lg p-3 text-sm">
+          <!-- Schritt 1 -->
+          <div id="duplikat-schritt1">
+            <p class="font-medium">Du hast für diesen Typ bereits geboten.</p>
+            <div class="flex gap-2 pt-2">
+              <button type="button" id="duplikat-abbrechen" class="border border-amber-400 text-amber-800 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 transition-colors">Abbrechen</button>
+              <button type="button" id="duplikat-weiter" class="border border-amber-500 bg-amber-100 text-amber-900 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 transition-colors">Fortfahren →</button>
+            </div>
+          </div>
+          <!-- Schritt 2 -->
+          <div id="duplikat-schritt2" class="hidden">
+            <p class="text-sm text-amber-800">Was möchtest du tun?</p>
+            <div class="flex gap-2 pt-2 flex-wrap">
+              <button type="button" id="duplikat-korrigieren" class="border border-amber-500 bg-amber-100 text-amber-900 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 transition-colors">Gebot korrigieren</button>
+              <button type="button" id="duplikat-bestaetigen" class="bg-amber-600 text-white rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-700 transition-colors">Zweites Gebot abgeben</button>
+            </div>
           </div>
         </div>
 
@@ -88,7 +97,11 @@ import Layout from '../../layouts/Layout.astro';
           Gebot abgeben
         </button>
 
-        <p class="text-xs text-slate-400 text-center">Dieser Schutz gilt nur für dieses Gerät.</p>
+        <p class="text-center mt-1">
+          <button type="button" id="korrektur-link-btn" class="text-xs text-slate-400 hover:text-slate-600 underline transition-colors">
+            Gebot von anderem Gerät korrigieren →
+          </button>
+        </p>
       </form>
     </div>
 
@@ -113,7 +126,7 @@ import Layout from '../../layouts/Layout.astro';
 
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Neuer Slot-Typ</p>
+          <p class="text-sm font-medium text-slate-700 mb-2">Neuer Typ</p>
           <div id="slot-auswahl-korrektur" class="space-y-2"></div>
         </div>
 
@@ -153,10 +166,8 @@ import Layout from '../../layouts/Layout.astro';
   <div id="zustand-bestaetigung" class="hidden text-center space-y-4 py-8">
     <h2 id="bestaetigung-titel" class="text-xl font-semibold">Gebot abgegeben</h2>
     <p id="bestaetigung-text" class="text-slate-500 text-sm max-w-sm mx-auto"></p>
-    <div id="emoji-box" class="bg-slate-100 rounded-xl px-6 py-4 inline-block">
-      <p class="text-xs text-slate-500 mb-1">Deine Emoji-ID</p>
-      <p id="emoji-id-text" class="text-3xl tracking-widest"></p>
-    </div>
+    <div id="emoji-anzeige" class="text-6xl tracking-widest mb-2"></div>
+    <p class="text-xs text-slate-500">Deine Emoji-ID</p>
   </div>
 </Layout>
 
@@ -280,6 +291,7 @@ import Layout from '../../layouts/Layout.astro';
           <span class="flex-1">
             <span class="text-sm font-medium text-slate-800">${slot.label}</span>
             <span class="text-xs text-slate-500 ml-2">Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
+            ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-green-600 ml-1 text-xs">✓ abgegeben</span>' : ''}
           </span>
         `;
         container.appendChild(label);
@@ -307,7 +319,16 @@ import Layout from '../../layouts/Layout.astro';
 
     document.getElementById('slot-auswahl')!.addEventListener('change', (e) => {
       const radio = e.target as HTMLInputElement;
-      if (radio.name === 'slot') betragFeldAktualisieren(parseInt(radio.value, 10), 'betrag', 'betrag-richtwert-hinweis');
+      if (radio.name === 'slot') {
+        betragFeldAktualisieren(parseInt(radio.value, 10), 'betrag', 'betrag-richtwert-hinweis');
+        // Slot gewechselt → Duplikat-Warnung auf Abbrechen-Zustand zurücksetzen
+        const duplikatWarnung = document.getElementById('duplikat-warnung')!;
+        if (!duplikatWarnung.classList.contains('hidden')) {
+          document.getElementById('duplikat-schritt1')!.classList.remove('hidden');
+          document.getElementById('duplikat-schritt2')!.classList.add('hidden');
+          duplikatWarnung.classList.add('hidden');
+        }
+      }
     });
     document.getElementById('slot-auswahl-korrektur')!.addEventListener('change', (e) => {
       const radio = e.target as HTMLInputElement;
@@ -357,11 +378,16 @@ import Layout from '../../layouts/Layout.astro';
     const gebotFehler = document.getElementById('gebot-fehler') as HTMLDivElement;
     const duplikatWarnung = document.getElementById('duplikat-warnung') as HTMLDivElement;
     const duplikatAbbrechen = document.getElementById('duplikat-abbrechen') as HTMLButtonElement;
+    const duplikatWeiter = document.getElementById('duplikat-weiter') as HTMLButtonElement;
+    const duplikatSchritt1 = document.getElementById('duplikat-schritt1') as HTMLDivElement;
+    const duplikatSchritt2 = document.getElementById('duplikat-schritt2') as HTMLDivElement;
     const duplikatKorrigieren = document.getElementById('duplikat-korrigieren') as HTMLButtonElement;
     const duplikatBestaetigen = document.getElementById('duplikat-bestaetigen') as HTMLButtonElement;
 
     function zeigeBestaetigung(emojiId: string, istKorrektur: boolean) {
-      document.getElementById('emoji-id-text')!.textContent = emojiId;
+      const emojiAnzeige = document.getElementById('emoji-anzeige')!;
+      emojiAnzeige.textContent = emojiId;
+      emojiAnzeige.classList.add('animate-pop-in');
       document.getElementById('bestaetigung-titel')!.textContent = istKorrektur ? 'Gebot korrigiert' : 'Gebot abgegeben';
       document.getElementById('bestaetigung-text')!.textContent = istKorrektur
         ? 'Dein Gebot wurde erfolgreich ersetzt. Deine Emoji-ID bleibt dieselbe.'
@@ -370,7 +396,6 @@ import Layout from '../../layouts/Layout.astro';
       const zustandBestaetigung = document.getElementById('zustand-bestaetigung')!;
       zustandBestaetigung.classList.remove('hidden');
       zustandBestaetigung.classList.add('animate-fade-in');
-      document.getElementById('emoji-box')!.classList.add('animate-pop-in');
     }
 
     // Kernfunktion: Gebot tatsächlich einreichen (mit Auto-Retry bei Emoji-Kollision)
@@ -451,16 +476,35 @@ import Layout from '../../layouts/Layout.astro';
       await gebot_einreichen();
     });
 
-    duplikatAbbrechen.addEventListener('click', () => {
+    function duplikatZuruecksetzen() {
+      duplikatSchritt1.classList.remove('hidden');
+      duplikatSchritt2.classList.add('hidden');
       duplikatWarnung.classList.add('hidden');
+    }
+
+    duplikatAbbrechen.addEventListener('click', () => {
+      duplikatZuruecksetzen();
+    });
+    duplikatWeiter.addEventListener('click', () => {
+      duplikatSchritt1.classList.add('hidden');
+      duplikatSchritt2.classList.remove('hidden');
     });
     duplikatKorrigieren.addEventListener('click', () => {
-      duplikatWarnung.classList.add('hidden');
+      duplikatZuruecksetzen();
+      tabKorrigieren.classList.remove('hidden');
       zeigeTab('korrigieren');
       document.getElementById('korrektur-emoji')?.focus();
     });
     duplikatBestaetigen.addEventListener('click', async () => {
+      duplikatZuruecksetzen();
       await gebot_einreichen();
+    });
+
+    // Korrektur-Link (immer sichtbar, öffnet Korrektur-Tab)
+    document.getElementById('korrektur-link-btn')!.addEventListener('click', () => {
+      tabKorrigieren.classList.remove('hidden');
+      zeigeTab('korrigieren');
+      document.getElementById('korrektur-emoji')?.focus();
     });
 
     // ── Tab 2: Gebot korrigieren ──────────────────────────────────────────────

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -39,20 +39,11 @@ import Layout from '../../../../layouts/Layout.astro';
       </div>
     </div>
 
-    <!-- Fehlbetrag / Überschuss -->
+    <!-- Duplikat-Warnung -->
     <div id="duplikat-box" class="hidden bg-red-50 border border-red-200 rounded-xl p-4 print:rounded-md print:p-3">
       <p class="text-sm font-medium text-red-800">⚠️ Zu viele Gebote — Auswertung nicht möglich</p>
       <p class="text-xs text-red-700 mt-1 mb-2">Für folgende Slots sind mehr Gebote eingegangen als erwartet. Bitte kläre die Doppeleinreichung und bitte die betroffene Person, nicht nochmals zu bieten.</p>
       <ul id="duplikat-liste" class="text-xs text-red-700 space-y-0.5 list-disc list-inside"></ul>
-    </div>
-    <div id="fehlbetrag-box" class="hidden bg-red-50 border border-red-200 rounded-xl p-4 print:rounded-md print:p-3">
-      <p class="text-sm font-medium text-red-800">Fehlbetrag</p>
-      <p id="fehlbetrag-text" class="text-2xl font-bold text-red-700 print:text-xl"></p>
-      <p class="text-xs text-red-600 mt-1">Die solidarischen Beiträge decken die Gesamtkosten nicht.</p>
-    </div>
-    <div id="ueberschuss-box" class="hidden bg-green-50 border border-green-200 rounded-xl p-4 print:rounded-md print:p-3">
-      <p class="text-sm font-medium text-green-800">Überschuss</p>
-      <p id="ueberschuss-text" class="text-2xl font-bold text-green-700 print:text-xl"></p>
     </div>
 
     <!-- Status-Banner -->
@@ -80,7 +71,7 @@ import Layout from '../../../../layouts/Layout.astro';
     <!-- Ausgleichszahlungen -->
     <div id="ausgleich-section" class="hidden space-y-2">
       <h2 class="text-sm font-medium text-slate-700 print:text-xs">Ausgleichszahlungen</h2>
-      <div id="ausgleich-liste" class="rounded-xl border border-slate-200 bg-white overflow-hidden print:text-xs"></div>
+      <div id="ausgleich-liste" class="rounded-xl border border-slate-200 bg-white px-4 py-3 space-y-2 print:text-xs"></div>
     </div>
 
     <!-- Status (klein, ergänzend zum Banner) -->
@@ -377,10 +368,13 @@ import Layout from '../../../../layouts/Layout.astro';
           const zeile = document.createElement('div');
           const vonLabel = emojiZuLabel.get(z.von) ?? z.von;
           const anLabel = emojiZuLabel.get(z.an) ?? z.an;
-          zeile.className = `flex justify-between items-center px-4 py-2.5 ${idx < zahlungen.length - 1 ? 'border-b border-slate-100' : ''}`;
+          zeile.className = `grid items-center gap-x-3 text-sm${idx < zahlungen.length - 1 ? ' pb-2 border-b border-slate-100' : ''}`;
+          zeile.style.gridTemplateColumns = '1fr auto 1fr auto';
           zeile.innerHTML = `
-            <span class="text-sm text-slate-700">${vonLabel} → ${anLabel}</span>
-            <span class="text-sm font-semibold text-slate-900">${eur(z.betrag)}</span>
+            <span class="text-slate-700 text-right">${vonLabel}</span>
+            <span class="text-slate-400">→</span>
+            <span class="text-slate-700">${anLabel}</span>
+            <span class="font-semibold text-slate-900 text-right">${eur(z.betrag)}</span>
           `;
           liste.appendChild(zeile);
         });
@@ -388,24 +382,14 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Fehlbetrag / Überschuss anzeigen (nur wenn vollständig und keine Duplikate)
-    if (allesDa && !hatDuplikate && auswertung) {
-      if (auswertung.fehlbetrag > 0.005) {
-        document.getElementById('fehlbetrag-text')!.textContent = eur(auswertung.fehlbetrag);
-        document.getElementById('fehlbetrag-box')!.classList.remove('hidden');
-      } else {
-        // Nur ohne Fehlbetrag: Beitrag-Spalten einblenden (sonst wären Gebote rekonstruierbar)
-        document.querySelectorAll('.vollstaendig-spalte').forEach((el) => el.classList.remove('hidden'));
-        if (!hatSplidDaten) {
-          document.querySelectorAll('.splid-spalte').forEach((el) => el.classList.add('hidden'));
-        }
-        if (hatSplidDaten) {
-          document.querySelectorAll('.emoji-spalte').forEach((el) => el.classList.add('hidden'));
-        }
-        if (auswertung.ueberschuss > 0.005) {
-          document.getElementById('ueberschuss-text')!.textContent = eur(auswertung.ueberschuss);
-          document.getElementById('ueberschuss-box')!.classList.remove('hidden');
-        }
+    // Beitrag-Spalten einblenden wenn vollständig, keine Duplikate, kein Fehlbetrag
+    if (allesDa && !hatDuplikate && auswertung && auswertung.fehlbetrag <= 0.005) {
+      document.querySelectorAll('.vollstaendig-spalte').forEach((el) => el.classList.remove('hidden'));
+      if (!hatSplidDaten) {
+        document.querySelectorAll('.splid-spalte').forEach((el) => el.classList.add('hidden'));
+      }
+      if (hatSplidDaten) {
+        document.querySelectorAll('.emoji-spalte').forEach((el) => el.classList.add('hidden'));
       }
     }
 

--- a/src/pages/ueber.astro
+++ b/src/pages/ueber.astro
@@ -26,7 +26,7 @@ import Layout from '../layouts/Layout.astro';
       </summary>
       <div class="mt-3 text-sm text-slate-600 space-y-3 pl-4 border-l-2 border-slate-200">
         <div>
-          <p class="font-medium text-slate-800">Anzahl der Teilnehmer*innen</p>
+          <p class="font-medium text-slate-800">Anzahl der Teilnehmer:innen</p>
           <p class="mt-0.5">Jedes Gebot ist ein separater verschlüsselter Eintrag im Server-Store — der Server kann Einträge zählen und so die ungefähre Teilnehmerzahl inferieren.</p>
         </div>
         <div>
@@ -39,7 +39,7 @@ import Layout from '../layouts/Layout.astro';
         </div>
         <div class="pt-1">
           <p class="font-medium text-slate-800">Was der Server <em>nicht</em> sieht</p>
-          <p class="mt-0.5">Namen, Gebotsbeträge, Slot-Auswahl, Emoji-IDs, Admin-Schlüssel — all das bleibt verschlüsselt.</p>
+          <p class="mt-0.5">Namen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel — all das bleibt verschlüsselt.</p>
         </div>
       </div>
     </details>
@@ -47,21 +47,21 @@ import Layout from '../layouts/Layout.astro';
 
   <!-- Vertrauen -->
   <div class="mb-6 rounded-xl border border-slate-200 bg-white p-6">
-    <h2 class="text-lg font-semibold text-slate-900 mb-2">Vertrauen in die Organisator*in</h2>
+    <h2 class="text-lg font-semibold text-slate-900 mb-2">Vertrauen in die Organisator:in</h2>
     <p class="text-sm text-slate-600 leading-relaxed mb-3">
-      Die App ist <strong>kein Zero-Trust-System</strong>. Die Organisator*in hat den
+      Die App ist <strong>kein Zero-Trust-System</strong>. Die Organisator:in hat den
       privaten Admin-Schlüssel und kann damit technisch alle Gebote entschlüsseln —
       das Frontend zeigt ihr nur die Auswertungstabelle, aber der Zugriff auf Rohwerte
       wäre im Code möglich.
     </p>
     <p class="text-sm text-slate-600 leading-relaxed mb-3">
-      Teilnehmer*innen hingegen können <strong>keine</strong> Gebote anderer sehen:
+      Teilnehmer:innen hingegen können <strong>keine</strong> Gebote anderer sehen:
       Gebote sind mit dem öffentlichen Admin-Schlüssel verschlüsselt und nur mit dem
-      privaten Schlüssel der Organisator*in lesbar.
+      privaten Schlüssel der Organisator:in lesbar.
     </p>
     <p class="text-sm text-slate-500 leading-relaxed">
-      Vertrauen in die Organisator*in ist Teil des Modells — vergleichbar mit einem
-      Kassenprüfer in einer Genossenschaft: Kontrolle durch Transparenz, nicht durch
+      Vertrauen in die Organisator:in ist Teil des Modells — vergleichbar mit einer
+      Kassenprüfer:in in einer Genossenschaft: Kontrolle durch Transparenz, nicht durch
       technische Sperre.
     </p>
   </div>
@@ -72,7 +72,7 @@ import Layout from '../layouts/Layout.astro';
     <p class="text-sm text-slate-600 leading-relaxed mb-3">
       FairShare speichert keine personenbezogenen Daten. Es gibt keine Nutzerkonten,
       keine E-Mail-Adressen, keine Tracking-Cookies. Runden-IDs sind zufällig generiert
-      und enthalten keine Nutzerinformationen.
+      und enthalten keine personenbezogenen Informationen.
     </p>
     <p class="text-sm text-slate-600 leading-relaxed">
       Gespeicherte Runden-Links werden ausschließlich in deinem Browser (localStorage)


### PR DESCRIPTION
## Was wurde gebaut

Zweite Runde UX-Verbesserungen auf Basis von Review-Feedback. Fokus: Gendering, Vereinfachung, Slot-Form-Überarbeitung, Bestätigungsseiten, Admin-Doppelmeldungen, Ausgleichszahlungs-Layout, Duplikat-Warnung Two-Step.

### Landing Page (`index.astro`)
- Ein Satz Hero: „Teilt Kosten solidarisch — jede Person zahlt, was sie kann."
- „So funktioniert's"-Block entfernt (Golden Apple Principle: ein Satz + ein Button)

### Über-Seite (`ueber.astro`)
- Durchgängiges Doppelpunkt-Gendering: Organisator:in, Kassenprüfer:in, Teilnehmer:innen, Typen-Auswahl

### Neue Runde (`neu.astro`)
- „Slot-Typen" → „Typen", „Plätze" → „Anzahl"
- Import-Link generisch: „Abrechnung importieren →" mit Hinweis auf Splid-XLSX
- Gewichtungs-Feld immer sichtbar: readonly + ausgegraut bei Presets (Erwachsen/Ermäßigt/Kind), editierbar bei Manuell
- Ausgaben-Input inline neben Label-Eingabe — kein auto-öffnendes Erweitert-Panel mehr
- Fallback-Label = Preset-Name (Erwachsen/Ermäßigt/Kind/Beitrag) statt generischem „Slot"
- Ergebnis-Screen Apple-like umgebaut: ✓ Checkmark, „Runde erstellt!", Teilnehmer:innen-Link mit primärem Kopieren-Button (Brand-Farbe), Admin-Link kompakt sekundär

### Gebot abgeben (`runde/[id].astro`)
- Emojis wieder groß (`text-6xl`) ohne Duplizierung — nur `#emoji-anzeige` mit kleiner „Deine Emoji-ID"-Beschriftung darunter, kein Box-Hintergrund
- ✓ abgegeben-Status zurück in der Slot-Auswahl (war in PR #20 entfernt worden)
- Duplikat-Warnung Two-Step: Schritt 1 (Abbrechen / Fortfahren →), Schritt 2 (Gebot korrigieren / Zweites Gebot abgeben)
- Slot-Wechsel → Warnung automatisch auf Abbrechen-Zustand zurücksetzen
- „Gebot von anderem Gerät korrigieren →" immer sichtbar unter Submit-Button (öffnet Korrektur-Tab)
- „Slot-Typ" → „Typ"

### Admin-Auswertung (`admin/[token].astro`)
- `#fehlbetrag-box` und `#ueberschuss-box` entfernt — der Status-Banner übernimmt alle Zustände vollständig
- Ausgleichszahlungen im CSS-Grid-Layout (`grid-template-columns: 1fr auto 1fr auto`): Pfeile und Beträge bündig ausgerichtet

## Wie wurde getestet

- `npm run test` — alle 50 Tests grün (keine Logik-Änderungen)
- Keine API- oder Krypto-Änderungen

## Was kommt als nächstes

Weitere Feedback-Punkte nach Review.