### PR TITLE
Automatische Löschung von Runden nach 6 Monaten

### DIFF
--- a/src/pages/api/runde/erstellen.ts
+++ b/src/pages/api/runde/erstellen.ts
@@ -1,12 +1,41 @@
 import type { APIRoute } from 'astro';
-import { writeFile } from 'node:fs/promises';
+import { writeFile, readdir, readFile, unlink, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 interface RundeJSON {
   id: string;
   adminToken: string;
+  createdAt: string;
   encTeilnehmerBlob: string;
   gebote: Array<{ emojiHmac: string; encGebot: string }>;
+}
+
+const SIX_MONTHS_MS = 6 * 30 * 24 * 60 * 60 * 1000;
+
+async function cleanupAlteRunden(dataDir: string): Promise<void> {
+  try {
+    const files = await readdir(dataDir);
+    const now = Date.now();
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      const filePath = join(dataDir, file);
+      try {
+        const raw = await readFile(filePath, 'utf-8');
+        const data = JSON.parse(raw) as Partial<RundeJSON>;
+        const createdAt = data.createdAt ? new Date(data.createdAt).getTime() : NaN;
+        const age = isNaN(createdAt)
+          ? now - (await stat(filePath)).mtimeMs
+          : now - createdAt;
+        if (age > SIX_MONTHS_MS) {
+          await unlink(filePath);
+        }
+      } catch {
+        // Einzelne Datei überspringen bei Fehler
+      }
+    }
+  } catch {
+    // Cleanup-Fehler nicht an den Client weitergeben
+  }
 }
 
 function generateId(length: number): string {
@@ -20,6 +49,7 @@ const BLOB_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 const DATA_DIR = join(process.cwd(), 'data', 'runden');
 
 export const POST: APIRoute = async ({ request }) => {
+  void cleanupAlteRunden(DATA_DIR);
   let body: unknown;
   try {
     body = await request.json();
@@ -49,6 +79,7 @@ export const POST: APIRoute = async ({ request }) => {
   const runde: RundeJSON = {
     id,
     adminToken,
+    createdAt: new Date().toISOString(),
     encTeilnehmerBlob,
     gebote: [],
   };

--- a/src/pages/ueber.astro
+++ b/src/pages/ueber.astro
@@ -74,9 +74,14 @@ import Layout from '../layouts/Layout.astro';
       keine E-Mail-Adressen, keine Tracking-Cookies. Runden-IDs sind zufällig generiert
       und enthalten keine personenbezogenen Informationen.
     </p>
-    <p class="text-sm text-slate-600 leading-relaxed">
+    <p class="text-sm text-slate-600 leading-relaxed mb-3">
       Gespeicherte Runden-Links werden ausschließlich in deinem Browser (localStorage)
       gespeichert — nie auf dem Server.
+    </p>
+    <p class="text-sm text-slate-600 leading-relaxed">
+      Runden werden nach <strong>6 Monaten automatisch vom Server gelöscht</strong>.
+      Der Inhalt ist ohnehin verschlüsselt — die automatische Löschung stellt sicher,
+      dass auch die verschlüsselten Rohdaten nicht dauerhaft gespeichert bleiben.
     </p>
   </div>
 </Layout>


### PR DESCRIPTION
## Was wurde gebaut

Runden häuften sich unbegrenzt auf dem Server an. Diese Änderung fügt eine automatische Bereinigung ein:

- Jede neue Runde bekommt beim Erstellen einen `createdAt`-Timestamp (ISO 8601)
- Bei jeder Runden-Erstellung (`POST /api/runde/erstellen`) wird ein fire-and-forget Cleanup ausgeführt
- Runden älter als 6 Monate werden gelöscht
- Altdaten ohne `createdAt` werden anhand des Datei-`mtime` bewertet
- Fehler im Cleanup werden abgefangen und nicht an den Client weitergegeben

Auf der Seite `/ueber` wurde im Datenschutz-Abschnitt ein Hinweis auf die automatische Löschung ergänzt.

## Wie wurde getestet

- Manuell: neue Runde erstellen, `createdAt` in der JSON-Datei prüfen
- Logik: Cleanup-Funktion liest `createdAt` (Fallback `mtime`), vergleicht mit 6-Monats-Schwelle

## Was kommt als nächstes

Weiter mit dem Backlog (Feature 2 oder weiteres nach Priorisierung).