### PR TITLE
feat: currency input fields always show 2 decimal places

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -43,12 +43,11 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           Gesamtkosten (€)
         </label>
         <input
-          type="number"
+          type="text"
+          inputmode="decimal"
           id="gesamtkosten"
           name="gesamtkosten"
           required
-          min="1"
-          step="0.01"
           placeholder="z.B. 1200"
           class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
         />
@@ -82,10 +81,9 @@ import FeedbackBox from '../components/FeedbackBox.astro';
               <div class="ausgaben-inline hidden flex items-center gap-1 shrink-0">
                 <span class="text-xs text-slate-400">€</span>
                 <input
-                  type="number"
+                  type="text"
+                  inputmode="decimal"
                   name="ausgaben[]"
-                  min="0"
-                  step="0.01"
                   placeholder="0,00"
                   class="w-20 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                 />
@@ -158,10 +156,9 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                   </label>
                   <div class="standardgebot-eingabe hidden flex items-center gap-1">
                     <input
-                      type="number"
+                      type="text"
+                      inputmode="decimal"
                       name="standardgebot[]"
-                      min="0"
-                      step="0.01"
                       data-auto="true"
                       class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                     />
@@ -365,6 +362,13 @@ import FeedbackBox from '../components/FeedbackBox.astro';
   }
 
   document.getElementById('gesamtkosten')!.addEventListener('input', aktualisiereRichtwert);
+
+  form.addEventListener('blur', (e) => {
+    const t = e.target as HTMLInputElement;
+    if (!['gesamtkosten', 'ausgaben[]', 'standardgebot[]'].includes(t.name)) return;
+    const v = parseFloat(t.value.replace(',', '.'));
+    if (!isNaN(v)) t.value = v.toFixed(2);
+  }, true);
 
   const presetNamen: Record<string, string> = { '1.0': 'Erwachsen', '0.75': 'Ermäßigt', '0.5': 'Kind' };
   function aktualisierePresetPlaceholder(slotEl: HTMLElement) {
@@ -628,7 +632,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       };
 
       (form.querySelector('#rundeName') as HTMLInputElement).value = config.name;
-      (form.querySelector('#gesamtkosten') as HTMLInputElement).value = String(config.kosten);
+      (form.querySelector('#gesamtkosten') as HTMLInputElement).value = Number(config.kosten).toFixed(2);
 
       function befuelleWiederholSlot(
         slotEl: HTMLDivElement,

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -366,8 +366,10 @@ import FeedbackBox from '../components/FeedbackBox.astro';
   form.addEventListener('blur', (e) => {
     const t = e.target as HTMLInputElement;
     if (!['gesamtkosten', 'ausgaben[]', 'standardgebot[]'].includes(t.name)) return;
+    if (t.value === '') return;
     const v = parseFloat(t.value.replace(',', '.'));
-    if (!isNaN(v)) t.value = v.toFixed(2);
+    if (isNaN(v) || v < 0) { t.value = ''; return; }
+    t.value = v.toFixed(2);
   }, true);
 
   const presetNamen: Record<string, string> = { '1.0': 'Erwachsen', '0.75': 'Ermäßigt', '0.5': 'Kind' };


### PR DESCRIPTION
## Summary

- Replaces `type="number"` with `type="text" inputmode="decimal"` on all three money fields (`gesamtkosten`, `ausgaben[]`, `standardgebot[]`)
- Removes `min` and `step` attributes (dead code after type change)
- Adds delegated `blur` handler on form to format values to 2 decimal places
- Fixes localStorage restore setting `gesamtkosten` without `toFixed(2)`

## Test plan

- [ ] Neue Runde öffnen — keine Spinner-Pfeile auf Geldfeldern sichtbar
- [ ] `12` eingeben, Feld verlassen → `12.00` angezeigt
- [ ] `12.1` eingeben, Feld verlassen → `12.10` angezeigt
- [ ] `12,5` mit Komma eingeben, Feld verlassen → `12.50` angezeigt
- [ ] Splid-Datei importieren → Gesamtkosten und Ausgaben mit 2 Nachkommastellen
- [ ] Runde aus localStorage wiederherstellen → Gesamtkosten mit 2 Nachkommastellen
- [ ] Auf Mobilgerät: Ziffernblock erscheint beim Antippen der Felder

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)