### PR TITLE
refactor: Währungsformatierung in zentrale formatEur()-Funktion auslagern

### DIFF
--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -1,3 +1,7 @@
+export function formatEur(n: number): string {
+  return n.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' €';
+}
+
 export function zeigeFeedback(
   elId: string,
   text: string,

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -284,7 +284,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
   } from '../lib/crypto';
   import { parseSplid } from '../lib/splid';
   import { saveRunde } from '../lib/storage';
-  import { zeigeFeedback, versteckeFeedback } from '../lib/ui';
+  import { zeigeFeedback, versteckeFeedback, formatEur } from '../lib/ui';
 
   function formatBetrag(n: number): string {
     return n.toFixed(2).replace('.', ',');
@@ -351,7 +351,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 
       const richtwertAnzeige = el.querySelector<HTMLSpanElement>('.standardgebot-richtwert');
       if (richtwertAnzeige) {
-        richtwertAnzeige.textContent = `Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
+        richtwertAnzeige.textContent = `Richtwert: ${formatEur(richtwertSlot)}`;
       }
     });
   }

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -418,7 +418,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         );
         const selectedSlot = blob.slots[selectedIdx];
         const betrag = parseFloat(
-          (gebotForm.querySelector('#betrag') as HTMLInputElement).value,
+          (gebotForm.querySelector('#betrag') as HTMLInputElement).value.replace(',', '.'),
         );
 
         let emojiId: string;
@@ -566,7 +566,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         );
         const selectedSlot = blob.slots[selectedIdx];
         const betrag = parseFloat(
-          (document.getElementById('korrektur-betrag') as HTMLInputElement).value,
+          (document.getElementById('korrektur-betrag') as HTMLInputElement).value.replace(',', '.'),
         );
 
         const emojiHmac = await hmac(hmacKey, emojiId);

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -184,7 +184,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   } from '../../lib/crypto';
   import { EMOJIS, generiereEmojiId } from '../../lib/solidarisch';
   import { saveRunde, saveGebotLokal, getGebotSlot } from '../../lib/storage';
-  import { zeigeFeedback, versteckeFeedback } from '../../lib/ui';
+  import { zeigeFeedback, versteckeFeedback, formatEur } from '../../lib/ui';
 
   interface TeilnehmerBlob {
     rundeName: string;
@@ -267,7 +267,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
     // Seite befüllen
     document.getElementById('runde-name')!.textContent = blob.rundeName;
-    document.getElementById('gesamtkosten')!.textContent = `${blob.gesamtkosten.toLocaleString('de-DE')} €`;
+    document.getElementById('gesamtkosten')!.textContent = formatEur(blob.gesamtkosten);
 
     // localStorage-Helfer: speichert welche Slots von diesem Gerät bereits geboten wurden
     function lsKey(label: string) {
@@ -293,7 +293,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
           <input type="radio" name="${nameAttr}" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
           <span class="flex-1">
             <span class="text-sm font-medium text-slate-800 dark:text-slate-200">${slot.label}</span>
-            <span class="text-xs text-slate-500 dark:text-slate-400 ml-2">Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €</span>
+            <span class="text-xs text-slate-500 dark:text-slate-400 ml-2">Richtwert: ${formatEur(richtwertSlot)}</span>
             ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-green-600 ml-1 text-xs">✓ abgegeben</span>' : ''}
           </span>
         `;
@@ -313,10 +313,10 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       const hinweis = document.getElementById(hinweisId)!;
       if (slot.standardgebot !== undefined) {
         betragInput.value = slot.standardgebot.toFixed(2);
-        hinweis.textContent = `Standardgebot: ${slot.standardgebot.toFixed(2).replace('.', ',')} € · Richtwert: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
+        hinweis.textContent = `Standardgebot: ${formatEur(slot.standardgebot)} · Richtwert: ${formatEur(richtwertSlot)}`;
       } else {
         betragInput.value = '';
-        hinweis.textContent = `Richtwert für diesen Slot: ${richtwertSlot.toFixed(2).replace('.', ',')} €`;
+        hinweis.textContent = `Richtwert für diesen Slot: ${formatEur(richtwertSlot)}`;
       }
     }
 

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -88,6 +88,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
     decryptGebot,
   } from '../../../../lib/crypto';
   import { berechneAuswertung, berechneAusgleich, type Gebot, type GebotErgebnis } from '../../../../lib/solidarisch';
+  import { formatEur } from '../../../../lib/ui';
 
   interface TeilnehmerBlob {
     rundeName: string;
@@ -97,9 +98,6 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
     slots: { label: string; gewichtung: number; anzahl: number; ausgaben?: number; standardgebot?: number }[];
   }
 
-  function eur(value: number): string {
-    return value.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' €';
-  }
 
   function zeigeFehler(msg: string) {
     document.getElementById('zustand-laden')!.classList.add('hidden');
@@ -232,7 +230,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
     // Kopfdaten immer anzeigen
     document.getElementById('runde-name')!.textContent = blob.rundeName;
-    document.getElementById('kz-gesamtkosten')!.textContent = eur(blob.gesamtkosten);
+    document.getElementById('kz-gesamtkosten')!.textContent = formatEur(blob.gesamtkosten);
 
     // Duplikat-Warnung anzeigen (vor Berechnung)
     if (hatDuplikate) {
@@ -254,11 +252,11 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
     const summeAlleGewichtungen = blob.slots.reduce((s, sl) => s + sl.gewichtung * sl.anzahl, 0);
     const rawRichtwert = blob.gesamtkosten / summeAlleGewichtungen;
     document.getElementById('kz-richtwert')!.textContent = auswertung
-      ? eur(auswertung.richtwert)
-      : eur(Math.ceil(rawRichtwert * 100) / 100);
+      ? formatEur(auswertung.richtwert)
+      : formatEur(Math.ceil(rawRichtwert * 100) / 100);
     // Summe Beiträge nur zeigen wenn kein Fehlbetrag (sonst rekonstruierbar)
     if (auswertung && auswertung.fehlbetrag <= 0.005) {
-      document.getElementById('kz-summe-beitraege')!.textContent = eur(auswertung.summeBeitraege);
+      document.getElementById('kz-summe-beitraege')!.textContent = formatEur(auswertung.summeBeitraege);
     }
 
     // Splid-Ausgaben-Map aufbauen (slotLabel → ausgaben)
@@ -320,7 +318,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 px-3 py-1.5 ${headerBg}">
           <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 min-w-0">
             <span class="text-sm font-semibold ${headerTextFarbe} shrink-0">${slot.label}</span>
-            <span class="text-xs text-slate-500 dark:text-slate-400 shrink-0">Faktor ${slot.gewichtung}x · ~${eur(richtwertAnteil)}</span>
+            <span class="text-xs text-slate-500 dark:text-slate-400 shrink-0">Faktor ${slot.gewichtung}x · ~${formatEur(richtwertAnteil)}</span>
           </div>
           <span class="text-xs font-semibold ${headerTextFarbe} shrink-0">${headerIcon} ${eingegangen}/${erwartet}${autoVollstaendig ? ' (auto)' : ''}</span>
         </div>
@@ -341,13 +339,13 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
             <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">geboten</span>
             ${zeigeBeitraege && e ? `
               <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Beitrag</span>
-              <span class="hidden sm:inline text-sm font-semibold text-slate-900 dark:text-slate-100 shrink-0">${eur(e.solidarischerBeitrag)}</span>
+              <span class="hidden sm:inline text-sm font-semibold text-slate-900 dark:text-slate-100 shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
             ` : ''}
             ${zeigeBeitraege && e && hatSplidDaten ? `
               <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Ausgaben</span>
-              <span class="hidden sm:inline text-xs font-semibold text-slate-900 dark:text-slate-100 shrink-0">${eur(ausgaben)}</span>
+              <span class="hidden sm:inline text-xs font-semibold text-slate-900 dark:text-slate-100 shrink-0">${formatEur(ausgaben)}</span>
               <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Noch zu zahlen</span>
-              <span class="hidden sm:inline text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${eur(e.solidarischerBeitrag - ausgaben)}</span>
+              <span class="hidden sm:inline text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
             ` : ''}
             <span class="ml-auto"><button class="loeschen-btn w-6 h-6 flex items-center justify-center rounded-full text-slate-300 dark:text-slate-600 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50 transition-colors" data-emoji-hmac="${emojiHmac}" data-slot="${slot.label}" aria-label="Gebot löschen">×</button></span>
           </div>
@@ -355,16 +353,16 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
             <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
               <div class="flex justify-between items-baseline">
                 <span class="text-xs text-slate-400 dark:text-slate-500">Beitrag</span>
-                <span class="text-sm font-semibold text-slate-900 dark:text-slate-100">${eur(e.solidarischerBeitrag)}</span>
+                <span class="text-sm font-semibold text-slate-900 dark:text-slate-100">${formatEur(e.solidarischerBeitrag)}</span>
               </div>
               ${hatSplidDaten ? `
                 <div class="flex justify-between items-baseline">
                   <span class="text-xs text-slate-400 dark:text-slate-500">Ausgaben</span>
-                  <span class="text-xs font-semibold text-slate-900 dark:text-slate-100">${eur(ausgaben)}</span>
+                  <span class="text-xs font-semibold text-slate-900 dark:text-slate-100">${formatEur(ausgaben)}</span>
                 </div>
                 <div class="flex justify-between items-baseline">
                   <span class="text-xs text-slate-400 dark:text-slate-500">Noch zu zahlen</span>
-                  <span class="text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'}">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${eur(e.solidarischerBeitrag - ausgaben)}</span>
+                  <span class="text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'}">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
                 </div>
               ` : ''}
             </div>
@@ -387,29 +385,29 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
               <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
               ${e ? `
                 <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Beitrag</span>
-                <span class="hidden sm:inline text-sm font-semibold text-slate-900 dark:text-slate-100 shrink-0">${eur(e.solidarischerBeitrag)}</span>
+                <span class="hidden sm:inline text-sm font-semibold text-slate-900 dark:text-slate-100 shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
               ` : ''}
               ${e && hatSplidDaten ? `
                 <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Ausgaben</span>
-                <span class="hidden sm:inline text-xs font-semibold text-slate-900 dark:text-slate-100 shrink-0">${eur(ausgaben)}</span>
+                <span class="hidden sm:inline text-xs font-semibold text-slate-900 dark:text-slate-100 shrink-0">${formatEur(ausgaben)}</span>
                 <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Noch zu zahlen</span>
-                <span class="hidden sm:inline text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${nochZuZahlen > 0 ? '+' : ''}${eur(nochZuZahlen)}</span>
+                <span class="hidden sm:inline text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
               ` : ''}
             </div>
             ${e ? `
               <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
                 <div class="flex justify-between items-baseline">
                   <span class="text-xs text-slate-400 dark:text-slate-500">Beitrag</span>
-                  <span class="text-sm font-semibold text-slate-900 dark:text-slate-100">${eur(e.solidarischerBeitrag)}</span>
+                  <span class="text-sm font-semibold text-slate-900 dark:text-slate-100">${formatEur(e.solidarischerBeitrag)}</span>
                 </div>
                 ${hatSplidDaten ? `
                   <div class="flex justify-between items-baseline">
                     <span class="text-xs text-slate-400 dark:text-slate-500">Ausgaben</span>
-                    <span class="text-xs font-semibold text-slate-900 dark:text-slate-100">${eur(ausgaben)}</span>
+                    <span class="text-xs font-semibold text-slate-900 dark:text-slate-100">${formatEur(ausgaben)}</span>
                   </div>
                   <div class="flex justify-between items-baseline">
                     <span class="text-xs text-slate-400 dark:text-slate-500">Noch zu zahlen</span>
-                    <span class="text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'}">${nochZuZahlen > 0 ? '+' : ''}${eur(nochZuZahlen)}</span>
+                    <span class="text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'}">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
                   </div>
                 ` : ''}
               </div>
@@ -489,7 +487,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
             <span class="text-slate-700 dark:text-slate-300 text-right">${vonLabel}</span>
             <span class="text-slate-400 dark:text-slate-500">→</span>
             <span class="text-slate-700 dark:text-slate-300">${anLabel}</span>
-            <span class="font-semibold text-slate-900 dark:text-slate-100 text-right">${eur(z.betrag)}</span>
+            <span class="font-semibold text-slate-900 dark:text-slate-100 text-right">${formatEur(z.betrag)}</span>
           `;
           liste.appendChild(zeile);
         });
@@ -524,7 +522,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
     } else if (allesDa) {
       const fehlbetragVorhanden = auswertung && auswertung.fehlbetrag > 0.005;
       if (fehlbetragVorhanden) {
-        zeigeBanner(`Fehlbetrag: ${eur(auswertung!.fehlbetrag)} — Runde muss wiederholt werden.`, 'red');
+        zeigeBanner(`Fehlbetrag: ${formatEur(auswertung!.fehlbetrag)} — Runde muss wiederholt werden.`, 'red');
       } else {
         zeigeBanner('Alle Beiträge vollständig. Auswertung abgeschlossen.', 'green');
       }


### PR DESCRIPTION
## Summary

- Neue Funktion `formatEur(n: number): string` in `src/lib/ui.ts` — einheitliches Format `1.234,56 €` (de-DE, 2 Nachkommastellen)
- Alle Anzeige-Strings in `neu.astro`, `runde/[id].astro` und `admin/[token].astro` nutzen jetzt `formatEur()`
- Lokale Hilfsfunktionen (`formatBetrag` für Display, `eur()`) entfernt
- `.value`-Zuweisungen für Input-Felder unberührt

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)