### PR TITLE
UX-Fixes: Button-Bug, Personen-Bezeichnung, Slot-Terminologie

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ import Layout from '../layouts/Layout.astro';
       <a
         id="cta-meine-runden"
         href="/meine-runden"
-        class="hidden w-full inline-flex items-center justify-center px-6 py-3 rounded-xl border border-slate-300 text-slate-700 font-medium hover:bg-slate-100 transition-colors"
+        class="hidden w-full items-center justify-center px-6 py-3 rounded-xl border border-slate-300 text-slate-700 font-medium hover:bg-slate-100 transition-colors"
       >
         Meine gespeicherten Runden
       </a>
@@ -42,7 +42,7 @@ import Layout from '../layouts/Layout.astro';
       const el = document.getElementById('cta-meine-runden');
       if (el) {
         el.classList.remove('hidden');
-        el.classList.add('animate-fade-in');
+        el.classList.add('inline-flex', 'animate-fade-in');
       }
     }
   } catch { /* ignore */ }

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -50,10 +50,10 @@ import Layout from '../layouts/Layout.astro';
         />
       </div>
 
-      <!-- Slot-Typen -->
+      <!-- Personen -->
       <div>
         <div class="flex items-center justify-between mb-2">
-          <label class="block text-sm font-medium text-slate-700">Typen</label>
+          <label class="block text-sm font-medium text-slate-700">Personen</label>
           <div class="flex items-center gap-3">
             <label class="flex items-center gap-1.5 text-sm text-slate-500 cursor-pointer select-none">
               <input type="checkbox" id="ausgaben-toggle" class="accent-green-700" />
@@ -64,7 +64,7 @@ import Layout from '../layouts/Layout.astro';
               id="slot-hinzufuegen"
               class="text-sm text-green-700 hover:text-green-900 font-medium"
             >
-              + Typ hinzufügen
+              + Person hinzufügen
             </button>
           </div>
         </div>

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -44,7 +44,7 @@ import Layout from '../../layouts/Layout.astro';
       <form id="gebot-form" class="space-y-5">
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Wähle deinen Typ</p>
+          <p class="text-sm font-medium text-slate-700 mb-2">Wähle deine Person</p>
           <div id="slot-auswahl" class="space-y-2"></div>
         </div>
 
@@ -73,7 +73,7 @@ import Layout from '../../layouts/Layout.astro';
         <div id="duplikat-warnung" class="hidden bg-amber-50 border border-amber-300 text-amber-800 rounded-lg p-3 text-sm">
           <!-- Schritt 1 -->
           <div id="duplikat-schritt1">
-            <p class="font-medium">Du hast für diesen Typ bereits geboten.</p>
+            <p class="font-medium">Du hast für diese Person bereits geboten.</p>
             <div class="flex gap-2 pt-2">
               <button type="button" id="duplikat-abbrechen" class="border border-amber-400 text-amber-800 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 transition-colors">Abbrechen</button>
               <button type="button" id="duplikat-weiter" class="border border-amber-500 bg-amber-100 text-amber-900 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 transition-colors">Fortfahren →</button>
@@ -126,7 +126,7 @@ import Layout from '../../layouts/Layout.astro';
 
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Neuer Typ</p>
+          <p class="text-sm font-medium text-slate-700 mb-2">Neue Person</p>
           <div id="slot-auswahl-korrektur" class="space-y-2"></div>
         </div>
 

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -44,7 +44,7 @@ import Layout from '../../layouts/Layout.astro';
       <form id="gebot-form" class="space-y-5">
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Wähle deine Person</p>
+          <p class="text-sm font-medium text-slate-700 mb-2">Wähle deinen Slot</p>
           <div id="slot-auswahl" class="space-y-2"></div>
         </div>
 
@@ -73,7 +73,7 @@ import Layout from '../../layouts/Layout.astro';
         <div id="duplikat-warnung" class="hidden bg-amber-50 border border-amber-300 text-amber-800 rounded-lg p-3 text-sm">
           <!-- Schritt 1 -->
           <div id="duplikat-schritt1">
-            <p class="font-medium">Du hast für diese Person bereits geboten.</p>
+            <p class="font-medium">Du hast für diesen Slot bereits geboten.</p>
             <div class="flex gap-2 pt-2">
               <button type="button" id="duplikat-abbrechen" class="border border-amber-400 text-amber-800 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 transition-colors">Abbrechen</button>
               <button type="button" id="duplikat-weiter" class="border border-amber-500 bg-amber-100 text-amber-900 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 transition-colors">Fortfahren →</button>
@@ -126,7 +126,7 @@ import Layout from '../../layouts/Layout.astro';
 
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Neue Person</p>
+          <p class="text-sm font-medium text-slate-700 mb-2">Neuer Slot</p>
           <div id="slot-auswahl-korrektur" class="space-y-2"></div>
         </div>
 


### PR DESCRIPTION
## Was wurde geändert

Kleinere Nachbesserungen nach Review von PR #21.

### Landing Page — Button wirklich versteckt
- `inline-flex` aus dem `hidden`-Element entfernt: Tailwind 4 konnte nicht entscheiden, welche `display`-Property gewinnt — der Button war immer sichtbar
- JS fügt `inline-flex` jetzt erst beim Einblenden hinzu → Button erscheint nur, wenn wirklich gespeicherte Runden im localStorage vorhanden sind

### Neue Runde — „Personen" statt „Typen"
- Abschnittsüberschrift: „Personen"
- Button: „+ Person hinzufügen"
- Intuitiver: beim Konfigurieren fügt man Personen hinzu

### Gebot abgeben — Slot-Terminologie beibehalten
- „Wähle deinen Slot", „Neuer Slot", „für diesen Slot bereits geboten"
- Auf der Gebotsseite wählt man seinen Platz in der Runde — „Slot" passt hier besser als „Person"

## Wie wurde getestet

Alle 50 Tests weiterhin grün.