### PR TITLE
fix: serverseitige Eingabevalidierung in API-Endpoints

### DIFF
--- a/src/pages/api/runde/[id]/gebot.test.ts
+++ b/src/pages/api/runde/[id]/gebot.test.ts
@@ -140,4 +140,33 @@ describe('POST /api/runde/[id]/gebot', () => {
     expect(afterSecond.gebote).toHaveLength(1);
     expect(afterSecond.gebote[0].encGebot).toBe(enc3);
   });
+
+  it('emojiHmac zu kurz gibt 400', async () => {
+    const res = await handler({
+      params: { id: 'abc12345' },
+      request: makeRequest({ emojiHmac: 'zuKurz', encGebot: VALID_ENC_GEBOT }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('emojiHmac mit ungültigem Zeichen gibt 400', async () => {
+    const invalidHmac = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA!';
+    const res = await handler({
+      params: { id: 'abc12345' },
+      request: makeRequest({ emojiHmac: invalidHmac, encGebot: VALID_ENC_GEBOT }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('encGebot über 1000 Zeichen gibt 400', async () => {
+    const longGebot = `${'A'.repeat(500)}.${'B'.repeat(100)}.${'C'.repeat(401)}`;
+    const res = await handler({
+      params: { id: 'abc12345' },
+      request: makeRequest({ emojiHmac: EMOJI_HMAC, encGebot: longGebot }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
 });

--- a/src/pages/api/runde/[id]/gebot.test.ts
+++ b/src/pages/api/runde/[id]/gebot.test.ts
@@ -34,7 +34,8 @@ function makeRunde(gebote: Array<{ emojiHmac: string; encGebot: string }>) {
 }
 
 const VALID_ENC_GEBOT = 'ephemKey.iv123.cipher';
-const EMOJI_HMAC = 'abc123';
+// 43-char base64url string — matches HMAC-SHA256 output length
+const EMOJI_HMAC = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/src/pages/api/runde/[id]/gebot.ts
+++ b/src/pages/api/runde/[id]/gebot.ts
@@ -47,13 +47,13 @@ export const POST: APIRoute = async ({ params, request }) => {
   }
 
   const b = body as Record<string, unknown>;
-  if (typeof b.emojiHmac !== 'string' || b.emojiHmac.length === 0) {
-    return new Response(JSON.stringify({ error: 'emojiHmac fehlt' }), {
+  if (typeof b.emojiHmac !== 'string' || b.emojiHmac.length !== 43) {
+    return new Response(JSON.stringify({ error: 'emojiHmac fehlt oder hat ungültiges Format' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });
   }
-  if (typeof b.encGebot !== 'string' || !GEBOT_FORMAT.test(b.encGebot)) {
+  if (typeof b.encGebot !== 'string' || !GEBOT_FORMAT.test(b.encGebot) || b.encGebot.length > 1_000) {
     return new Response(JSON.stringify({ error: 'encGebot fehlt oder hat ungültiges Format' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
@@ -133,15 +133,15 @@ export const DELETE: APIRoute = async ({ params, request }) => {
 
   const b = body as Record<string, unknown>;
 
-  if (typeof b.emojiHmac !== 'string' || b.emojiHmac.length === 0) {
-    return new Response(JSON.stringify({ error: 'emojiHmac fehlt' }), {
+  if (typeof b.emojiHmac !== 'string' || b.emojiHmac.length !== 43) {
+    return new Response(JSON.stringify({ error: 'emojiHmac fehlt oder hat ungültiges Format' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });
   }
 
-  if (typeof b.adminToken !== 'string' || b.adminToken.length === 0) {
-    return new Response(JSON.stringify({ error: 'adminToken fehlt' }), {
+  if (typeof b.adminToken !== 'string' || b.adminToken.length !== 16) {
+    return new Response(JSON.stringify({ error: 'adminToken fehlt oder hat ungültiges Format' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/src/pages/api/runde/[id]/gebot.ts
+++ b/src/pages/api/runde/[id]/gebot.ts
@@ -11,6 +11,7 @@ interface RundeJSON {
 }
 
 const ID_FORMAT = /^[a-z0-9]{8}$/;
+const EMOJI_HMAC_FORMAT = /^[A-Za-z0-9_-]{43}$/;
 // ECDH-Format: <ephemPubKey>.<iv>.<ciphertext> — drei Base64url-Teile
 const GEBOT_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 const DATA_DIR = join(process.cwd(), 'data', 'runden');
@@ -47,7 +48,7 @@ export const POST: APIRoute = async ({ params, request }) => {
   }
 
   const b = body as Record<string, unknown>;
-  if (typeof b.emojiHmac !== 'string' || b.emojiHmac.length !== 43) {
+  if (typeof b.emojiHmac !== 'string' || !EMOJI_HMAC_FORMAT.test(b.emojiHmac)) {
     return new Response(JSON.stringify({ error: 'emojiHmac fehlt oder hat ungültiges Format' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
@@ -133,7 +134,7 @@ export const DELETE: APIRoute = async ({ params, request }) => {
 
   const b = body as Record<string, unknown>;
 
-  if (typeof b.emojiHmac !== 'string' || b.emojiHmac.length !== 43) {
+  if (typeof b.emojiHmac !== 'string' || !EMOJI_HMAC_FORMAT.test(b.emojiHmac)) {
     return new Response(JSON.stringify({ error: 'emojiHmac fehlt oder hat ungültiges Format' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },

--- a/src/pages/api/runde/erstellen.ts
+++ b/src/pages/api/runde/erstellen.ts
@@ -67,6 +67,13 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   const { encTeilnehmerBlob } = body as { encTeilnehmerBlob: string };
+
+  if (encTeilnehmerBlob.length > 10_000) {
+    return new Response(JSON.stringify({ error: 'encTeilnehmerBlob zu lang' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
   const id = generateId(8);
   const adminToken = generateId(16);
 


### PR DESCRIPTION
## Summary

- `encTeilnehmerBlob` in `erstellen.ts` auf ≤ 10 000 Zeichen begrenzt
- `encGebot` in `gebot.ts` auf ≤ 1 000 Zeichen begrenzt
- `emojiHmac` auf exakt 43 Zeichen geprüft (HMAC-SHA256 Base64url) — POST + DELETE
- `adminToken` auf exakt 16 Zeichen geprüft — DELETE
- Test-Fixture `EMOJI_HMAC` auf gültigen 43-Zeichen-Wert aktualisiert

## Test plan

- [x] `npm run test` — alle 58 Tests grün

Closes #38