### PR TITLE
chore: restructure CLAUDE.md and add .claude/rules/

### DIFF
--- a/.claude/commands/issue-prep.md
+++ b/.claude/commands/issue-prep.md
@@ -1,0 +1,32 @@
+---
+description: Mache ein refinement eines GitHub Issue für fairshare-zk und setze es auf "ready", wenn die definition of ready erfüllt ist
+argument-hint: [issue-nummer]
+---
+
+# Issue Prep Command
+
+Arbeite GitHub Issue #$ARGUMENTS aus, bis es die Definition of Ready erfüllt.
+
+## Workflow
+
+### Schritt 1: Issue-Inhalt erfassen
+Lies den aktuellen Issue-Titel und die vorhandene Beschreibung aus GitHub.
+Falls kein GitHub-Zugriff möglich ist, frage den Nutzer nach dem Inhalt.
+
+### Schritt 2: Rückfragen stellen (nur wenn nötig)
+Lade den Skill @issue-refinement.
+
+Analysiere ob der Issue bereits klar genug ist. Stelle offene Fragen —
+maximal 3, einzeln nacheinander, nicht alle auf einmal.
+
+### Schritt 3: Issue-Text formulieren
+Schreibe den fertigen Issue-Text mit:
+- Kurze Problembeschreibung (1–3 Sätze)
+- Acceptance Criteria als Checkboxen
+- Betroffene Dateien (soweit bekannt)
+- Abhängigkeiten zu anderen Issues (falls vorhanden)
+- Label-Vorschlag
+
+### Schritt 4: Ready-Bewertung
+Bewerte abschließend: Kann das `ready`-Label gesetzt werden?
+Falls nicht — benenne konkret was noch fehlt.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,22 @@
+# Architecture Details
+
+## Data flow
+
+1. **Create round** (`neu.astro` → `POST /api/runde/erstellen`): generate keys, encrypt blob, server returns 8-char ID + 16-char adminToken, save participant/admin links locally.
+2. **Submit bid** (`/runde/[id]`): fetch + decrypt blob, encrypt bid with admin pubkey via ephemeral ECDH, POST with HMAC-based emojiHmac for deduplication.
+3. **Admin view** (`/runde/[id]/admin/[token]`): server verifies token (timing-safe), client decrypts all bids with adminPrivKey, runs solidarisch calculation.
+
+## Server-side JSON schema
+
+```json
+{
+  "id": "abc12345",
+  "adminToken": "1234567890abcdef",
+  "encTeilnehmerBlob": "<iv>.<ct>",
+  "gebote": [
+    { "emojiHmac": "<base64url>", "encGebot": "<ephPubKey>.<iv>.<ct>" }
+  ]
+}
+```
+
+Files in `data/runden/` are auto-deleted after 6 months.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -8,3 +8,4 @@ Zero-knowledge is the core promise of this app — these rules are non-negotiabl
 - No `console.log` with keys or decrypted content
 - HTTPS is required
 - After loading a link: remove the fragment via `history.replaceState()`
+- **No personal data collected** — no names, emails, accounts, or IP logging; the app must not ask for or persist any PII (DSGVO principle, not an afterthought)

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,10 @@
+# Security Rules
+
+Zero-knowledge is the core promise of this app — these rules are non-negotiable.
+
+- **No plaintext on the server** — never send slots, bids, names, or amounts unencrypted
+- Encryption always happens in the browser, before the API call
+- Only WebCrypto API for cryptography — no external crypto packages
+- No `console.log` with keys or decrypted content
+- HTTPS is required
+- After loading a link: remove the fragment via `history.replaceState()`

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,14 @@
+# Workflow Tips
+
+## Debugging
+
+- Use `/doctor` for Claude Code diagnostics
+- Run long-running terminal commands as background tasks for better log visibility
+- Browser automation MCPs (Claude in Chrome, Playwright, Chrome DevTools) for console log inspection
+- Provide screenshots when reporting visual issues
+
+## Context management
+
+- Perform `/compact` at ~50% context usage
+- Start with plan mode for complex tasks
+- Break subtasks small enough to complete in under 50% context

--- a/.claude/skills/issue-refinement/SKILL.md
+++ b/.claude/skills/issue-refinement/SKILL.md
@@ -36,4 +36,3 @@ Konkret und prüfbar — nicht „funktioniert korrekt", sondern messbar:
 - Implementierungsdetails (wie gebaut wird — entscheidet Claude)
 - Infos die bereits in CLAUDE.md, TECH.md oder ANFORDERUNGEN.md stehen
 
-

--- a/.claude/skills/issue-refinement/SKILL.md
+++ b/.claude/skills/issue-refinement/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: issue-refinement
+description: Definition of Ready und Acceptance-Criteria-Stil für fairshare-zk Issues
+user-invocable: false
+---
+
+# Issue Refinement — fairshare-zk
+
+## Definition of Ready
+
+Ein Issue ist bereit wenn:
+- [ ] Ziel klar: Was ist danach anders?
+- [ ] Acceptance Criteria als Checkboxen formuliert
+- [ ] Scope passt in einen PR (~100–150 Zeilen)
+- [ ] Kein offener Designentscheid
+- [ ] Abhängigkeiten zu anderen Issues benannt
+- [ ] Betroffene Dateien identifiziert (soweit bekannt)
+
+## Acceptance Criteria — Stil
+
+Konkret und prüfbar — nicht „funktioniert korrekt", sondern messbar:
+- src/lib/solidarisch.ts gibt bei leerem Input einen Fehler zurück
+- Kein console.log in src/ vorhanden
+- Vitest-Tests sind grün
+
+## Besonderheiten je Label
+
+**`bug`** — Ist-Zustand + Soll-Zustand + Reproduktionsschritte
+**`security`** — Bedrohungsmodell nennen, Bezug zum Zero-Knowledge-Prinzip
+**`test`** — Datei/Funktion + zu testende Szenarien (Happy Path, Edge Cases, Fehler)
+**`chore`** — Kein neues Verhalten, nur messbare Qualitätsverbesserung
+**`feature`** — Nutzen aus User-Perspektive, Abhängigkeiten explizit  
+
+## Was NICHT in den Issue gehört
+
+- Implementierungsdetails (wie gebaut wird — entscheidet Claude)
+- Infos die bereits in CLAUDE.md, TECH.md oder ANFORDERUNGEN.md stehen
+
+

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+.astro/
+.git/
+*.log
+.env
+.DS_Store
+coverage/
+package-lock.json
+data/runden/*.json
+input/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ data/sync/*.json
 .env.*
 !.env.example
 .astro/
-.claude/
+.claude/settings.local.json
 .claire/
 
 # manual input files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Encryption formats:
 - TypeScript strict mode throughout.
 - No linter — follow the style of surrounding code.
 - Responsive/mobile-first with Tailwind 4; brand green is `#3B6D11`.
+- Tailwind utility classes only — no inline styles, no custom CSS outside `src/styles/global.css`.
 - Print styles in `src/styles/global.css` optimize the admin view for PDF export.
 
 ## Design-Prinzipien (UX)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,129 +1,90 @@
-# CLAUDE.md — FairShare (Zero-Knowledge)
+# CLAUDE.md
 
-## Projekt
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-Eine Web-App für solidarische Gruppenfinanzierung mit Zero-Knowledge-Prinzip.
-Alle Inhalte werden im Browser verschlüsselt — der Server sieht nie Klartext.
-Details in ANFORDERUNGEN.md und TECH.md.
+## What this app does
 
----
+FairShare is a German-language web app for solidarische (solidarity-based) group cost-sharing. Participants submit anonymous sealed bids for what they can afford. An admin views aggregated results and calculates fair shares via a "Richtwert" (reference value per weighted unit). All sensitive data is encrypted in the browser — the server never sees amounts or identities.
 
-## Setup: Visuelles Design aus dem Vorgängerprojekt
+## Architecture
 
-Das neue Projekt soll visuell identisch mit dem Vorgängerprojekt `syndikit/fairshare`
-aussehen. Im Ordner `input/` liegen alle relevanten Dateien aus dem alten Projekt.
-Übernimm beim initialen Setup folgende Dateien **unverändert**:
+**Framework:** Astro 5 (SSR, Node.js adapter, standalone mode)  
+**Storage:** Filesystem JSON in `data/runden/*.json` — no database  
+**Crypto:** Native WebCrypto API only (no npm crypto packages)  
+**Testing:** Vitest in Node.js environment  
+**Path alias:** `@/*` → `src/*`
 
-| Quelldatei (`input/`) | Ziel im neuen Projekt |
-|---|---|
-| `astro.config.mjs` | `astro.config.mjs` |
-| `src/styles/global.css` | `src/styles/global.css` |
-| `src/layouts/Layout.astro` | `src/layouts/Layout.astro` |
-| `public/syndikit-c-icon.svg` | `public/syndikit-c-icon.svg` |
-| `public/syndikit-c-logo.svg` | `public/syndikit-c-logo.svg` |
+### Key source files
 
-Die TypeScript-Typen aus `input/src/types/` dienen als **Referenz und Orientierung**,
-werden aber nicht direkt kopiert — die Typen ändern sich durch die neue
-Zero-Knowledge-Architektur grundlegend.
+| File | Purpose |
+|------|---------|
+| `src/lib/crypto.ts` | All encryption primitives (AES-GCM, ECDH, HMAC) |
+| `src/lib/solidarisch.ts` | Core Richtwert calculation algorithm |
+| `src/lib/splid.ts` | Splid XLSX import parser |
+| `src/lib/storage.ts` | Browser localStorage management |
+| `src/pages/neu.astro` | Round creation (key generation happens here) |
+| `src/pages/runde/[id].astro` | Participant view (decrypt blob, submit bid) |
+| `src/pages/runde/[id]/admin/[token].astro` | Admin results view |
+| `src/pages/api/runde/` | REST API endpoints (create, blob, gebot) |
 
----
+### Zero-knowledge design
 
-## Arbeitsweise
+Three keys are generated client-side and never sent to the server:
 
-### Allgemein
+- **partKey** (AES-256-GCM): encrypts the round blob (name, costs, slots, admin public key)
+- **adminPrivKey** (ECDH P-256): decrypts individual bids — only the admin link holder can see amounts
+- **hmacKey** (HMAC-SHA256): generates anonymous 3-emoji participant IDs
 
-- Lies zu Beginn jeder Session ANFORDERUNGEN.md und TECH.md
-- Stelle Fragen bevor du Annahmen triffst
-- Baue Schritt für Schritt — nicht alles auf einmal
-- Nach jedem größeren Schritt: kurze Zusammenfassung was gemacht wurde, dann warten
+Keys live only in URL fragments (`#pk=...&bk=...`). The server stores encrypted ciphertext, bid count, and timestamps only.
 
-### Sicherheit hat oberste Priorität
+Encryption formats:
+- Blob: `<iv_b64url>.<ct_b64url>` (AES-GCM)
+- Bids: `<ephemPubKey_b64url>.<iv_b64url>.<ct_b64url>` (ephemeral ECDH + HKDF → AES-GCM)
 
-- **Kein Klartext auf dem Server** — das ist das Kernversprechen der App
-- Niemals sensible Daten (Slots, Gebote, Namen, Beträge) unverschlüsselt
-  an den Server senden
-- Verschlüsselung findet **immer** im Browser statt, **vor** dem API-Aufruf
-- Kein `console.log` mit Schlüsseln oder entschlüsselten Inhalten
-- Nur WebCrypto API für Kryptografie — keine externen Krypto-Pakete
-- HTTPS ist Pflicht
-- Nach dem Laden eines Links: Fragment per `history.replaceState()` entfernen
+### Solidarisch calculation
 
-### Planung
+- `Richtwert = gesamtkosten / Σ(gewichtung × anzahl)` across all slots
+- Per bid: `richtwertAnteil = gewichtung × Richtwert`; `ueberRichtwert = max(0, bid − richtwertAnteil)`
+- Surplus: proportionally refund overpayers. Deficit: no refund.
+- `Ausgleichszahlungen`: greedy debt-settling (schuldner pay gläubiger minimum transfers)
 
-- Beginne jede neue Aufgabe mit einem kurzen Arbeitsplan
-- Warte auf mein OK bevor du anfängst zu bauen
-- Wenn etwas unklar ist: frage, baue nicht drauflos
+## Language & conventions
 
-### Git & Branches
+- All UI copy, validation messages, and variable names are in German (e.g., `Richtwert`, `Gebot`, `Runde`, `Slot`, `Ausgleichszahlung`).
+- TypeScript strict mode throughout.
+- No linter — follow the style of surrounding code.
+- Responsive/mobile-first with Tailwind 4; brand green is `#3B6D11`.
+- Print styles in `src/styles/global.css` optimize the admin view for PDF export.
 
-- MVP 0 und MVP 1 werden auf `main` entwickelt
-- Ab Feature 1: eigener Branch pro Feature
-- Branch-Format: `feature/kurze-beschreibung` (Deutsch)
-- Commits auf Englisch, klein und präzise
-- Beispiele: `add webcrypto aes-gcm wrapper`, `add teilnehmer gebot form`
+## Design-Prinzipien (UX)
 
-### Codequalität
+- **Progressive Disclosure:** Komplexität erscheint erst, wenn sie gebraucht wird. Features werden nicht entfernt — sie werden zum richtigen Moment sichtbar.
+- Kein Feature im primären Sichtbereich, das die meisten Nutzer nie brauchen.
+- Power-Features sind auffindbar, aber nie aufdringlich.
 
-- Code ist sauber, verständlich, wartbar und konsistent
-- Krypto-Logik ausschließlich in `src/lib/crypto.ts` — nie inline
-- Die App speichert keine personenbezogenen Daten — Grundprinzip, kein Nice-to-have
-- DSGVO-Konformität von Anfang an, nicht nachträglich
-- Tailwind Design Tokens statt Inline-Styles
+## Git-Workflow
 
-### Tests
+- Commits: English, Conventional Commits (feat/fix/refactor/chore/docs/test/style)
+- **Separate commit per file** — never bundle multiple file changes into one commit
+- Commit often — at least once per completed task
+- Branch: `feature/issue-{nr}-kurzbeschreibung`
+- PRs klein halten — ein Feature pro PR; immer mit `Closes #Nr`
+- Squash Merge beim Mergen in main
+- Labels: feature, bug, chore, security, test, ready — vom Issue auf den PR übertragen; ready-Label vom Issue entfernen wenn Umsetzung beginnt
 
-- Definiere Tests zuerst und zeige sie mir — bevor du sie ausführst
-- `crypto.ts` bekommt Roundtrip-Tests für jeden Primitive
-- `solidarisch.ts` bekommt Unit-Tests mit bekannten Eingaben und Erwartungen
-- Kein PR ohne grüne Tests
-- Tests prüfen auch Codequalität wo sinnvoll
+## Commands
 
-### Pull Requests
+```bash
+npm run dev          # Start Astro dev server
+npm run build        # Production build
+npm run preview      # Preview production build
+npm run test         # Run Vitest test suite once
+npm run test:watch   # Run tests in watch mode
+```
 
-- PR erst öffnen wenn ich explizit „fertig" oder „PR erstellen" sage
-- PR-Beschreibung auf Deutsch
-- PR enthält: Was wurde gebaut, wie wurde getestet, was kommt als nächstes
+Node.js at `/opt/homebrew/opt/node.js/bin/` — use absolute paths if `node`/`npm` not in PATH.  
+Single test file: `npx vitest run src/lib/solidarisch.test.ts`
 
-### Kommunikation
+## Vor der Umsetzung
 
-- Antworte auf Deutsch
-- Kurze Zusammenfassungen — kein Roman
-- Bei Fehlern: Problem erklären, Lösungsvorschlag machen, auf OK warten
-
----
-
-## Agiler Workflow
-
-### MVP 0 — Crypto-Fundament
-
-1. Ich sage „starte MVP 0"
-2. Du zeigst den Arbeitsplan — ich sage OK
-3. Du baust `crypto.ts`
-4. Du zeigst die Tests — ich sage OK
-5. Du führst Tests aus
-6. Ich gebe frei → Push auf `main`
-
-### MVP 1 — Kern-Workflow
-
-1. Ich sage „starte MVP 1"
-2. Du zeigst den Arbeitsplan — ich sage OK
-3. Du baust Schritt für Schritt (erst API, dann Seiten)
-4. Du zeigst Tests — ich sage OK
-5. Du führst Tests aus
-6. Ich gebe frei → Push auf `main`
-
-### Features (ab Feature 1)
-
-1. Ich beschreibe das Feature
-2. Du erstellst Branch `feature/...`
-3. Arbeitsplan → OK → Bauen → Tests zeigen → OK → Tests ausführen → Freigabe → PR
-
-Für die vollständige Feature-Liste: BACKLOG.md
-
----
-
-## Was ich selbst mache
-
-- PRs reviewen und mergen auf GitHub.com
-- Entscheidungen über Anforderungsänderungen
-- Freigabe von Tests und PRs
+Erstelle zuerst einen Plan und warte auf Bestätigung, bevor du mit dem Coden anfängst.


### PR DESCRIPTION
## Summary

- `.claude/` aus `.gitignore` entfernt — nur `settings.local.json` bleibt ausgeschlossen, damit Skills, Commands und Rules versioniert werden
- `CLAUDE.md` von 129 auf 91 Zeilen gekürzt: Template-Artefakte aus dem shanraisshan-Repo entfernt (Skill-Frontmatter, Config-Hierarchy, tote Dokumentationslinks); Tailwind-Konvention ergänzt
- Detailinhalte in neue `.claude/rules/`-Dateien ausgelagert:
  - `.claude/rules/architecture.md` — Data Flow + Server-JSON-Schema
  - `.claude/rules/security.md` — Zero-Knowledge Security-Regeln inkl. No-PII/DSGVO
  - `.claude/rules/workflow.md` — Debugging Tips + Context Management
- `.claude/commands/issue-prep.md` und `.claude/skills/issue-refinement/` erstmals versioniert
- `.claudeignore` hinzugefügt: Astro-spezifisch (`.astro/` statt `.next/`), `data/runden/*.json` und `package-lock.json` ausgeschlossen

## Test plan

- [ ] CLAUDE.md enthält keine toten Links oder fremden Template-Inhalte mehr
- [ ] `.claude/rules/` Dateien sind in git versioniert
- [ ] `settings.local.json` bleibt weiterhin gitignored
- [ ] Security-Regeln inkl. No-PII sind in `.claude/rules/security.md` erhalten
- [ ] Tailwind-only-Konvention ist in CLAUDE.md dokumentiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)