### PR TITLE
Admin: Beitrags-Zählung inkl. Auto-Slots, neue Formulierung

### DIFF
--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -393,22 +393,30 @@ import Layout from '../../../../layouts/Layout.astro';
       }
     }
 
-    // Status-Banner + Statuszeile (nur Gebote für Slots ohne standardgebot zählen)
+    // Status-Banner + Statuszeile
+    // Gesamtbild: alle Slots zählen; Auto-Slots gelten als bereits erledigt
+    const totalAlle = blob.slots.reduce((s, sl) => s + sl.anzahl, 0);
+    const autoAnzahl = blob.slots
+      .filter((s) => s.standardgebot !== undefined)
+      .reduce((s, sl) => s + sl.anzahl, 0);
+    const erledigt = autoAnzahl + geboteOhneStandard.length;
+    const ausstehend = totalAlle - erledigt;
+
     if (hatDuplikate) {
       zeigeBanner('Doppelgebote vorhanden — bitte klären.', 'amber');
       document.getElementById('gebote-anzahl')!.textContent =
-        `${geboteOhneStandard.length} Gebote eingegangen, ${totalErwartet} erwartet`;
+        `${geboteOhneStandard.length} von ${totalErwartet} Geboten eingegangen`;
     } else if (allesDa) {
       const fehlbetragVorhanden = auswertung && auswertung.fehlbetrag > 0.005;
-      if (totalErwartet === 0) {
-        zeigeBanner('Auswertung vollständig (alle Slots mit Standardgebot).', 'green');
-      } else if (fehlbetragVorhanden) {
+      if (fehlbetragVorhanden) {
         zeigeBanner(`Fehlbetrag: ${eur(auswertung!.fehlbetrag)} — Runde muss wiederholt werden.`, 'red');
       } else {
-        zeigeBanner('Alle Gebote eingegangen. Auswertung abgeschlossen.', 'green');
+        zeigeBanner('Alle Beiträge vollständig. Auswertung abgeschlossen.', 'green');
       }
+      document.getElementById('gebote-anzahl')!.textContent = '';
     } else {
-      zeigeBanner(`${geboteOhneStandard.length} von ${totalErwartet} Geboten eingegangen.`, 'amber');
+      zeigeBanner(`${ausstehend} von ${totalAlle} Beiträge ausstehend.`, 'amber');
+      document.getElementById('gebote-anzahl')!.textContent = '';
     }
 
     document.getElementById('zustand-laden')!.classList.add('hidden');


### PR DESCRIPTION
## Problem

Slots mit Standardgebot wurden aus der Zählung ausgeschlossen. Eine Runde mit 9 manuellen Slots und 1 Auto-Slot zeigte „0 von 9 Geboten eingegangen" — der Auto-Slot war unsichtbar, was verwirrt.

## Lösung

- **Gesamtzahl** = alle Slots (inkl. Auto-Slots)
- **Erledigt** = Auto-Slots + eingegangene Gebote für manuelle Slots
- **Angezeigt** = Ausstehende Beiträge: `${ausstehend} von ${totalAlle} Beiträge ausstehend`

**Neue Formulierung:** „ausstehend" statt „eingegangen" — passt neutral zu beiden Quellen (abgegebene Gebote und automatische Standardwerte).

**Vollständig-Banner** angepasst: „Alle Beiträge vollständig. Auswertung abgeschlossen."

## Wie wurde getestet

50/50 Tests grün.