### PR TITLE
style: remove encryption hint text

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -7,7 +7,6 @@ import FeedbackBox from '../components/FeedbackBox.astro';
   <!-- Formular-Bereich -->
   <div id="form-bereich">
     <h1 class="text-2xl font-semibold mb-1">Neue Runde erstellen</h1>
-    <p class="text-slate-500 text-sm mb-6">Alle Daten werden im Browser verschlüsselt — der Server sieht nie Klartext.</p>
 
     <!-- Import (kompakt) -->
     <p class="mb-6 text-sm text-slate-400">


### PR DESCRIPTION
## Summary

- Entfernt den Fließtext „Alle Daten werden im Browser verschlüsselt…" unter der Überschrift
- Kein Ersatz nötig — security-bewusste Nutzer finden die Info auf der Startseite; Progressive Disclosure

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)