### PR TITLE
fix: "auto"-Badge in Admin-Auswertung grün färben

### DIFF
--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -371,7 +371,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           zeile.className = 'flex items-center gap-2 px-3 py-1';
           zeile.innerHTML = `
             <span class="text-base w-16 shrink-0 text-slate-300">—</span>
-            <span class="text-xs bg-slate-100 text-slate-500 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
+            <span class="text-xs bg-green-100 text-green-700 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
             ${zeigeBeitraege ? `<span class="text-sm font-semibold text-slate-900 shrink-0 ml-auto">${eur(slot.standardgebot!)}</span>` : ''}
           `;
           zeilenContainer.appendChild(zeile);


### PR DESCRIPTION
## Summary

- Das „auto"-Badge bei Standardgebot-Slots war grau (`bg-slate-100 text-slate-500`) — optisch identisch mit „fehlt"-Zeilen
- Geändert zu grün (`bg-green-100 text-green-700`), konsistent mit dem „geboten"-Badge
- Standardgebote sind akzeptierte Werte, keine Platzhalter — grün kommuniziert das korrekt

## Test plan

- [ ] Runde mit Standardgebot-Slot anlegen (z. B. „Kind", Faktor 0,5)
- [ ] Admin-Auswertung öffnen → „auto"-Badge erscheint grün
- [ ] „fehlt"-Badge bleibt grau (visuelle Unterscheidung erhalten)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)