### PR TITLE
fix: localStorage-Korruption sichtbar melden statt lautlos ignorieren

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -40,6 +40,10 @@ export function deleteRunde(id: string): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(runden));
 }
 
+export function clearRunden(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
 export function saveGebotLokal(rundenId: string, emojiId: string, slotLabel: string): void {
   const key = `fairshare-gebot-${rundenId}`;
   let gebote: Array<{ emojiId: string; slotLabel: string }> = [];

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,14 +10,11 @@ export interface LocalRunde {
 }
 
 export function getRunden(): LocalRunde[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error('Ungültiges Format in localStorage');
+  return parsed;
 }
 
 export function saveRunde(runde: LocalRunde): void {

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -70,12 +70,14 @@ import FeedbackBox from '../components/FeedbackBox.astro';
   }
 
   function renderRunden() {
+    versteckeFeedback('storage-fehler');
     let runden: LocalRunde[];
     try {
       runden = getRunden().sort(
         (a, b) => new Date(b.hinzugefuegtAm).getTime() - new Date(a.hinzugefuegtAm).getTime(),
       );
     } catch (err) {
+      rundenListe.innerHTML = '';
       const meldung = err instanceof SyntaxError
         ? 'Deine gespeicherten Runden konnten nicht geladen werden — die Daten im Browser sind beschädigt. Du kannst sie über das ⋯-Menü zurücksetzen.'
         : 'Deine gespeicherten Runden konnten nicht geladen werden.';

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -30,6 +30,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       <input type="file" id="import-file" accept=".json" class="hidden" />
     </div>
 
+    <FeedbackBox id="storage-fehler" />
     <FeedbackBox id="import-fehler" />
 
     <!-- Leer-Zustand -->
@@ -62,9 +63,15 @@ import FeedbackBox from '../components/FeedbackBox.astro';
   }
 
   function renderRunden() {
-    const runden = getRunden().sort(
-      (a, b) => new Date(b.hinzugefuegtAm).getTime() - new Date(a.hinzugefuegtAm).getTime(),
-    );
+    let runden: LocalRunde[];
+    try {
+      runden = getRunden().sort(
+        (a, b) => new Date(b.hinzugefuegtAm).getTime() - new Date(a.hinzugefuegtAm).getTime(),
+      );
+    } catch {
+      zeigeFeedback('storage-fehler', 'Deine gespeicherten Runden konnten nicht geladen werden — die Daten im Browser sind beschädigt. Du kannst die Daten unter Einstellungen → Anwendung → Local Storage manuell löschen.', 'rot');
+      return;
+    }
 
     rundenListe.innerHTML = '';
 

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -68,8 +68,11 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       runden = getRunden().sort(
         (a, b) => new Date(b.hinzugefuegtAm).getTime() - new Date(a.hinzugefuegtAm).getTime(),
       );
-    } catch {
-      zeigeFeedback('storage-fehler', 'Deine gespeicherten Runden konnten nicht geladen werden — die Daten im Browser sind beschädigt. Du kannst die Daten unter Einstellungen → Anwendung → Local Storage manuell löschen.', 'rot');
+    } catch (err) {
+      const meldung = err instanceof SyntaxError
+        ? 'Deine gespeicherten Runden konnten nicht geladen werden — die Daten im Browser sind beschädigt. Du kannst sie über die Entwicklertools deines Browsers löschen.'
+        : 'Deine gespeicherten Runden konnten nicht geladen werden.';
+      zeigeFeedback('storage-fehler', meldung, 'rot');
       return;
     }
 

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -25,6 +25,13 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           >
             Importieren
           </button>
+          <hr class="my-1 border-slate-100 dark:border-slate-700" />
+          <button
+            id="zuruecksetzen-btn"
+            class="w-full text-left px-3 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+          >
+            Zurücksetzen
+          </button>
         </div>
       </details>
       <input type="file" id="import-file" accept=".json" class="hidden" />
@@ -48,7 +55,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 </Layout>
 
 <script>
-  import { getRunden, deleteRunde, exportJson, importJson } from '../lib/storage';
+  import { getRunden, deleteRunde, clearRunden, exportJson, importJson } from '../lib/storage';
   import type { LocalRunde } from '../lib/storage';
   import { zeigeFeedback, versteckeFeedback } from '../lib/ui';
 
@@ -70,7 +77,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       );
     } catch (err) {
       const meldung = err instanceof SyntaxError
-        ? 'Deine gespeicherten Runden konnten nicht geladen werden — die Daten im Browser sind beschädigt. Du kannst sie über die Entwicklertools deines Browsers löschen.'
+        ? 'Deine gespeicherten Runden konnten nicht geladen werden — die Daten im Browser sind beschädigt. Du kannst sie über das ⋯-Menü zurücksetzen.'
         : 'Deine gespeicherten Runden konnten nicht geladen werden.';
       zeigeFeedback('storage-fehler', meldung, 'rot');
       return;
@@ -176,6 +183,14 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     }
 
     importFileInput.value = '';
+  });
+
+  // Zurücksetzen
+  document.getElementById('zuruecksetzen-btn')!.addEventListener('click', () => {
+    if (!confirm('Alle gespeicherten Runden aus diesem Browser löschen?')) return;
+    clearRunden();
+    versteckeFeedback('storage-fehler');
+    renderRunden();
   });
 
   renderRunden();


### PR DESCRIPTION
## Summary

- `getRunden()` in `storage.ts` wirft jetzt bei korruptem JSON statt `[]` zurückzugeben
- `meine-runden.astro` fängt den Fehler und zeigt dem Nutzer eine deutschsprachige Fehlermeldung via `zeigeFeedback()`
- `saveGebotLokal()` und `getGebotSlot()` bleiben unverändert still

## Test plan

- [ ] DevTools → Application → Local Storage → `fairshare_runden` auf `{kaputt}` setzen
- [ ] `/meine-runden` laden → rote Fehlermeldung erscheint, keine leere Liste
- [ ] `fairshare_runden` löschen → Seite zeigt Leer-Zustand wie erwartet
- [ ] Normale Nutzung (keine Korruption) funktioniert weiterhin

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)