### PR TITLE
fix: Korrektur-Slot aus localStorage sperren

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -43,6 +43,30 @@ export function deleteRunde(id: string): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(runden));
 }
 
+export function saveGebotLokal(rundenId: string, emojiId: string, slotLabel: string): void {
+  const key = `fairshare-gebot-${rundenId}`;
+  let gebote: Array<{ emojiId: string; slotLabel: string }> = [];
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) gebote = JSON.parse(raw);
+  } catch { /* ignore */ }
+  if (!gebote.some((g) => g.emojiId === emojiId)) {
+    gebote.push({ emojiId, slotLabel });
+    localStorage.setItem(key, JSON.stringify(gebote));
+  }
+}
+
+export function getGebotSlot(rundenId: string, emojiId: string): string | null {
+  try {
+    const raw = localStorage.getItem(`fairshare-gebot-${rundenId}`);
+    if (!raw) return null;
+    const gebote: Array<{ emojiId: string; slotLabel: string }> = JSON.parse(raw);
+    return gebote.find((g) => g.emojiId === emojiId)?.slotLabel ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function exportJson(): string {
   return JSON.stringify(getRunden(), null, 2);
 }

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -127,8 +127,9 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Neuer Slot</p>
+          <p class="text-sm font-medium text-slate-700 mb-2">Slot</p>
           <div id="slot-auswahl-korrektur" class="space-y-2"></div>
+          <p id="korrektur-slot-hinweis" class="text-xs mt-1"></p>
         </div>
 
         <!-- Betrag -->
@@ -182,7 +183,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     hmac,
   } from '../../lib/crypto';
   import { EMOJIS, generiereEmojiId } from '../../lib/solidarisch';
-  import { saveRunde } from '../../lib/storage';
+  import { saveRunde, saveGebotLokal, getGebotSlot } from '../../lib/storage';
   import { zeigeFeedback, versteckeFeedback } from '../../lib/ui';
 
   interface TeilnehmerBlob {
@@ -447,6 +448,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         }
 
         slotAlsGebotenMarkieren(selectedSlot.label);
+        saveGebotLokal(rundenId, emojiId!, selectedSlot.label);
         document.getElementById('tab-korrigieren')!.classList.remove('hidden');
         zeigeBestaetigung(emojiId!, false);
       } catch (err) {
@@ -509,6 +511,33 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     // ── Tab 2: Gebot korrigieren ──────────────────────────────────────────────
     const korrekturForm = document.getElementById('korrektur-form') as HTMLFormElement;
     const korrekturBtn = document.getElementById('korrektur-btn') as HTMLButtonElement;
+    const korrekturEmojiInput = document.getElementById('korrektur-emoji') as HTMLInputElement;
+    const korrekturSlotHinweis = document.getElementById('korrektur-slot-hinweis')!;
+
+    function aktualisiereKorrekturSlot() {
+      const emojiId = korrekturEmojiInput.value.trim();
+      const bekannterSlot = emojiId ? getGebotSlot(rundenId, emojiId) : null;
+      const radios = korrekturForm.querySelectorAll<HTMLInputElement>('input[name="slot-korrektur"]');
+
+      if (bekannterSlot) {
+        const slotIdx = blob.slots.findIndex((s) => s.label === bekannterSlot);
+        radios.forEach((r, i) => {
+          r.checked = i === slotIdx;
+          r.disabled = true;
+        });
+        korrekturSlotHinweis.textContent = `Slot aus deinem ursprünglichen Gebot: ${bekannterSlot}`;
+        korrekturSlotHinweis.className = 'text-xs text-green-700 mt-1';
+        if (slotIdx >= 0) betragFeldAktualisieren(slotIdx, 'korrektur-betrag', 'korrektur-richtwert-hinweis');
+      } else {
+        radios.forEach((r) => { r.disabled = false; });
+        korrekturSlotHinweis.textContent = emojiId
+          ? 'Gebot auf diesem Gerät nicht gefunden — wähle denselben Slot wie beim ursprünglichen Gebot.'
+          : '';
+        korrekturSlotHinweis.className = 'text-xs text-amber-600 mt-1';
+      }
+    }
+
+    korrekturEmojiInput.addEventListener('input', aktualisiereKorrekturSlot);
 
     korrekturForm.addEventListener('submit', async (e) => {
       e.preventDefault();

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -521,19 +521,28 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
       if (bekannterSlot) {
         const slotIdx = blob.slots.findIndex((s) => s.label === bekannterSlot);
+        if (slotIdx < 0) {
+          radios.forEach((r) => { r.disabled = false; });
+          korrekturSlotHinweis.textContent = 'Dein ursprünglicher Slot existiert nicht mehr — bitte wähle einen Slot.';
+          korrekturSlotHinweis.className = 'text-xs text-amber-600 mt-1';
+          return;
+        }
         radios.forEach((r, i) => {
           r.checked = i === slotIdx;
           r.disabled = true;
         });
         korrekturSlotHinweis.textContent = `Slot aus deinem ursprünglichen Gebot: ${bekannterSlot}`;
         korrekturSlotHinweis.className = 'text-xs text-green-700 mt-1';
-        if (slotIdx >= 0) betragFeldAktualisieren(slotIdx, 'korrektur-betrag', 'korrektur-richtwert-hinweis');
+        betragFeldAktualisieren(slotIdx, 'korrektur-betrag', 'korrektur-richtwert-hinweis');
       } else {
         radios.forEach((r) => { r.disabled = false; });
-        korrekturSlotHinweis.textContent = emojiId
-          ? 'Gebot auf diesem Gerät nicht gefunden — wähle denselben Slot wie beim ursprünglichen Gebot.'
-          : '';
-        korrekturSlotHinweis.className = 'text-xs text-amber-600 mt-1';
+        if (emojiId) {
+          korrekturSlotHinweis.textContent = 'Gebot auf diesem Gerät nicht gefunden — wähle denselben Slot wie beim ursprünglichen Gebot.';
+          korrekturSlotHinweis.className = 'text-xs text-amber-600 mt-1';
+        } else {
+          korrekturSlotHinweis.textContent = '';
+          korrekturSlotHinweis.className = '';
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Beim Korrigieren eines Gebots wird die Emoji-ID→Slot-Zuordnung aus `localStorage` ausgelesen und der Slot automatisch vorausgewählt + gesperrt
- Verhindert versehentlichen Slot-Wechsel (Bug: Gebot wandert in falschen Slot)
- Cross-Device-Fallback: Slot-Auswahl bleibt offen, aber ein Hinweistext warnt, denselben Slot wie beim ursprünglichen Gebot zu wählen

## Warum localStorage?

Serverseitig nicht lösbar: Slot-Label steckt verschlüsselt im `encGebot` (ECDH + AES-GCM), der Server sieht nur den HMAC. Ciphertext-Vergleich ebenfalls unmöglich wegen ephemerem Key + Random-IV pro Gebot.

## Test plan

- [ ] Gebot abgeben → `localStorage` enthält Eintrag `fairshare-gebot-{id}` mit `{emojiId, slotLabel}`
- [ ] Korrektur-Formular öffnen, Emoji-ID eingeben → richtiger Slot wird vorausgewählt, Radios sind disabled, grüner Hinweis erscheint
- [ ] Andere Emoji-ID eingeben (nicht im localStorage) → Radios wieder aktiv, orangefarbener Hinweis erscheint
- [ ] Korrektur erfolgreich abschicken → Gebot bleibt beim richtigen Slot

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)