### PR TITLE
fix: Standard-Slots in Ausgleichszahlungen und Admin-Auswertung

### DIFF
--- a/src/lib/solidarisch.test.ts
+++ b/src/lib/solidarisch.test.ts
@@ -408,17 +408,48 @@ describe('berechneAusgleich', () => {
     expect(zahlungen[0].betrag).toBeCloseTo(50);
   });
 
-  it('istStandard-Einträge werden übersprungen', () => {
+  it('Standard-Slot als Schuldner erscheint mit slotLabel in Ausgleichszahlungen', () => {
     const ergebnisse: GebotErgebnis[] = [
       ergebnis('🐼🚀🌈', 'A', 80),
       ergebnis('—', 'B', 40, { istStandard: true }),
-      ergebnis('🦊🌙⭐', 'C', 70),
     ];
-    // A schuldet 50 (zahlt 30), C Gläubiger 30 (zahlt 100)
-    // Standard-Eintrag soll ignoriert werden
-    const ausgaben = new Map([['A', 30], ['B', 0], ['C', 100]]);
+    // A: solidarisch 80, ausgaben 100 → Gläubiger 20
+    // B: solidarisch 40, ausgaben 0 → Schuldner 40
+    const ausgaben = new Map([['A', 100], ['B', 0]]);
     const zahlungen = berechneAusgleich(ergebnisse, ausgaben);
-    expect(zahlungen.every((z) => z.von !== '—' && z.an !== '—')).toBe(true);
+    expect(zahlungen).toHaveLength(1);
+    expect(zahlungen[0].von).toBe('B');
+    expect(zahlungen[0].an).toBe('🐼🚀🌈');
+    expect(zahlungen[0].betrag).toBeCloseTo(20);
+  });
+
+  it('mehrere Standard-Slots im selben Slot werden aggregiert', () => {
+    const ergebnisse: GebotErgebnis[] = [
+      ergebnis('—', 'Kind', 30, { istStandard: true }),
+      ergebnis('—', 'Kind', 30, { istStandard: true }),
+      ergebnis('🌟🎉🦋', 'Erwachsen', 60),
+    ];
+    // Kind: 2×30=60 solidarisch, ausgaben 0 → schuldet 60
+    // Erwachsen: 60 solidarisch, ausgaben 120 → Gläubiger 60
+    const ausgaben = new Map([['Kind', 0], ['Erwachsen', 120]]);
+    const zahlungen = berechneAusgleich(ergebnisse, ausgaben);
+    expect(zahlungen).toHaveLength(1);
+    expect(zahlungen[0].von).toBe('Kind');
+    expect(zahlungen[0].an).toBe('🌟🎉🦋');
+    expect(zahlungen[0].betrag).toBeCloseTo(60);
+  });
+
+  it('Standard-Slot als Gläubiger wenn ausgaben > solidarischerBeitrag', () => {
+    const ergebnisse: GebotErgebnis[] = [
+      ergebnis('🐼🚀🌈', 'A', 80),
+      ergebnis('—', 'B', 20, { istStandard: true }),
+    ];
+    // A: solidarisch 80, ausgaben 120 → Gläubiger 40
+    // B: solidarisch 20, ausgaben 100 → Gläubiger 80  (ausgaben > beitrag)
+    // kein Schuldner → keine Zahlungen
+    const ausgaben = new Map([['A', 120], ['B', 100]]);
+    const zahlungen = berechneAusgleich(ergebnisse, ausgaben);
+    expect(zahlungen).toHaveLength(0);
   });
 });
 

--- a/src/lib/solidarisch.test.ts
+++ b/src/lib/solidarisch.test.ts
@@ -439,17 +439,19 @@ describe('berechneAusgleich', () => {
     expect(zahlungen[0].betrag).toBeCloseTo(60);
   });
 
-  it('Standard-Slot als Gläubiger wenn ausgaben > solidarischerBeitrag', () => {
+  it('Standard-Slot als Gläubiger: Schuldner zahlt an Standard-Slot', () => {
     const ergebnisse: GebotErgebnis[] = [
-      ergebnis('🐼🚀🌈', 'A', 80),
+      ergebnis('🐼🚀🌈', 'A', 50),
       ergebnis('—', 'B', 20, { istStandard: true }),
     ];
-    // A: solidarisch 80, ausgaben 120 → Gläubiger 40
-    // B: solidarisch 20, ausgaben 100 → Gläubiger 80  (ausgaben > beitrag)
-    // kein Schuldner → keine Zahlungen
-    const ausgaben = new Map([['A', 120], ['B', 100]]);
+    // A: solidarisch 50, ausgaben 0 → Schuldner 50
+    // B: solidarisch 20, ausgaben 80 → Gläubiger 60
+    const ausgaben = new Map([['A', 0], ['B', 80]]);
     const zahlungen = berechneAusgleich(ergebnisse, ausgaben);
-    expect(zahlungen).toHaveLength(0);
+    expect(zahlungen).toHaveLength(1);
+    expect(zahlungen[0].von).toBe('🐼🚀🌈');
+    expect(zahlungen[0].an).toBe('B');
+    expect(zahlungen[0].betrag).toBeCloseTo(50);
   });
 });
 

--- a/src/lib/solidarisch.ts
+++ b/src/lib/solidarisch.ts
@@ -217,7 +217,7 @@ export function berechneAusgleich(
   const standardBeitrag = new Map<string, number>();
   for (const e of ergebnisse) {
     if (!e.istStandard) continue;
-    standardBeitrag.set(e.slotLabel, runden((standardBeitrag.get(e.slotLabel) ?? 0) + e.solidarischerBeitrag));
+    standardBeitrag.set(e.slotLabel, (standardBeitrag.get(e.slotLabel) ?? 0) + e.solidarischerBeitrag);
   }
   for (const [label, beitrag] of standardBeitrag) {
     const ausgaben = ausgabenProSlot.get(label) ?? 0;

--- a/src/lib/solidarisch.ts
+++ b/src/lib/solidarisch.ts
@@ -208,10 +208,23 @@ export function berechneAusgleich(
   ergebnisse: GebotErgebnis[],
   ausgabenProSlot: Map<string, number>,
 ): Ausgleichszahlung[] {
-  // Netto-Bilanz pro Person berechnen (synthetische Einträge überspringen)
+  // Netto-Bilanz pro Person/Slot berechnen; Standard-Slots nach slotLabel aggregieren (kein echtes emojiId)
   type Posten = { emojiId: string; betrag: number };
   const schuldner: Posten[] = [];
   const glaeubiger: Posten[] = [];
+
+  // Standard-Slots: solidarischerBeitrag summieren, ausgaben einmal pro Slot abziehen
+  const standardBeitrag = new Map<string, number>();
+  for (const e of ergebnisse) {
+    if (!e.istStandard) continue;
+    standardBeitrag.set(e.slotLabel, runden((standardBeitrag.get(e.slotLabel) ?? 0) + e.solidarischerBeitrag));
+  }
+  for (const [label, beitrag] of standardBeitrag) {
+    const ausgaben = ausgabenProSlot.get(label) ?? 0;
+    const netto = runden(beitrag - ausgaben);
+    if (netto > 0.005) schuldner.push({ emojiId: label, betrag: netto });
+    else if (netto < -0.005) glaeubiger.push({ emojiId: label, betrag: -netto });
+  }
 
   for (const e of ergebnisse) {
     if (e.istStandard) continue;

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -365,15 +365,35 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
       // Auto-Gebote
       if (slot.standardgebot !== undefined) {
-        const anzahlAuto = autoAnzahl;
-        for (let i = 0; i < anzahlAuto; i++) {
-          const e = zeigeBeitraege ? slotErgebnisse.find((r) => r.istStandard) : null;
+        const standardErgebnisse = slotErgebnisse.filter((r) => r.istStandard);
+        for (let i = 0; i < autoAnzahl; i++) {
+          const e = zeigeBeitraege ? (standardErgebnisse[i] ?? null) : null;
+          const nochZuZahlen = e ? runden(e.solidarischerBeitrag - ausgaben) : 0;
           const zeile = document.createElement('div');
-          zeile.className = 'flex items-center gap-2 px-3 py-1';
+          zeile.className = 'flex flex-col px-3 py-1';
           zeile.innerHTML = `
-            <span class="text-base w-16 shrink-0 text-slate-300">—</span>
-            <span class="text-xs bg-green-100 text-green-700 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
-            ${zeigeBeitraege ? `<span class="text-sm font-semibold text-slate-900 shrink-0 ml-auto">${eur(slot.standardgebot!)}</span>` : ''}
+            <div class="flex items-center gap-2 w-full">
+              <span class="text-base w-16 shrink-0 text-slate-300">—</span>
+              <span class="text-xs bg-green-100 text-green-700 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
+              ${e ? `
+                <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Beitrag</span>
+                <span class="hidden sm:inline text-sm font-semibold text-slate-900 shrink-0">${eur(e.solidarischerBeitrag)}</span>
+              ` : ''}
+              ${e && hatSplidDaten ? `
+                <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Noch zu zahlen</span>
+                <span class="hidden sm:inline text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${nochZuZahlen > 0 ? '+' : ''}${eur(nochZuZahlen)}</span>
+              ` : ''}
+            </div>
+            ${e ? `
+              <div class="flex items-center gap-3 pl-[4.5rem] sm:hidden pb-1">
+                <span class="text-xs text-slate-400">Beitrag</span>
+                <span class="text-sm font-semibold text-slate-900">${eur(e.solidarischerBeitrag)}</span>
+                ${hatSplidDaten ? `
+                  <span class="text-xs text-slate-400">Noch zu zahlen</span>
+                  <span class="text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'}">${nochZuZahlen > 0 ? '+' : ''}${eur(nochZuZahlen)}</span>
+                ` : ''}
+              </div>
+            ` : ''}
           `;
           zeilenContainer.appendChild(zeile);
         }

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -368,7 +368,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         const standardErgebnisse = slotErgebnisse.filter((r) => r.istStandard);
         for (let i = 0; i < autoAnzahl; i++) {
           const e = zeigeBeitraege ? (standardErgebnisse[i] ?? null) : null;
-          const nochZuZahlen = e ? runden(e.solidarischerBeitrag - ausgaben) : 0;
+          const nochZuZahlen = e ? e.solidarischerBeitrag - ausgaben : 0;
           const zeile = document.createElement('div');
           zeile.className = 'flex flex-col px-3 py-1';
           zeile.innerHTML = `


### PR DESCRIPTION
## Summary

- `berechneAusgleich` berücksichtigt Standard-Slots jetzt korrekt: `solidarischerBeitrag` wird nach `slotLabel` aggregiert, Slot-Ausgaben werden einmal abgezogen, der Nettoposten fließt als Schuldner oder Gläubiger in den Ausgleich ein
- Standard-Slots erscheinen in Ausgleichszahlungen mit ihrem Slot-Namen als Bezeichner
- Auto-Zeilen in der Admin-Auswertung zeigen `solidarischerBeitrag` und „Noch zu zahlen" (rot/grün) analog zu echten Geboten, wenn Splid-Daten vorhanden sind

## Test plan

- [ ] Runde mit Splid-Import erstellen, zusätzlich Slot mit Standardgebot hinzufügen
- [ ] Admin-Auswertung: Auto-Zeile zeigt Beitrag und Noch-zu-zahlen
- [ ] Ausgleichszahlungen-Sektion: Standard-Slot erscheint mit Slot-Namen
- [ ] Vitest: 28/28 Tests grün (`npm run test`)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)