### PR TITLE
feat: Dark Mode Phase 2 — Seiten & Komponenten

### DIFF
--- a/src/pages/datenschutz.astro
+++ b/src/pages/datenschutz.astro
@@ -5,7 +5,7 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Datenschutz">
   <h1 class="text-3xl font-bold mb-10">Datenschutzerklärung</h1>
 
-  <div class="space-y-8 text-slate-700 leading-relaxed">
+  <div class="space-y-8 text-slate-700 dark:text-slate-300 leading-relaxed">
 
     <div>
       <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">1. Verantwortlicher</h2>
@@ -20,7 +20,7 @@ import Layout from '../layouts/Layout.astro';
 
     <div>
       <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">2. Hosting</h2>
-      <p class="text-slate-500 text-sm">
+      <p class="text-slate-500 dark:text-slate-400 text-sm">
         Diese Website wird gehostet bei netzguerilla.net. Dabei werden technisch notwendige
         Verbindungsdaten verarbeitet (IP-Adresse, Zeitstempel, aufgerufene URL).
         Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse am Betrieb der Website).
@@ -29,14 +29,14 @@ import Layout from '../layouts/Layout.astro';
 
     <div>
       <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">3. Zero-Knowledge-Prinzip</h2>
-      <p class="text-slate-500 text-sm mb-3">
-        Alle Inhalte einer Runde werden <strong class="text-slate-700">im Browser verschlüsselt</strong>,
+      <p class="text-slate-500 dark:text-slate-400 text-sm mb-3">
+        Alle Inhalte einer Runde werden <strong class="text-slate-700 dark:text-slate-200">im Browser verschlüsselt</strong>,
         bevor sie den Server erreichen. Der Schlüssel steckt im URL-Fragment
-        (<code class="font-mono text-xs bg-slate-100 px-1 py-0.5 rounded">#…</code>) —
+        (<code class="font-mono text-xs bg-slate-100 dark:bg-slate-700 dark:text-slate-300 px-1 py-0.5 rounded">#…</code>) —
         diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
       </p>
-      <p class="text-slate-500 text-sm mb-2">Was der Server nie sieht: Namen der Teilnehmer:innen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel.</p>
-      <p class="text-slate-500 text-sm">
+      <p class="text-slate-500 dark:text-slate-400 text-sm mb-2">Was der Server nie sieht: Namen der Teilnehmer:innen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel.</p>
+      <p class="text-slate-500 dark:text-slate-400 text-sm">
         Was der Server sehen kann: Anzahl der Einträge, Zeitpunkte der Einreichung, Existenz einer Runden-ID.
         Mehr dazu: <a href="/#wie-es-funktioniert" class="text-brand hover:text-brand-dark">Wie FairShare funktioniert</a>.
       </p>
@@ -44,24 +44,24 @@ import Layout from '../layouts/Layout.astro';
 
     <div>
       <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">4. Gespeicherte Daten</h2>
-      <p class="text-slate-500 text-sm mb-3">
+      <p class="text-slate-500 dark:text-slate-400 text-sm mb-3">
         FairShare speichert keine personenbezogenen Daten. Es gibt keine Nutzerkonten,
         keine E-Mail-Adressen und keine Tracking-Cookies. Runden-IDs sind zufällig generiert
         und enthalten keine personenbezogenen Informationen.
       </p>
-      <p class="text-slate-500 text-sm mb-3">
+      <p class="text-slate-500 dark:text-slate-400 text-sm mb-3">
         Gespeicherte Runden-Links werden ausschließlich in deinem Browser
-        (<code class="font-mono text-xs bg-slate-100 px-1 py-0.5 rounded">localStorage</code>)
+        (<code class="font-mono text-xs bg-slate-100 dark:bg-slate-700 dark:text-slate-300 px-1 py-0.5 rounded">localStorage</code>)
         gespeichert — nie auf dem Server.
       </p>
-      <p class="text-slate-500 text-sm">
-        Runden werden nach <strong class="text-slate-700">6 Monaten automatisch vom Server gelöscht</strong>.
+      <p class="text-slate-500 dark:text-slate-400 text-sm">
+        Runden werden nach <strong class="text-slate-700 dark:text-slate-200">6 Monaten automatisch vom Server gelöscht</strong>.
       </p>
     </div>
 
     <div>
       <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">5. Cookies &amp; Tracking</h2>
-      <p class="text-slate-500 text-sm">
+      <p class="text-slate-500 dark:text-slate-400 text-sm">
         FairShare setzt keine Tracking-Cookies und verwendet keine Analyse-Dienste.
         Es werden keine personenbezogenen Daten für Werbezwecke verarbeitet.
       </p>
@@ -69,7 +69,7 @@ import Layout from '../layouts/Layout.astro';
 
     <div>
       <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">6. Deine Rechte</h2>
-      <p class="text-slate-500 text-sm">
+      <p class="text-slate-500 dark:text-slate-400 text-sm">
         Du hast das Recht auf Auskunft, Berichtigung, Löschung und Einschränkung der Verarbeitung
         deiner personenbezogenen Daten sowie das Recht auf Datenübertragbarkeit.
         Da FairShare keine personenbezogenen Daten speichert, liegen in aller Regel keine

--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -5,7 +5,7 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Impressum">
   <h1 class="text-3xl font-bold mb-10">Impressum</h1>
 
-  <div class="space-y-8 text-slate-700 leading-relaxed">
+  <div class="space-y-8 text-slate-700 dark:text-slate-300 leading-relaxed">
     <div>
       <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">Angaben gemäß § 5 TMG</h2>
       <p>
@@ -34,7 +34,7 @@ import Layout from '../layouts/Layout.astro';
 
     <div>
       <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">Haftungsausschluss</h2>
-      <p class="text-slate-500 text-sm">
+      <p class="text-slate-500 dark:text-slate-400 text-sm">
         Die Inhalte dieser Website wurden mit größtmöglicher Sorgfalt erstellt.
         Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen.
       </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,10 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Solidarische Gruppenfinanzierung" fullWidth>
   <section class="w-full min-h-[80vh] flex items-center justify-center px-6 py-32">
     <div class="max-w-3xl mx-auto text-center space-y-8">
-      <h1 class="text-[clamp(2rem,8vw,3.75rem)] font-bold leading-tight tracking-tight text-slate-900">
+      <h1 class="text-[clamp(2rem,8vw,3.75rem)] font-bold leading-tight tracking-tight text-slate-900 dark:text-slate-100">
         Teile Kosten solidarisch. Zahle, was du kannst.
       </h1>
-      <p class="text-xl text-slate-500 max-w-xl mx-auto leading-relaxed">
+      <p class="text-xl text-slate-500 dark:text-slate-400 max-w-xl mx-auto leading-relaxed">
         FairShare hilft Gruppen, Kosten fair aufzuteilen. Jede Person gibt ihr Gebot ab — anonym und verschlüsselt.
       </p>
       <div class="flex flex-col items-center gap-3">
@@ -21,7 +21,7 @@ import Layout from '../layouts/Layout.astro';
         <a
           id="cta-meine-runden"
           href="/meine-runden"
-          class="hidden items-center gap-2 text-sm text-slate-500 hover:text-slate-800 transition-colors px-4 py-2"
+          class="hidden items-center gap-2 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors px-4 py-2"
         >
           Meine gespeicherten Runden →
         </a>
@@ -33,11 +33,11 @@ import Layout from '../layouts/Layout.astro';
     <div class="mx-auto max-w-2xl px-6 space-y-6">
       <p data-animate class="text-sm font-semibold text-slate-400 tracking-widest uppercase">Wie es funktioniert</p>
 
-      <div class="rounded-xl border border-slate-200 bg-white p-6">
-        <h2 class="text-lg font-semibold text-slate-900 mb-2">Zero-Knowledge-Prinzip</h2>
-        <p class="text-sm text-slate-600 leading-relaxed mb-4">
+      <div class="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
+        <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">Zero-Knowledge-Prinzip</h2>
+        <p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed mb-4">
           Alle Inhalte werden im Browser verschlüsselt, bevor sie den Server erreichen.
-          Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-slate-100 px-1 py-0.5 rounded">#…</code>)
+          Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-slate-100 dark:bg-slate-700 dark:text-slate-300 px-1 py-0.5 rounded">#…</code>)
           — diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
           Die App folgt dem <strong>Zero-Knowledge-Prinzip</strong>: mit einigen
           bewussten Einschränkungen, die wir transparent machen.
@@ -47,41 +47,41 @@ import Layout from '../layouts/Layout.astro';
             <span class="transition-transform group-open:rotate-90 inline-block">›</span>
             Was der Server theoretisch inferieren kann (Threat Model)
           </summary>
-          <div class="mt-3 text-sm text-slate-600 space-y-3 pl-4 border-l-2 border-slate-200">
+          <div class="mt-3 text-sm text-slate-600 dark:text-slate-400 space-y-3 pl-4 border-l-2 border-slate-200 dark:border-slate-700">
             <div>
-              <p class="font-medium text-slate-800">Anzahl der Teilnehmer:innen</p>
+              <p class="font-medium text-slate-800 dark:text-slate-200">Anzahl der Teilnehmer:innen</p>
               <p class="mt-0.5">Jedes Gebot ist ein separater verschlüsselter Eintrag im Server-Store — der Server kann Einträge zählen und so die ungefähre Teilnehmerzahl inferieren.</p>
             </div>
             <div>
-              <p class="font-medium text-slate-800">Zeitpunkte der Gebots-Einreichung</p>
+              <p class="font-medium text-slate-800 dark:text-slate-200">Zeitpunkte der Gebots-Einreichung</p>
               <p class="mt-0.5">Der Server sieht, wann ein Gebot einging. Muster (z.&nbsp;B. alle binnen 5 Minuten) können auf Gruppenverhalten hindeuten.</p>
             </div>
             <div>
-              <p class="font-medium text-slate-800">Existenz einer Runde</p>
+              <p class="font-medium text-slate-800 dark:text-slate-200">Existenz einer Runde</p>
               <p class="mt-0.5">Eine Runden-ID existiert auf dem Server und ist aktiv oder nicht — ohne Klartext-Bezug zum Inhalt.</p>
             </div>
             <div class="pt-1">
-              <p class="font-medium text-slate-800">Was der Server <em>nicht</em> sieht</p>
+              <p class="font-medium text-slate-800 dark:text-slate-200">Was der Server <em>nicht</em> sieht</p>
               <p class="mt-0.5">Namen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel — all das bleibt verschlüsselt.</p>
             </div>
           </div>
         </details>
       </div>
 
-      <div class="rounded-xl border border-slate-200 bg-white p-6">
-        <h2 class="text-lg font-semibold text-slate-900 mb-2">Vertrauen in die Organisator:in</h2>
-        <p class="text-sm text-slate-600 leading-relaxed mb-3">
+      <div class="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
+        <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">Vertrauen in die Organisator:in</h2>
+        <p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed mb-3">
           Die App ist <strong>kein Zero-Trust-System</strong>. Die Organisator:in hat den
           privaten Admin-Schlüssel und kann damit technisch alle Gebote entschlüsseln —
           das Frontend zeigt ihr nur die Auswertungstabelle, aber der Zugriff auf Rohwerte
           wäre im Code möglich.
         </p>
-        <p class="text-sm text-slate-600 leading-relaxed mb-3">
+        <p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed mb-3">
           Teilnehmer:innen hingegen können <strong>keine</strong> Gebote anderer sehen:
           Gebote sind mit dem öffentlichen Admin-Schlüssel verschlüsselt und nur mit dem
           privaten Schlüssel der Organisator:in lesbar.
         </p>
-        <p class="text-sm text-slate-500 leading-relaxed">
+        <p class="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">
           Vertrauen in die Organisator:in ist Teil des Modells — vergleichbar mit einer
           Kassenprüfer:in in einer Genossenschaft: Kontrolle durch Transparenz, nicht durch
           technische Sperre.

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -12,16 +12,16 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       </div>
       <details class="relative">
         <summary class="cursor-pointer text-slate-400 hover:text-slate-600 transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
-        <div class="absolute right-0 top-9 bg-white border border-slate-200 rounded-xl shadow-lg z-10 min-w-36 p-1">
+        <div class="absolute right-0 top-9 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg z-10 min-w-36 p-1">
           <button
             id="export-btn"
-            class="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 rounded-lg transition-colors"
+            class="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 rounded-lg transition-colors"
           >
             Exportieren
           </button>
           <button
             id="import-btn"
-            class="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 rounded-lg transition-colors"
+            class="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 rounded-lg transition-colors"
           >
             Importieren
           </button>
@@ -82,11 +82,11 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     for (const runde of runden) {
       const istAdmin = !!runde.adminLink;
       const karte = document.createElement('div');
-      karte.className = 'bg-white border border-slate-200 rounded-xl p-4 space-y-3';
+      karte.className = 'bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-4 space-y-3';
 
       const badge = istAdmin
-        ? '<span class="text-xs font-medium text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">Admin</span>'
-        : '<span class="text-xs font-medium text-slate-600 bg-slate-100 px-2 py-0.5 rounded-full">Teilnehmer:in</span>';
+        ? '<span class="text-xs font-medium text-amber-700 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 rounded-full">Admin</span>'
+        : '<span class="text-xs font-medium text-slate-600 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 px-2 py-0.5 rounded-full">Teilnehmer:in</span>';
 
       karte.innerHTML = `
         <div class="flex items-start justify-between gap-2">
@@ -101,14 +101,14 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         <div class="flex flex-wrap items-center gap-2">
           <a
             href="${runde.teilnehmerLink}"
-            class="inline-flex items-center gap-1 border border-slate-300 rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
+            class="inline-flex items-center gap-1 border border-slate-300 dark:border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
           >
             Runde öffnen ↗
           </a>
           ${istAdmin ? `
           <a
             href="${runde.adminLink}"
-            class="inline-flex items-center gap-1 border border-amber-300 rounded-lg px-3 py-1.5 text-sm text-amber-700 hover:bg-amber-50 transition-colors"
+            class="inline-flex items-center gap-1 border border-amber-300 dark:border-amber-700 rounded-lg px-3 py-1.5 text-sm text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/30 transition-colors"
           >
             Admin öffnen ↗
           </a>

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -8,10 +8,10 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-2xl font-semibold mb-1">Meine Runden</h1>
-        <p class="text-slate-500 text-sm">Gespeichert in deinem Browser.</p>
+        <p class="text-slate-500 dark:text-slate-400 text-sm">Gespeichert in deinem Browser.</p>
       </div>
       <details class="relative">
-        <summary class="cursor-pointer text-slate-400 hover:text-slate-600 transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
+        <summary class="cursor-pointer text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
         <div class="absolute right-0 top-9 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg z-10 min-w-36 p-1">
           <button
             id="export-btn"
@@ -33,7 +33,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <FeedbackBox id="import-fehler" />
 
     <!-- Leer-Zustand -->
-    <div id="leer-zustand" class="hidden text-center py-16 text-slate-500">
+    <div id="leer-zustand" class="hidden text-center py-16 text-slate-500 dark:text-slate-400">
       <p class="mb-4">Noch keine Runden gespeichert.</p>
       <a href="/neu" class="inline-block bg-brand text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-brand-dark transition-colors">
         Neue Runde erstellen
@@ -93,9 +93,9 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           <div class="space-y-1">
             <div class="flex items-center gap-2 flex-wrap">
               ${badge}
-              <span class="text-sm font-medium text-slate-800">${runde.name}</span>
+              <span class="text-sm font-medium text-slate-800 dark:text-slate-200">${runde.name}</span>
             </div>
-            <p class="text-xs text-slate-400">Hinzugefügt am ${formatDatum(runde.hinzugefuegtAm)}</p>
+            <p class="text-xs text-slate-400 dark:text-slate-500">Hinzugefügt am ${formatDatum(runde.hinzugefuegtAm)}</p>
           </div>
         </div>
         <div class="flex flex-wrap items-center gap-2">

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -10,10 +10,10 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       <h1 class="text-2xl font-semibold">Neue Runde erstellen</h1>
       <div class="relative">
         <button id="power-menu-btn" type="button" aria-label="Weitere Optionen" aria-expanded="false"
-          class="text-slate-400 hover:text-slate-600 text-xl leading-none px-2 py-1 rounded hover:bg-slate-100 transition-colors">…</button>
-        <div id="power-menu" class="hidden absolute right-0 mt-1 w-52 bg-white border border-slate-200 rounded-lg shadow-lg z-10 py-1">
+          class="text-slate-400 hover:text-slate-600 text-xl leading-none px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">…</button>
+        <div id="power-menu" class="hidden absolute right-0 mt-1 w-52 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg z-10 py-1">
           <button id="splid-import-btn" type="button"
-            class="w-full text-left text-sm px-4 py-2 hover:bg-slate-50 transition-colors">Abrechnung importieren</button>
+            class="w-full text-left text-sm px-4 py-2 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors">Abrechnung importieren</button>
         </div>
       </div>
     </div>
@@ -24,7 +24,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <form id="runde-form" class="space-y-6">
       <!-- Runden-Name -->
       <div>
-        <label for="rundeName" class="block text-sm font-medium text-slate-700 mb-1">
+        <label for="rundeName" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
           Name der Runde
         </label>
         <input
@@ -33,7 +33,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           name="rundeName"
           required
           placeholder="z.B. Haushaltskasse Oktober"
-          class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
         />
       </div>
 
@@ -49,14 +49,14 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           name="gesamtkosten"
           required
           placeholder="z.B. 1200"
-          class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
         />
       </div>
 
       <!-- Personen -->
       <div>
         <div class="flex items-center justify-between mb-2">
-          <label class="block text-sm font-medium text-slate-700">Personen</label>
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300">Personen</label>
           <div class="flex items-center gap-3">
             <button
               type="button"
@@ -69,13 +69,13 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         </div>
         <div id="slots-container" class="space-y-2">
           <!-- Initial ein Slot -->
-          <div class="slot-eintrag bg-white border border-slate-200 rounded-lg p-3 space-y-2">
+          <div class="slot-eintrag bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3 space-y-2">
             <div class="flex items-center gap-2 min-w-0">
               <input
                 type="text"
                 name="label[]"
                 placeholder="Erwachsen"
-                class="min-w-0 flex-1 border border-slate-300 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+                class="min-w-0 flex-1 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
               />
               <!-- Ausgaben inline (nur sichtbar wenn Toggle aktiv) -->
               <div class="ausgaben-inline hidden flex items-center gap-1 shrink-0">
@@ -85,7 +85,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                   inputmode="decimal"
                   name="ausgaben[]"
                   placeholder="0,00"
-                  class="w-20 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                  class="w-20 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                 />
               </div>
               <button
@@ -98,17 +98,17 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 
             <!-- Erweiterte Optionen (eingeklappt) -->
             <details class="slot-erweitert-details">
-              <summary class="text-xs text-slate-400 cursor-pointer hover:text-slate-600 transition-colors select-none list-none flex items-center gap-1">
+              <summary class="text-xs text-slate-400 dark:text-slate-500 cursor-pointer hover:text-slate-600 dark:hover:text-slate-300 transition-colors select-none list-none flex items-center gap-1">
                 <span class="inline-block transition-transform details-arrow">›</span> Erweitert
               </summary>
               <div class="pt-3 space-y-3">
                 <!-- Gewichtungs-Kategorien -->
                 <div class="slot-gewichtung-gruppe">
-                  <p class="text-xs text-slate-500 mb-1.5">Gewichtung</p>
+                  <p class="text-xs text-slate-500 dark:text-slate-400 mb-1.5">Gewichtung</p>
                   <div class="flex flex-wrap gap-1.5">
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="1.0" checked />
-                      <span class="slot-gewichtung-badge inline-block border border-slate-200 rounded-md px-2.5 py-1 text-xs text-slate-600 hover:border-green-500 transition-colors selected:border-green-600 selected:bg-green-50 selected:text-green-800">Erwachsen</span>
+                      <span class="slot-gewichtung-badge inline-block border border-slate-200 dark:border-slate-600 rounded-md px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-green-500 transition-colors">Erwachsen</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.75" />
@@ -124,7 +124,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                     </label>
                     <input
                       type="number"
-                      class="slot-gewichtung-manuell w-16 border border-slate-300 rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="slot-gewichtung-manuell w-16 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-green-600"
                       min="0.1"
                       max="2"
                       step="0.05"
@@ -137,7 +137,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                 </div>
                 <!-- Anzahl -->
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-slate-500">Anzahl</span>
+                  <span class="text-xs text-slate-500 dark:text-slate-400">Anzahl</span>
                   <input
                     type="number"
                     name="anzahl[]"
@@ -145,12 +145,12 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                     min="1"
                     step="1"
                     required
-                    class="w-16 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
+                    class="w-16 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
                   />
                 </div>
                 <!-- Standardgebot -->
                 <div class="standardgebot-zeile flex items-center gap-2 flex-wrap">
-                  <label class="flex items-center gap-1 text-xs text-slate-500 cursor-pointer select-none">
+                  <label class="flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400 cursor-pointer select-none">
                     <input type="checkbox" class="standardgebot-checkbox accent-green-700" />
                     Standardgebot festlegen
                   </label>
@@ -160,7 +160,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       inputmode="decimal"
                       name="standardgebot[]"
                       data-auto="true"
-                      class="w-28 border border-slate-300 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="w-28 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                     />
                   </div>
                 </div>
@@ -200,16 +200,16 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     </div>
 
     <!-- Teilnehmer-Link (primär) -->
-    <div class="bg-white border border-brand/30 rounded-xl p-5 space-y-3">
+    <div class="bg-white dark:bg-slate-800 border border-brand/30 dark:border-brand/40 rounded-xl p-5 space-y-3">
       <div>
-        <p class="text-sm font-semibold text-slate-900">Teilnehmer:innen-Link</p>
-        <p class="text-xs text-slate-500 mt-0.5">Diesen Link mit allen Teilnehmenden teilen</p>
+        <p class="text-sm font-semibold text-slate-900 dark:text-slate-100">Teilnehmer:innen-Link</p>
+        <p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">Diesen Link mit allen Teilnehmenden teilen</p>
       </div>
       <input
         id="teilnehmer-link"
         type="text"
         readonly
-        class="w-full border border-slate-200 rounded-md px-2 py-1.5 text-xs text-slate-600 bg-slate-50 font-mono"
+        class="w-full border border-slate-200 dark:border-slate-600 rounded-md px-2 py-1.5 text-xs text-slate-600 dark:text-slate-300 bg-slate-50 dark:bg-slate-700 font-mono"
       />
       <div class="flex gap-2">
         <button
@@ -223,7 +223,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           href="#"
           target="_blank"
           rel="noopener"
-          class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 transition-colors whitespace-nowrap"
+          class="border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-2 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors whitespace-nowrap"
         >
           Öffnen ↗
         </a>
@@ -231,21 +231,21 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     </div>
 
     <!-- Admin-Link (sekundär) -->
-    <div class="bg-amber-50 border border-amber-200 rounded-xl p-5 space-y-3">
+    <div class="bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded-xl p-5 space-y-3">
       <div>
-        <p class="text-sm font-semibold text-amber-900">⚠ Admin-Link</p>
-        <p class="text-xs text-amber-700 mt-0.5">Nur für dich — sicher aufbewahren</p>
+        <p class="text-sm font-semibold text-amber-900 dark:text-amber-300">⚠ Admin-Link</p>
+        <p class="text-xs text-amber-700 dark:text-amber-400 mt-0.5">Nur für dich — sicher aufbewahren</p>
       </div>
       <input
         id="admin-link"
         type="text"
         readonly
-        class="w-full border border-amber-300 rounded-md px-2 py-1.5 text-xs text-amber-900 bg-amber-100 font-mono"
+        class="w-full border border-amber-300 dark:border-amber-700 rounded-md px-2 py-1.5 text-xs text-amber-900 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 font-mono"
       />
       <div class="flex gap-2">
         <button
           id="copy-admin"
-          class="flex-1 border border-amber-300 rounded-lg px-4 py-2 text-sm text-amber-800 hover:bg-amber-200 transition-colors"
+          class="flex-1 border border-amber-300 dark:border-amber-700 rounded-lg px-4 py-2 text-sm text-amber-800 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors"
         >
           Kopieren
         </button>
@@ -254,12 +254,12 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           href="#"
           target="_blank"
           rel="noopener"
-          class="border border-amber-300 rounded-lg px-4 py-2 text-sm text-amber-800 hover:bg-amber-200 transition-colors whitespace-nowrap"
+          class="border border-amber-300 dark:border-amber-700 rounded-lg px-4 py-2 text-sm text-amber-800 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors whitespace-nowrap"
         >
           Öffnen ↗
         </a>
       </div>
-      <p class="text-xs text-amber-700">
+      <p class="text-xs text-amber-700 dark:text-amber-400">
         Dieser Link enthält deinen privaten Schlüssel. Wer ihn hat, kann alle Gebote einsehen.
       </p>
     </div>
@@ -273,18 +273,6 @@ import FeedbackBox from '../components/FeedbackBox.astro';
   </div>
 </Layout>
 
-<style>
-  /* Aktiver Zustand für Gewichtungs-Badges */
-  .slot-gewichtung-radio:checked + .slot-gewichtung-badge {
-    border-color: #3B6D11;
-    background-color: #f0f7eb;
-    color: #27500A;
-  }
-  /* Details-Pfeil drehen wenn offen */
-  details[open] .details-arrow {
-    transform: rotate(90deg);
-  }
-</style>
 
 <script>
   import {

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -39,7 +39,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 
       <!-- Gesamtkosten -->
       <div>
-        <label for="gesamtkosten" class="block text-sm font-medium text-slate-700 mb-1">
+        <label for="gesamtkosten" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
           Gesamtkosten (€)
         </label>
         <input
@@ -79,7 +79,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
               />
               <!-- Ausgaben inline (nur sichtbar wenn Toggle aktiv) -->
               <div class="ausgaben-inline hidden flex items-center gap-1 shrink-0">
-                <span class="text-xs text-slate-400">€</span>
+                <span class="text-xs text-slate-400 dark:text-slate-500">€</span>
                 <input
                   type="text"
                   inputmode="decimal"
@@ -90,11 +90,11 @@ import FeedbackBox from '../components/FeedbackBox.astro';
               </div>
               <button
                 type="button"
-                class="slot-entfernen shrink-0 text-slate-400 hover:text-red-500 text-lg leading-none hidden"
+                class="slot-entfernen shrink-0 text-slate-400 dark:text-slate-600 hover:text-red-500 text-lg leading-none hidden"
                 aria-label="Slot entfernen"
               >×</button>
             </div>
-            <span class="standardgebot-richtwert text-xs text-slate-400"></span>
+            <span class="standardgebot-richtwert text-xs text-slate-400 dark:text-slate-500"></span>
 
             <!-- Erweiterte Optionen (eingeklappt) -->
             <details class="slot-erweitert-details">
@@ -112,15 +112,15 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.75" />
-                      <span class="slot-gewichtung-badge inline-block border border-slate-200 rounded-md px-2.5 py-1 text-xs text-slate-600 hover:border-green-500 transition-colors">Ermäßigt</span>
+                      <span class="slot-gewichtung-badge inline-block border border-slate-200 dark:border-slate-600 rounded-md px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-green-500 transition-colors">Ermäßigt</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.5" />
-                      <span class="slot-gewichtung-badge inline-block border border-slate-200 rounded-md px-2.5 py-1 text-xs text-slate-600 hover:border-green-500 transition-colors">Kind</span>
+                      <span class="slot-gewichtung-badge inline-block border border-slate-200 dark:border-slate-600 rounded-md px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-green-500 transition-colors">Kind</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="manuell" />
-                      <span class="slot-gewichtung-badge inline-block border border-slate-200 rounded-md px-2.5 py-1 text-xs text-slate-600 hover:border-green-500 transition-colors">Manuell</span>
+                      <span class="slot-gewichtung-badge inline-block border border-slate-200 dark:border-slate-600 rounded-md px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-green-500 transition-colors">Manuell</span>
                     </label>
                     <input
                       type="number"
@@ -172,7 +172,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           type="button"
           id="ausgaben-link"
           aria-expanded="false"
-          class="text-xs text-slate-400 hover:text-slate-600 mt-1 transition-colors"
+          class="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 mt-1 transition-colors"
         >+ Ausgaben erfassen</button>
       </div>
 
@@ -195,8 +195,8 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <!-- Header -->
     <div class="text-center pt-4 pb-2">
       <div class="text-5xl text-brand mb-3">✓</div>
-      <h1 class="text-2xl font-bold text-slate-900 mb-1">Runde erstellt!</h1>
-      <p class="text-sm text-slate-500">Speichere beide Links — sie werden hier nicht erneut angezeigt.</p>
+      <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-1">Runde erstellt!</h1>
+      <p class="text-sm text-slate-500 dark:text-slate-400">Speichere beide Links — sie werden hier nicht erneut angezeigt.</p>
     </div>
 
     <!-- Teilnehmer-Link (primär) -->
@@ -266,7 +266,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 
     <a
       href="/neu"
-      class="block text-center text-sm text-slate-500 hover:text-slate-700 transition-colors"
+      class="block text-center text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
     >
       Weitere Runde erstellen →
     </a>

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -5,7 +5,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
 <Layout title="Runde">
   <!-- Laden -->
-  <div id="zustand-laden" class="text-center py-12 text-slate-500 text-sm">
+  <div id="zustand-laden" class="text-center py-12 text-slate-500 dark:text-slate-400 text-sm">
     Lade Runde…
   </div>
 
@@ -64,7 +64,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             placeholder="z.B. 80"
             class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
-          <p id="betrag-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
+          <p id="betrag-richtwert-hinweis" class="text-xs text-slate-400 dark:text-slate-500 mt-1"></p>
         </div>
 
         <!-- Fehler -->
@@ -99,7 +99,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         </button>
 
         <p class="text-center mt-1">
-          <button type="button" id="korrektur-link-btn" class="text-xs text-slate-400 hover:text-slate-600 underline transition-colors">
+          <button type="button" id="korrektur-link-btn" class="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 underline transition-colors">
             Gebot von anderem Gerät korrigieren →
           </button>
         </p>
@@ -351,12 +351,16 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       const istAbgeben = tab === 'abgeben';
       tabAbgeben.classList.toggle('border-green-600', istAbgeben);
       tabAbgeben.classList.toggle('text-green-700', istAbgeben);
+      tabAbgeben.classList.toggle('dark:text-green-400', istAbgeben);
       tabAbgeben.classList.toggle('border-transparent', !istAbgeben);
       tabAbgeben.classList.toggle('text-slate-500', !istAbgeben);
+      tabAbgeben.classList.toggle('dark:text-slate-400', !istAbgeben);
       tabKorrigieren.classList.toggle('border-green-600', !istAbgeben);
       tabKorrigieren.classList.toggle('text-green-700', !istAbgeben);
+      tabKorrigieren.classList.toggle('dark:text-green-400', !istAbgeben);
       tabKorrigieren.classList.toggle('border-transparent', istAbgeben);
       tabKorrigieren.classList.toggle('text-slate-500', istAbgeben);
+      tabKorrigieren.classList.toggle('dark:text-slate-400', istAbgeben);
       panelAbgeben.classList.toggle('hidden', !istAbgeben);
       panelKorrigieren.classList.toggle('hidden', istAbgeben);
     }

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -111,7 +111,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       <form id="korrektur-form" class="space-y-5">
         <!-- Emoji-ID -->
         <div>
-          <label for="korrektur-emoji" class="block text-sm font-medium text-slate-700 mb-1">
+          <label for="korrektur-emoji" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
             Deine Emoji-ID
           </label>
           <input
@@ -127,14 +127,14 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Slot</p>
+          <p class="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Slot</p>
           <div id="slot-auswahl-korrektur" class="space-y-2"></div>
           <p id="korrektur-slot-hinweis" class="text-xs mt-1"></p>
         </div>
 
         <!-- Betrag -->
         <div>
-          <label for="korrektur-betrag" class="block text-sm font-medium text-slate-700 mb-1">
+          <label for="korrektur-betrag" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
             Neues Gebot (€)
           </label>
           <input
@@ -288,12 +288,12 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         const bereitsGeboten = slotBereitsGeboten(slot.label);
         const label = document.createElement('label');
         label.className =
-          'flex items-center gap-3 bg-white border border-slate-200 rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 transition-colors';
+          'flex items-center gap-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 dark:has-[:checked]:bg-green-950/40 transition-colors';
         label.innerHTML = `
           <input type="radio" name="${nameAttr}" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
           <span class="flex-1">
-            <span class="text-sm font-medium text-slate-800">${slot.label}</span>
-            <span class="text-xs text-slate-500 ml-2">Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
+            <span class="text-sm font-medium text-slate-800 dark:text-slate-200">${slot.label}</span>
+            <span class="text-xs text-slate-500 dark:text-slate-400 ml-2">Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
             ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-green-600 ml-1 text-xs">✓ abgegeben</span>' : ''}
           </span>
         `;

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -10,7 +10,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   </div>
 
   <!-- Fehler -->
-  <div id="zustand-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-xl p-5">
+  <div id="zustand-fehler" class="hidden bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-xl p-5">
     <p class="font-medium mb-1">Fehler</p>
     <p id="fehler-text" class="text-sm"></p>
   </div>
@@ -19,22 +19,22 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   <div id="zustand-formular" class="hidden space-y-6">
     <div>
       <h1 id="runde-name" class="text-2xl font-semibold mb-1"></h1>
-      <p class="text-slate-500 text-sm">
-        Gesamtkosten: <span id="gesamtkosten" class="font-medium text-slate-700"></span>
+      <p class="text-slate-500 dark:text-slate-400 text-sm">
+        Gesamtkosten: <span id="gesamtkosten" class="font-medium text-slate-700 dark:text-slate-200"></span>
       </p>
     </div>
 
     <!-- Tab-Navigation -->
-    <div class="flex border-b border-slate-200">
+    <div class="flex border-b border-slate-200 dark:border-slate-700">
       <button
         id="tab-abgeben"
-        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-green-700 -mb-px transition-colors"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-green-700 dark:text-green-400 -mb-px transition-colors"
       >
         Gebot abgeben
       </button>
       <button
         id="tab-korrigieren"
-        class="hidden px-4 py-2 text-sm font-medium border-b-2 border-transparent text-slate-500 -mb-px hover:text-slate-700 transition-colors"
+        class="hidden px-4 py-2 text-sm font-medium border-b-2 border-transparent text-slate-500 dark:text-slate-400 -mb-px hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
       >
         Gebot korrigieren
       </button>
@@ -45,13 +45,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       <form id="gebot-form" class="space-y-5">
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 mb-2">Wähle deinen Slot</p>
+          <p class="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Wähle deinen Slot</p>
           <div id="slot-auswahl" class="space-y-2"></div>
         </div>
 
         <!-- Betrag -->
         <div>
-          <label for="betrag" class="block text-sm font-medium text-slate-700 mb-1">
+          <label for="betrag" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
             Dein Gebot (€)
           </label>
           <input
@@ -62,7 +62,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
-            class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
           <p id="betrag-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
         </div>
@@ -71,20 +71,20 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         <FeedbackBox id="gebot-fehler" />
 
         <!-- Duplikat-Warnung Two-Step (Soft-Warning, kein Hard-Block) -->
-        <div id="duplikat-warnung" class="hidden bg-amber-50 border border-amber-300 text-amber-800 rounded-lg p-3 text-sm">
+        <div id="duplikat-warnung" class="hidden bg-amber-50 dark:bg-amber-950/50 border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-300 rounded-lg p-3 text-sm">
           <!-- Schritt 1 -->
           <div id="duplikat-schritt1">
             <p class="font-medium">Du hast für diesen Slot bereits geboten.</p>
             <div class="flex gap-2 pt-2">
-              <button type="button" id="duplikat-abbrechen" class="border border-amber-400 text-amber-800 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 transition-colors">Abbrechen</button>
-              <button type="button" id="duplikat-weiter" class="border border-amber-500 bg-amber-100 text-amber-900 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 transition-colors">Fortfahren →</button>
+              <button type="button" id="duplikat-abbrechen" class="border border-amber-400 dark:border-amber-700 text-amber-800 dark:text-amber-300 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-100 dark:hover:bg-amber-900/40 transition-colors">Abbrechen</button>
+              <button type="button" id="duplikat-weiter" class="border border-amber-500 dark:border-amber-600 bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors">Fortfahren →</button>
             </div>
           </div>
           <!-- Schritt 2 -->
           <div id="duplikat-schritt2" class="hidden">
             <p class="text-sm text-amber-800">Was möchtest du tun?</p>
             <div class="flex gap-2 pt-2 flex-wrap">
-              <button type="button" id="duplikat-korrigieren" class="border border-amber-500 bg-amber-100 text-amber-900 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 transition-colors">Gebot korrigieren</button>
+              <button type="button" id="duplikat-korrigieren" class="border border-amber-500 dark:border-amber-600 bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200 rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors">Gebot korrigieren</button>
               <button type="button" id="duplikat-bestaetigen" class="bg-amber-600 text-white rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-700 transition-colors">Zweites Gebot abgeben</button>
             </div>
           </div>
@@ -120,9 +120,9 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             name="emojiId"
             required
             placeholder="z.B. 🦊🌙⭐"
-            class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
-          <p class="text-xs text-slate-400 mt-1">Die 3 Emojis, die dir beim Abgeben angezeigt wurden.</p>
+          <p class="text-xs text-slate-400 dark:text-slate-500 mt-1">Die 3 Emojis, die dir beim Abgeben angezeigt wurden.</p>
         </div>
 
         <!-- Slot-Auswahl -->
@@ -145,7 +145,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
-            class="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
           <p id="korrektur-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
         </div>
@@ -167,9 +167,9 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   <!-- Bestätigung -->
   <div id="zustand-bestaetigung" class="hidden text-center space-y-4 py-8">
     <h2 id="bestaetigung-titel" class="text-xl font-semibold">Gebot abgegeben</h2>
-    <p id="bestaetigung-text" class="text-slate-500 text-sm max-w-sm mx-auto"></p>
+    <p id="bestaetigung-text" class="text-slate-500 dark:text-slate-400 text-sm max-w-sm mx-auto"></p>
     <div id="emoji-anzeige" class="text-6xl tracking-widest mb-2"></div>
-    <p class="text-xs text-slate-500">Deine Emoji-ID</p>
+    <p class="text-xs text-slate-500 dark:text-slate-400">Deine Emoji-ID</p>
   </div>
 </Layout>
 

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -10,7 +10,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   </div>
 
   <!-- Fehler -->
-  <div id="zustand-fehler" class="hidden bg-red-50 border border-red-200 text-red-700 rounded-xl p-5">
+  <div id="zustand-fehler" class="hidden bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-xl p-5">
     <p class="font-medium mb-1">Fehler</p>
     <p id="fehler-text" class="text-sm"></p>
   </div>
@@ -19,19 +19,19 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   <div id="zustand-auswertung" class="hidden space-y-8 print:space-y-4">
     <div class="print:mb-2">
       <h1 id="runde-name" class="text-2xl font-semibold mb-1 print:text-xl"></h1>
-      <p class="text-slate-500 text-sm print:text-xs">
+      <p class="text-slate-500 dark:text-slate-400 text-sm print:text-xs">
         Admin-Auswertung · alle Daten wurden lokal entschlüsselt
       </p>
     </div>
 
     <!-- Kennzahlen -->
     <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 print:grid-cols-3 print:gap-2">
-      <div class="bg-white border border-slate-200 rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-slate-500 mb-0.5">Gesamtkosten</p>
+      <div class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-3 print:rounded-md print:p-2">
+        <p class="text-xs text-slate-500 dark:text-slate-400 mb-0.5">Gesamtkosten</p>
         <p id="kz-gesamtkosten" class="text-lg font-semibold print:text-base"></p>
       </div>
-      <div class="bg-white border border-slate-200 rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-slate-500 mb-0.5">Richtwert / Einheit</p>
+      <div class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-3 print:rounded-md print:p-2">
+        <p class="text-xs text-slate-500 dark:text-slate-400 mb-0.5">Richtwert / Einheit</p>
         <p id="kz-richtwert" class="text-lg font-semibold print:text-base"></p>
       </div>
       <div class="vollstaendig-spalte hidden bg-white border border-slate-200 rounded-xl p-3 print:rounded-md print:p-2">
@@ -41,10 +41,10 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
     </div>
 
     <!-- Duplikat-Warnung -->
-    <div id="duplikat-box" class="hidden bg-red-50 border border-red-200 rounded-xl p-4 print:rounded-md print:p-3">
-      <p class="text-sm font-medium text-red-800">⚠️ Zu viele Gebote — Auswertung nicht möglich</p>
-      <p class="text-xs text-red-700 mt-1 mb-2">Für folgende Slots sind mehr Gebote eingegangen als erwartet. Bitte kläre die Doppeleinreichung und bitte die betroffene Person, nicht nochmals zu bieten.</p>
-      <ul id="duplikat-liste" class="text-xs text-red-700 space-y-0.5 list-disc list-inside"></ul>
+    <div id="duplikat-box" class="hidden bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-xl p-4 print:rounded-md print:p-3">
+      <p class="text-sm font-medium text-red-800 dark:text-red-300">⚠️ Zu viele Gebote — Auswertung nicht möglich</p>
+      <p class="text-xs text-red-700 dark:text-red-400 mt-1 mb-2">Für folgende Slots sind mehr Gebote eingegangen als erwartet. Bitte kläre die Doppeleinreichung und bitte die betroffene Person, nicht nochmals zu bieten.</p>
+      <ul id="duplikat-liste" class="text-xs text-red-700 dark:text-red-400 space-y-0.5 list-disc list-inside"></ul>
     </div>
 
     <!-- Status-Banner -->
@@ -55,8 +55,8 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
     <!-- Ausgleichszahlungen -->
     <div id="ausgleich-section" class="hidden space-y-2">
-      <h2 class="text-sm font-medium text-slate-700 print:text-xs">Ausgleichszahlungen</h2>
-      <div id="ausgleich-liste" class="rounded-xl border border-slate-200 bg-white px-4 py-3 space-y-2 print:text-xs"></div>
+      <h2 class="text-sm font-medium text-slate-700 dark:text-slate-300 print:text-xs">Ausgleichszahlungen</h2>
+      <div id="ausgleich-liste" class="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-4 py-3 space-y-2 print:text-xs"></div>
     </div>
 
     <!-- Status (klein, ergänzend zum Banner) -->
@@ -72,7 +72,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
       </button>
       <button
         id="wiederholen-btn"
-        class="border border-slate-300 rounded-lg px-4 py-2 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
+        class="border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-2 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
       >
         Runde wiederholen
       </button>
@@ -110,9 +110,9 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   function zeigeBanner(text: string, farbe: 'green' | 'amber' | 'red') {
     const banner = document.getElementById('status-banner')!;
     const farbenKlassen: Record<string, string> = {
-      green: 'bg-green-50 border border-green-200 text-green-800',
-      amber: 'bg-amber-50 border border-amber-200 text-amber-800',
-      red:   'bg-red-50 border border-red-200 text-red-800',
+      green: 'bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-300',
+      amber: 'bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300',
+      red:   'bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-300',
     };
     banner.className = `rounded-xl px-4 py-3 text-sm font-medium print:hidden ${farbenKlassen[farbe]}`;
     banner.textContent = text;
@@ -301,30 +301,30 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
       // Slot-Karte
       const karte = document.createElement('div');
-      karte.className = 'border border-slate-200 rounded-xl overflow-hidden bg-white';
+      karte.className = 'border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden bg-white dark:bg-slate-800';
 
       // Slot-Header-Farbe
       const headerBg = zuViele
-        ? 'bg-red-50 border-b border-red-200'
+        ? 'bg-red-50 dark:bg-red-950/50 border-b border-red-200 dark:border-red-800'
         : vollstaendig
-          ? 'bg-green-50 border-b border-green-200'
-          : 'bg-amber-50 border-b border-amber-200';
+          ? 'bg-green-50 dark:bg-green-950/50 border-b border-green-200 dark:border-green-800'
+          : 'bg-amber-50 dark:bg-amber-950/50 border-b border-amber-200 dark:border-amber-800';
       const headerTextFarbe = zuViele
-        ? 'text-red-800'
+        ? 'text-red-800 dark:text-red-300'
         : vollstaendig
-          ? 'text-green-800'
-          : 'text-amber-800';
+          ? 'text-green-800 dark:text-green-300'
+          : 'text-amber-800 dark:text-amber-300';
       const headerIcon = zuViele ? '⚠️' : vollstaendig ? '✓' : '○';
 
       karte.innerHTML = `
         <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 px-3 py-1.5 ${headerBg}">
           <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 min-w-0">
             <span class="text-sm font-semibold ${headerTextFarbe} shrink-0">${slot.label}</span>
-            <span class="text-xs text-slate-500 shrink-0">Faktor ${slot.gewichtung}x · ~${eur(richtwertAnteil)}</span>
+            <span class="text-xs text-slate-500 dark:text-slate-400 shrink-0">Faktor ${slot.gewichtung}x · ~${eur(richtwertAnteil)}</span>
           </div>
           <span class="text-xs font-semibold ${headerTextFarbe} shrink-0">${headerIcon} ${eingegangen}/${erwartet}${autoVollstaendig ? ' (auto)' : ''}</span>
         </div>
-        <div class="slot-zeilen divide-y divide-slate-100"></div>
+        <div class="slot-zeilen divide-y divide-slate-100 dark:divide-slate-700"></div>
       `;
 
       const zeilenContainer = karte.querySelector<HTMLDivElement>('.slot-zeilen')!;
@@ -338,32 +338,32 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         zeile.innerHTML = `
           <div class="flex items-center gap-2 w-full">
             <span class="text-base w-16 shrink-0">${g.emojiId}</span>
-            <span class="text-xs bg-green-100 text-green-700 rounded px-1.5 py-0.5 font-medium shrink-0">geboten</span>
+            <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">geboten</span>
             ${zeigeBeitraege && e ? `
-              <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Beitrag</span>
-              <span class="hidden sm:inline text-sm font-semibold text-slate-900 shrink-0">${eur(e.solidarischerBeitrag)}</span>
+              <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Beitrag</span>
+              <span class="hidden sm:inline text-sm font-semibold text-slate-900 dark:text-slate-100 shrink-0">${eur(e.solidarischerBeitrag)}</span>
             ` : ''}
             ${zeigeBeitraege && e && hatSplidDaten ? `
-              <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Ausgaben</span>
-              <span class="hidden sm:inline text-xs font-semibold text-slate-900 shrink-0">${eur(ausgaben)}</span>
-              <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Noch zu zahlen</span>
+              <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Ausgaben</span>
+              <span class="hidden sm:inline text-xs font-semibold text-slate-900 dark:text-slate-100 shrink-0">${eur(ausgaben)}</span>
+              <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Noch zu zahlen</span>
               <span class="hidden sm:inline text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${eur(e.solidarischerBeitrag - ausgaben)}</span>
             ` : ''}
-            <span class="ml-auto"><button class="loeschen-btn w-6 h-6 flex items-center justify-center rounded-full text-slate-300 hover:text-red-500 hover:bg-red-50 transition-colors" data-emoji-hmac="${emojiHmac}" data-slot="${slot.label}" aria-label="Gebot löschen">×</button></span>
+            <span class="ml-auto"><button class="loeschen-btn w-6 h-6 flex items-center justify-center rounded-full text-slate-300 dark:text-slate-600 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50 transition-colors" data-emoji-hmac="${emojiHmac}" data-slot="${slot.label}" aria-label="Gebot löschen">×</button></span>
           </div>
           ${zeigeBeitraege && e ? `
             <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
               <div class="flex justify-between items-baseline">
-                <span class="text-xs text-slate-400">Beitrag</span>
-                <span class="text-sm font-semibold text-slate-900">${eur(e.solidarischerBeitrag)}</span>
+                <span class="text-xs text-slate-400 dark:text-slate-500">Beitrag</span>
+                <span class="text-sm font-semibold text-slate-900 dark:text-slate-100">${eur(e.solidarischerBeitrag)}</span>
               </div>
               ${hatSplidDaten ? `
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-slate-400">Ausgaben</span>
-                  <span class="text-xs font-semibold text-slate-900">${eur(ausgaben)}</span>
+                  <span class="text-xs text-slate-400 dark:text-slate-500">Ausgaben</span>
+                  <span class="text-xs font-semibold text-slate-900 dark:text-slate-100">${eur(ausgaben)}</span>
                 </div>
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-slate-400">Noch zu zahlen</span>
+                  <span class="text-xs text-slate-400 dark:text-slate-500">Noch zu zahlen</span>
                   <span class="text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'}">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${eur(e.solidarischerBeitrag - ausgaben)}</span>
                 </div>
               ` : ''}
@@ -383,8 +383,8 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           zeile.className = 'flex flex-col px-3 py-1';
           zeile.innerHTML = `
             <div class="flex items-center gap-2 w-full">
-              <span class="text-base w-16 shrink-0 text-slate-300">—</span>
-              <span class="text-xs bg-green-100 text-green-700 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
+              <span class="text-base w-16 shrink-0 text-slate-300 dark:text-slate-600">—</span>
+              <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
               ${e ? `
                 <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Beitrag</span>
                 <span class="hidden sm:inline text-sm font-semibold text-slate-900 shrink-0">${eur(e.solidarischerBeitrag)}</span>
@@ -425,8 +425,8 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         const zeile = document.createElement('div');
         zeile.className = 'flex items-center gap-2 px-3 py-1';
         zeile.innerHTML = `
-          <span class="text-base w-16 shrink-0 text-slate-300">—</span>
-          <span class="text-xs bg-slate-100 text-slate-500 rounded px-1.5 py-0.5 shrink-0">fehlt</span>
+          <span class="text-base w-16 shrink-0 text-slate-300 dark:text-slate-600">—</span>
+          <span class="text-xs bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 rounded px-1.5 py-0.5 shrink-0">fehlt</span>
         `;
         zeilenContainer.appendChild(zeile);
       }
@@ -483,13 +483,13 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           const zeile = document.createElement('div');
           const vonLabel = emojiZuLabel.get(z.von) ?? z.von;
           const anLabel = emojiZuLabel.get(z.an) ?? z.an;
-          zeile.className = `grid items-center gap-x-3 text-sm${idx < zahlungen.length - 1 ? ' pb-2 border-b border-slate-100' : ''}`;
+          zeile.className = `grid items-center gap-x-3 text-sm${idx < zahlungen.length - 1 ? ' pb-2 border-b border-slate-100 dark:border-slate-700' : ''}`;
           zeile.style.gridTemplateColumns = '1fr auto 1fr auto';
           zeile.innerHTML = `
-            <span class="text-slate-700 text-right">${vonLabel}</span>
-            <span class="text-slate-400">→</span>
-            <span class="text-slate-700">${anLabel}</span>
-            <span class="font-semibold text-slate-900 text-right">${eur(z.betrag)}</span>
+            <span class="text-slate-700 dark:text-slate-300 text-right">${vonLabel}</span>
+            <span class="text-slate-400 dark:text-slate-500">→</span>
+            <span class="text-slate-700 dark:text-slate-300">${anLabel}</span>
+            <span class="font-semibold text-slate-900 dark:text-slate-100 text-right">${eur(z.betrag)}</span>
           `;
           liste.appendChild(zeile);
         });

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -34,8 +34,8 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         <p class="text-xs text-slate-500 dark:text-slate-400 mb-0.5">Richtwert / Einheit</p>
         <p id="kz-richtwert" class="text-lg font-semibold print:text-base"></p>
       </div>
-      <div class="vollstaendig-spalte hidden bg-white border border-slate-200 rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-slate-500 mb-0.5">Summe Beiträge</p>
+      <div class="vollstaendig-spalte hidden bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-3 print:rounded-md print:p-2">
+        <p class="text-xs text-slate-500 dark:text-slate-400 mb-0.5">Summe Beiträge</p>
         <p id="kz-summe-beitraege" class="text-lg font-semibold print:text-base"></p>
       </div>
     </div>
@@ -386,29 +386,29 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
               <span class="text-base w-16 shrink-0 text-slate-300 dark:text-slate-600">—</span>
               <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
               ${e ? `
-                <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Beitrag</span>
-                <span class="hidden sm:inline text-sm font-semibold text-slate-900 shrink-0">${eur(e.solidarischerBeitrag)}</span>
+                <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Beitrag</span>
+                <span class="hidden sm:inline text-sm font-semibold text-slate-900 dark:text-slate-100 shrink-0">${eur(e.solidarischerBeitrag)}</span>
               ` : ''}
               ${e && hatSplidDaten ? `
-                <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Ausgaben</span>
-                <span class="hidden sm:inline text-xs font-semibold text-slate-900 shrink-0">${eur(ausgaben)}</span>
-                <span class="hidden sm:inline text-xs text-slate-400 shrink-0">Noch zu zahlen</span>
+                <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Ausgaben</span>
+                <span class="hidden sm:inline text-xs font-semibold text-slate-900 dark:text-slate-100 shrink-0">${eur(ausgaben)}</span>
+                <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Noch zu zahlen</span>
                 <span class="hidden sm:inline text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${nochZuZahlen > 0 ? '+' : ''}${eur(nochZuZahlen)}</span>
               ` : ''}
             </div>
             ${e ? `
               <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-slate-400">Beitrag</span>
-                  <span class="text-sm font-semibold text-slate-900">${eur(e.solidarischerBeitrag)}</span>
+                  <span class="text-xs text-slate-400 dark:text-slate-500">Beitrag</span>
+                  <span class="text-sm font-semibold text-slate-900 dark:text-slate-100">${eur(e.solidarischerBeitrag)}</span>
                 </div>
                 ${hatSplidDaten ? `
                   <div class="flex justify-between items-baseline">
-                    <span class="text-xs text-slate-400">Ausgaben</span>
-                    <span class="text-xs font-semibold text-slate-900">${eur(ausgaben)}</span>
+                    <span class="text-xs text-slate-400 dark:text-slate-500">Ausgaben</span>
+                    <span class="text-xs font-semibold text-slate-900 dark:text-slate-100">${eur(ausgaben)}</span>
                   </div>
                   <div class="flex justify-between items-baseline">
-                    <span class="text-xs text-slate-400">Noch zu zahlen</span>
+                    <span class="text-xs text-slate-400 dark:text-slate-500">Noch zu zahlen</span>
                     <span class="text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'}">${nochZuZahlen > 0 ? '+' : ''}${eur(nochZuZahlen)}</span>
                   </div>
                 ` : ''}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -85,6 +85,25 @@
   }
 }
 
+/* Gewichtungs-Badge: ausgewählter Zustand */
+.slot-gewichtung-radio:checked + .slot-gewichtung-badge {
+  border-color: var(--color-brand);
+  background-color: #f0f7eb;
+  color: var(--color-brand-dark);
+}
+
+@media (prefers-color-scheme: dark) {
+  .slot-gewichtung-radio:checked + .slot-gewichtung-badge {
+    background-color: #1a2e0a;
+    color: #a8d96a;
+  }
+}
+
+/* Details-Pfeil drehen wenn offen */
+details[open] .details-arrow {
+  transform: rotate(90deg);
+}
+
 /* === Print-Styles === */
 @media print {
   /* Sticky Screen-Header verstecken */


### PR DESCRIPTION
## Summary

- Dark Mode für alle Seiten: `datenschutz`, `impressum`, `index`, `meine-runden`, `neu`, `runde/[id]`, `runde/[id]/admin/[token]`
- `<style>` Block aus `neu.astro` entfernt, Regeln mit Dark-Mode-Unterstützung in `global.css` überführt
- JS-generierte HTML-Strings vollständig mit `dark:`-Klassen versehen

## Test plan

- [ ] Alle Seiten im Dark Mode (System-Präferenz) prüfen
- [ ] Slot-Auswahl in Teilnehmer-View: selected state grün und dunkel
- [ ] Admin-View: Slot-Karten, Banner, Ausgleichszahlungen
- [ ] Meine Runden: Karten und Dropdown-Menü

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)