### PR TITLE
refactor: Dark Mode mit semantischen CSS-Tokens (#89)

### DIFF
--- a/src/components/FeedbackBox.astro
+++ b/src/components/FeedbackBox.astro
@@ -6,9 +6,9 @@ interface Props {
 }
 const { id, typ = 'rot', klasse = '' } = Astro.props;
 const farben = {
-  rot:   'bg-red-50 border-red-200 text-red-700 dark:bg-red-950 dark:border-red-800 dark:text-red-300',
-  gruen: 'bg-green-50 border-green-200 text-green-700 dark:bg-green-950 dark:border-green-800 dark:text-green-300',
-  amber: 'bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-950 dark:border-amber-800 dark:text-amber-200',
+  rot:   'bg-danger-bg border-danger-border text-danger-text',
+  gruen: 'bg-success-bg border-success-border text-success-text',
+  amber: 'bg-warning-bg border-warning-border text-warning-text',
 };
 ---
 <div id={id} class={`hidden ${farben[typ]} border rounded-lg p-3 text-sm ${klasse}`}></div>

--- a/src/components/FeedbackBox.astro
+++ b/src/components/FeedbackBox.astro
@@ -6,9 +6,9 @@ interface Props {
 }
 const { id, typ = 'rot', klasse = '' } = Astro.props;
 const farben = {
-  rot:   'bg-danger-bg border-danger-border text-danger-text',
-  gruen: 'bg-success-bg border-success-border text-success-text',
-  amber: 'bg-warning-bg border-warning-border text-warning-text',
+  rot:   'bg-danger-subtle border-danger-outline text-danger-fg',
+  gruen: 'bg-success-subtle border-success-outline text-success-fg',
+  amber: 'bg-warning-subtle border-warning-outline text-warning-fg',
 };
 ---
 <div id={id} class={`hidden ${farben[typ]} border rounded-lg p-3 text-sm ${klasse}`}></div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,20 +18,20 @@ const pathname = Astro.url.pathname;
     <title>{title} – FairShare</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
-  <body class="min-h-screen bg-white text-slate-900 antialiased flex flex-col dark:bg-slate-900 dark:text-slate-100">
+  <body class="min-h-screen bg-surface text-text antialiased flex flex-col">
     <!-- Print-only Branding (im Browser unsichtbar) -->
     <div class="hidden print:block pb-3 mb-4 border-b border-slate-300 font-serif text-[1.1rem] tracking-[-0.02em]">
       <span class="font-bold text-brand">SyndiKit</span><span class="font-normal text-slate-900 text-[0.9rem]"> · FairShare</span>
     </div>
     <!-- Screen-Header -->
-    <header class="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-slate-100 print:hidden dark:bg-slate-900/80 dark:border-slate-800">
+    <header class="sticky top-0 z-50 bg-surface/80 backdrop-blur-md border-b border-border-subtle print:hidden">
       <div class="mx-auto max-w-5xl px-4 h-16 flex items-center justify-between">
         <a href="/" class="font-serif text-xl tracking-[-0.02em]">
-          <span class="font-bold text-brand">SyndiKit</span><span class="font-normal text-base text-slate-900 dark:text-slate-100"> · FairShare</span>
+          <span class="font-bold text-brand">SyndiKit</span><span class="font-normal text-base text-text"> · FairShare</span>
         </a>
         <nav class="flex items-center gap-1">
-          <a href="/neu" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 ${pathname === '/neu' ? 'text-brand font-semibold' : 'text-slate-600 dark:text-slate-300'}`}>Neue Runde</a>
-          <a id="nav-meine-runden" href="/meine-runden" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 ${pathname === '/meine-runden' ? 'text-brand font-semibold' : 'text-slate-600 dark:text-slate-300 hidden'}`}>Meine Runden</a>
+          <a href="/neu" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-surface-hover ${pathname === '/neu' ? 'text-brand font-semibold' : 'text-text-secondary'}`}>Neue Runde</a>
+          <a id="nav-meine-runden" href="/meine-runden" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-surface-hover ${pathname === '/meine-runden' ? 'text-brand font-semibold' : 'text-text-secondary hidden'}`}>Meine Runden</a>
         </nav>
       </div>
     </header>
@@ -58,12 +58,12 @@ const pathname = Astro.url.pathname;
         <div class="py-16"></div>
       </slot>
     </section>
-    <footer class="border-t border-slate-100 py-12 print:hidden dark:border-slate-800">
-      <div class="mx-auto max-w-5xl px-4 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400">
+    <footer class="border-t border-border-subtle py-12 print:hidden">
+      <div class="mx-auto max-w-5xl px-4 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-text-faint">
         <span>© 2026 SyndiKit · FairShare</span>
         <nav class="flex gap-6">
-          <a href="/datenschutz" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">Datenschutz</a>
-          <a href="/impressum" class="hover:text-slate-600 dark:hover:text-slate-300 transition-colors">Impressum</a>
+          <a href="/datenschutz" class="hover:text-text-secondary transition-colors">Datenschutz</a>
+          <a href="/impressum" class="hover:text-text-secondary transition-colors">Impressum</a>
         </nav>
       </div>
     </footer>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -53,7 +53,7 @@ const pathname = Astro.url.pathname;
     <main class={fullWidth ? 'flex-1' : 'flex-1 mx-auto w-full max-w-2xl px-6 py-24 pb-20'}>
       <slot />
     </main>
-    <section class="bg-slate-50 print:hidden dark:bg-slate-800/30">
+    <section class="bg-surface-tinted print:hidden">
       <slot name="gray-section">
         <div class="py-16"></div>
       </slot>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,7 +18,7 @@ const pathname = Astro.url.pathname;
     <title>{title} – FairShare</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
-  <body class="min-h-screen bg-surface text-text antialiased flex flex-col">
+  <body class="min-h-screen bg-surface text-fg antialiased flex flex-col">
     <!-- Print-only Branding (im Browser unsichtbar) -->
     <div class="hidden print:block pb-3 mb-4 border-b border-slate-300 font-serif text-[1.1rem] tracking-[-0.02em]">
       <span class="font-bold text-brand">SyndiKit</span><span class="font-normal text-slate-900 text-[0.9rem]"> · FairShare</span>
@@ -27,11 +27,11 @@ const pathname = Astro.url.pathname;
     <header class="sticky top-0 z-50 bg-surface/80 backdrop-blur-md border-b border-border-subtle print:hidden">
       <div class="mx-auto max-w-5xl px-4 h-16 flex items-center justify-between">
         <a href="/" class="font-serif text-xl tracking-[-0.02em]">
-          <span class="font-bold text-brand">SyndiKit</span><span class="font-normal text-base text-text"> · FairShare</span>
+          <span class="font-bold text-brand">SyndiKit</span><span class="font-normal text-base text-fg"> · FairShare</span>
         </a>
         <nav class="flex items-center gap-1">
-          <a href="/neu" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-surface-hover ${pathname === '/neu' ? 'text-brand font-semibold' : 'text-text-secondary'}`}>Neue Runde</a>
-          <a id="nav-meine-runden" href="/meine-runden" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-surface-hover ${pathname === '/meine-runden' ? 'text-brand font-semibold' : 'text-text-secondary hidden'}`}>Meine Runden</a>
+          <a href="/neu" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-surface-hover ${pathname === '/neu' ? 'text-brand font-semibold' : 'text-fg-secondary'}`}>Neue Runde</a>
+          <a id="nav-meine-runden" href="/meine-runden" class={`px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-surface-hover ${pathname === '/meine-runden' ? 'text-brand font-semibold' : 'text-fg-secondary hidden'}`}>Meine Runden</a>
         </nav>
       </div>
     </header>
@@ -59,11 +59,11 @@ const pathname = Astro.url.pathname;
       </slot>
     </section>
     <footer class="border-t border-border-subtle py-12 print:hidden">
-      <div class="mx-auto max-w-5xl px-4 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-text-faint">
+      <div class="mx-auto max-w-5xl px-4 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-fg-faint">
         <span>© 2026 SyndiKit · FairShare</span>
         <nav class="flex gap-6">
-          <a href="/datenschutz" class="hover:text-text-secondary transition-colors">Datenschutz</a>
-          <a href="/impressum" class="hover:text-text-secondary transition-colors">Impressum</a>
+          <a href="/datenschutz" class="hover:text-fg-secondary transition-colors">Datenschutz</a>
+          <a href="/impressum" class="hover:text-fg-secondary transition-colors">Impressum</a>
         </nav>
       </div>
     </footer>

--- a/src/pages/datenschutz.astro
+++ b/src/pages/datenschutz.astro
@@ -5,10 +5,10 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Datenschutz">
   <h1 class="text-3xl font-bold mb-10">Datenschutzerklärung</h1>
 
-  <div class="space-y-8 text-text-secondary leading-relaxed">
+  <div class="space-y-8 text-fg-secondary leading-relaxed">
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">1. Verantwortlicher</h2>
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">1. Verantwortlicher</h2>
       <p>
         Sebastian Tran<br />
         c/o Raumkante<br />
@@ -19,8 +19,8 @@ import Layout from '../layouts/Layout.astro';
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">2. Hosting</h2>
-      <p class="text-text-muted text-sm">
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">2. Hosting</h2>
+      <p class="text-fg-muted text-sm">
         Diese Website wird gehostet bei netzguerilla.net. Dabei werden technisch notwendige
         Verbindungsdaten verarbeitet (IP-Adresse, Zeitstempel, aufgerufene URL).
         Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse am Betrieb der Website).
@@ -28,48 +28,48 @@ import Layout from '../layouts/Layout.astro';
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">3. Zero-Knowledge-Prinzip</h2>
-      <p class="text-text-muted text-sm mb-3">
-        Alle Inhalte einer Runde werden <strong class="text-text-secondary">im Browser verschlüsselt</strong>,
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">3. Zero-Knowledge-Prinzip</h2>
+      <p class="text-fg-muted text-sm mb-3">
+        Alle Inhalte einer Runde werden <strong class="text-fg-secondary">im Browser verschlüsselt</strong>,
         bevor sie den Server erreichen. Der Schlüssel steckt im URL-Fragment
-        (<code class="font-mono text-xs bg-surface-elevated text-text-secondary px-1 py-0.5 rounded">#…</code>) —
+        (<code class="font-mono text-xs bg-surface-elevated text-fg-secondary px-1 py-0.5 rounded">#…</code>) —
         diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
       </p>
-      <p class="text-text-muted text-sm mb-2">Was der Server nie sieht: Namen der Teilnehmer:innen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel.</p>
-      <p class="text-text-muted text-sm">
+      <p class="text-fg-muted text-sm mb-2">Was der Server nie sieht: Namen der Teilnehmer:innen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel.</p>
+      <p class="text-fg-muted text-sm">
         Was der Server sehen kann: Anzahl der Einträge, Zeitpunkte der Einreichung, Existenz einer Runden-ID.
         Mehr dazu: <a href="/#wie-es-funktioniert" class="text-brand hover:text-brand-dark">Wie FairShare funktioniert</a>.
       </p>
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">4. Gespeicherte Daten</h2>
-      <p class="text-text-muted text-sm mb-3">
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">4. Gespeicherte Daten</h2>
+      <p class="text-fg-muted text-sm mb-3">
         FairShare speichert keine personenbezogenen Daten. Es gibt keine Nutzerkonten,
         keine E-Mail-Adressen und keine Tracking-Cookies. Runden-IDs sind zufällig generiert
         und enthalten keine personenbezogenen Informationen.
       </p>
-      <p class="text-text-muted text-sm mb-3">
+      <p class="text-fg-muted text-sm mb-3">
         Gespeicherte Runden-Links werden ausschließlich in deinem Browser
-        (<code class="font-mono text-xs bg-surface-elevated text-text-secondary px-1 py-0.5 rounded">localStorage</code>)
+        (<code class="font-mono text-xs bg-surface-elevated text-fg-secondary px-1 py-0.5 rounded">localStorage</code>)
         gespeichert — nie auf dem Server.
       </p>
-      <p class="text-text-muted text-sm">
-        Runden werden nach <strong class="text-text-secondary">6 Monaten automatisch vom Server gelöscht</strong>.
+      <p class="text-fg-muted text-sm">
+        Runden werden nach <strong class="text-fg-secondary">6 Monaten automatisch vom Server gelöscht</strong>.
       </p>
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">5. Cookies &amp; Tracking</h2>
-      <p class="text-text-muted text-sm">
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">5. Cookies &amp; Tracking</h2>
+      <p class="text-fg-muted text-sm">
         FairShare setzt keine Tracking-Cookies und verwendet keine Analyse-Dienste.
         Es werden keine personenbezogenen Daten für Werbezwecke verarbeitet.
       </p>
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">6. Deine Rechte</h2>
-      <p class="text-text-muted text-sm">
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">6. Deine Rechte</h2>
+      <p class="text-fg-muted text-sm">
         Du hast das Recht auf Auskunft, Berichtigung, Löschung und Einschränkung der Verarbeitung
         deiner personenbezogenen Daten sowie das Recht auf Datenübertragbarkeit.
         Da FairShare keine personenbezogenen Daten speichert, liegen in aller Regel keine

--- a/src/pages/datenschutz.astro
+++ b/src/pages/datenschutz.astro
@@ -5,10 +5,10 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Datenschutz">
   <h1 class="text-3xl font-bold mb-10">Datenschutzerklärung</h1>
 
-  <div class="space-y-8 text-slate-700 dark:text-slate-300 leading-relaxed">
+  <div class="space-y-8 text-text-secondary leading-relaxed">
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">1. Verantwortlicher</h2>
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">1. Verantwortlicher</h2>
       <p>
         Sebastian Tran<br />
         c/o Raumkante<br />
@@ -19,8 +19,8 @@ import Layout from '../layouts/Layout.astro';
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">2. Hosting</h2>
-      <p class="text-slate-500 dark:text-slate-400 text-sm">
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">2. Hosting</h2>
+      <p class="text-text-muted text-sm">
         Diese Website wird gehostet bei netzguerilla.net. Dabei werden technisch notwendige
         Verbindungsdaten verarbeitet (IP-Adresse, Zeitstempel, aufgerufene URL).
         Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse am Betrieb der Website).
@@ -28,48 +28,48 @@ import Layout from '../layouts/Layout.astro';
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">3. Zero-Knowledge-Prinzip</h2>
-      <p class="text-slate-500 dark:text-slate-400 text-sm mb-3">
-        Alle Inhalte einer Runde werden <strong class="text-slate-700 dark:text-slate-200">im Browser verschlüsselt</strong>,
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">3. Zero-Knowledge-Prinzip</h2>
+      <p class="text-text-muted text-sm mb-3">
+        Alle Inhalte einer Runde werden <strong class="text-text-secondary">im Browser verschlüsselt</strong>,
         bevor sie den Server erreichen. Der Schlüssel steckt im URL-Fragment
-        (<code class="font-mono text-xs bg-slate-100 dark:bg-slate-700 dark:text-slate-300 px-1 py-0.5 rounded">#…</code>) —
+        (<code class="font-mono text-xs bg-surface-elevated text-text-secondary px-1 py-0.5 rounded">#…</code>) —
         diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
       </p>
-      <p class="text-slate-500 dark:text-slate-400 text-sm mb-2">Was der Server nie sieht: Namen der Teilnehmer:innen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel.</p>
-      <p class="text-slate-500 dark:text-slate-400 text-sm">
+      <p class="text-text-muted text-sm mb-2">Was der Server nie sieht: Namen der Teilnehmer:innen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel.</p>
+      <p class="text-text-muted text-sm">
         Was der Server sehen kann: Anzahl der Einträge, Zeitpunkte der Einreichung, Existenz einer Runden-ID.
         Mehr dazu: <a href="/#wie-es-funktioniert" class="text-brand hover:text-brand-dark">Wie FairShare funktioniert</a>.
       </p>
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">4. Gespeicherte Daten</h2>
-      <p class="text-slate-500 dark:text-slate-400 text-sm mb-3">
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">4. Gespeicherte Daten</h2>
+      <p class="text-text-muted text-sm mb-3">
         FairShare speichert keine personenbezogenen Daten. Es gibt keine Nutzerkonten,
         keine E-Mail-Adressen und keine Tracking-Cookies. Runden-IDs sind zufällig generiert
         und enthalten keine personenbezogenen Informationen.
       </p>
-      <p class="text-slate-500 dark:text-slate-400 text-sm mb-3">
+      <p class="text-text-muted text-sm mb-3">
         Gespeicherte Runden-Links werden ausschließlich in deinem Browser
-        (<code class="font-mono text-xs bg-slate-100 dark:bg-slate-700 dark:text-slate-300 px-1 py-0.5 rounded">localStorage</code>)
+        (<code class="font-mono text-xs bg-surface-elevated text-text-secondary px-1 py-0.5 rounded">localStorage</code>)
         gespeichert — nie auf dem Server.
       </p>
-      <p class="text-slate-500 dark:text-slate-400 text-sm">
-        Runden werden nach <strong class="text-slate-700 dark:text-slate-200">6 Monaten automatisch vom Server gelöscht</strong>.
+      <p class="text-text-muted text-sm">
+        Runden werden nach <strong class="text-text-secondary">6 Monaten automatisch vom Server gelöscht</strong>.
       </p>
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">5. Cookies &amp; Tracking</h2>
-      <p class="text-slate-500 dark:text-slate-400 text-sm">
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">5. Cookies &amp; Tracking</h2>
+      <p class="text-text-muted text-sm">
         FairShare setzt keine Tracking-Cookies und verwendet keine Analyse-Dienste.
         Es werden keine personenbezogenen Daten für Werbezwecke verarbeitet.
       </p>
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">6. Deine Rechte</h2>
-      <p class="text-slate-500 dark:text-slate-400 text-sm">
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">6. Deine Rechte</h2>
+      <p class="text-text-muted text-sm">
         Du hast das Recht auf Auskunft, Berichtigung, Löschung und Einschränkung der Verarbeitung
         deiner personenbezogenen Daten sowie das Recht auf Datenübertragbarkeit.
         Da FairShare keine personenbezogenen Daten speichert, liegen in aller Regel keine

--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -5,9 +5,9 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Impressum">
   <h1 class="text-3xl font-bold mb-10">Impressum</h1>
 
-  <div class="space-y-8 text-text-secondary leading-relaxed">
+  <div class="space-y-8 text-fg-secondary leading-relaxed">
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">Angaben gemäß § 5 TMG</h2>
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">Angaben gemäß § 5 TMG</h2>
       <p>
         Sebastian Tran<br />
         c/o Raumkante<br />
@@ -17,14 +17,14 @@ import Layout from '../layouts/Layout.astro';
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">Kontakt</h2>
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">Kontakt</h2>
       <p>
         E-Mail: <a href="mailto:kontakt@syndikit.de" class="text-brand hover:text-brand-dark">kontakt@syndikit.de</a>
       </p>
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">Verantwortlich für den Inhalt</h2>
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">Verantwortlich für den Inhalt</h2>
       <p>
         Sebastian Tran<br />
         Rheinstraße 4<br />
@@ -33,8 +33,8 @@ import Layout from '../layouts/Layout.astro';
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">Haftungsausschluss</h2>
-      <p class="text-text-muted text-sm">
+      <h2 class="text-sm font-semibold text-fg-faint tracking-widest uppercase mb-3">Haftungsausschluss</h2>
+      <p class="text-fg-muted text-sm">
         Die Inhalte dieser Website wurden mit größtmöglicher Sorgfalt erstellt.
         Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen.
       </p>

--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -5,9 +5,9 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Impressum">
   <h1 class="text-3xl font-bold mb-10">Impressum</h1>
 
-  <div class="space-y-8 text-slate-700 dark:text-slate-300 leading-relaxed">
+  <div class="space-y-8 text-text-secondary leading-relaxed">
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">Angaben gemäß § 5 TMG</h2>
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">Angaben gemäß § 5 TMG</h2>
       <p>
         Sebastian Tran<br />
         c/o Raumkante<br />
@@ -17,14 +17,14 @@ import Layout from '../layouts/Layout.astro';
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">Kontakt</h2>
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">Kontakt</h2>
       <p>
         E-Mail: <a href="mailto:kontakt@syndikit.de" class="text-brand hover:text-brand-dark">kontakt@syndikit.de</a>
       </p>
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">Verantwortlich für den Inhalt</h2>
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">Verantwortlich für den Inhalt</h2>
       <p>
         Sebastian Tran<br />
         Rheinstraße 4<br />
@@ -33,8 +33,8 @@ import Layout from '../layouts/Layout.astro';
     </div>
 
     <div>
-      <h2 class="text-sm font-semibold text-slate-400 tracking-widest uppercase mb-3">Haftungsausschluss</h2>
-      <p class="text-slate-500 dark:text-slate-400 text-sm">
+      <h2 class="text-sm font-semibold text-text-faint tracking-widest uppercase mb-3">Haftungsausschluss</h2>
+      <p class="text-text-muted text-sm">
         Die Inhalte dieser Website wurden mit größtmöglicher Sorgfalt erstellt.
         Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen.
       </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,10 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Solidarische Gruppenfinanzierung" fullWidth>
   <section class="w-full min-h-[80vh] flex items-center justify-center px-6 py-32">
     <div class="max-w-3xl mx-auto text-center space-y-8">
-      <h1 class="text-[clamp(2rem,8vw,3.75rem)] font-bold leading-tight tracking-tight text-text">
+      <h1 class="text-[clamp(2rem,8vw,3.75rem)] font-bold leading-tight tracking-tight text-fg">
         Teile Kosten solidarisch. Zahle, was du kannst.
       </h1>
-      <p class="text-xl text-text-muted max-w-xl mx-auto leading-relaxed">
+      <p class="text-xl text-fg-muted max-w-xl mx-auto leading-relaxed">
         FairShare hilft Gruppen, Kosten fair aufzuteilen. Jede Person gibt ihr Gebot ab — anonym und verschlüsselt.
       </p>
       <div class="flex flex-col items-center gap-3">
@@ -21,7 +21,7 @@ import Layout from '../layouts/Layout.astro';
         <a
           id="cta-meine-runden"
           href="/meine-runden"
-          class="hidden items-center gap-2 text-sm text-text-muted hover:text-text-strong transition-colors px-4 py-2"
+          class="hidden items-center gap-2 text-sm text-fg-muted hover:text-fg-strong transition-colors px-4 py-2"
         >
           Meine gespeicherten Runden →
         </a>
@@ -31,13 +31,13 @@ import Layout from '../layouts/Layout.astro';
 
   <section slot="gray-section" id="wie-es-funktioniert" class="py-24">
     <div class="mx-auto max-w-2xl px-6 space-y-6">
-      <p data-animate class="text-sm font-semibold text-slate-400 tracking-widest uppercase">Wie es funktioniert</p>
+      <p data-animate class="text-sm font-semibold text-fg-faint tracking-widest uppercase">Wie es funktioniert</p>
 
       <div class="rounded-xl border border-border bg-surface-raised p-6">
-        <h2 class="text-lg font-semibold text-text mb-2">Zero-Knowledge-Prinzip</h2>
-        <p class="text-sm text-text-muted leading-relaxed mb-4">
+        <h2 class="text-lg font-semibold text-fg mb-2">Zero-Knowledge-Prinzip</h2>
+        <p class="text-sm text-fg-muted leading-relaxed mb-4">
           Alle Inhalte werden im Browser verschlüsselt, bevor sie den Server erreichen.
-          Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-surface-elevated text-text-secondary px-1 py-0.5 rounded">#…</code>)
+          Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-surface-elevated text-fg-secondary px-1 py-0.5 rounded">#…</code>)
           — diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
           Die App folgt dem <strong>Zero-Knowledge-Prinzip</strong>: mit einigen
           bewussten Einschränkungen, die wir transparent machen.
@@ -47,21 +47,21 @@ import Layout from '../layouts/Layout.astro';
             <span class="transition-transform group-open:rotate-90 inline-block">›</span>
             Was der Server theoretisch inferieren kann (Threat Model)
           </summary>
-          <div class="mt-3 text-sm text-text-muted space-y-3 pl-4 border-l-2 border-border">
+          <div class="mt-3 text-sm text-fg-muted space-y-3 pl-4 border-l-2 border-border">
             <div>
-              <p class="font-medium text-text-strong">Anzahl der Teilnehmer:innen</p>
+              <p class="font-medium text-fg-strong">Anzahl der Teilnehmer:innen</p>
               <p class="mt-0.5">Jedes Gebot ist ein separater verschlüsselter Eintrag im Server-Store — der Server kann Einträge zählen und so die ungefähre Teilnehmerzahl inferieren.</p>
             </div>
             <div>
-              <p class="font-medium text-text-strong">Zeitpunkte der Gebots-Einreichung</p>
+              <p class="font-medium text-fg-strong">Zeitpunkte der Gebots-Einreichung</p>
               <p class="mt-0.5">Der Server sieht, wann ein Gebot einging. Muster (z.&nbsp;B. alle binnen 5 Minuten) können auf Gruppenverhalten hindeuten.</p>
             </div>
             <div>
-              <p class="font-medium text-text-strong">Existenz einer Runde</p>
+              <p class="font-medium text-fg-strong">Existenz einer Runde</p>
               <p class="mt-0.5">Eine Runden-ID existiert auf dem Server und ist aktiv oder nicht — ohne Klartext-Bezug zum Inhalt.</p>
             </div>
             <div class="pt-1">
-              <p class="font-medium text-text-strong">Was der Server <em>nicht</em> sieht</p>
+              <p class="font-medium text-fg-strong">Was der Server <em>nicht</em> sieht</p>
               <p class="mt-0.5">Namen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel — all das bleibt verschlüsselt.</p>
             </div>
           </div>
@@ -69,19 +69,19 @@ import Layout from '../layouts/Layout.astro';
       </div>
 
       <div class="rounded-xl border border-border bg-surface-raised p-6">
-        <h2 class="text-lg font-semibold text-text mb-2">Vertrauen in die Organisator:in</h2>
-        <p class="text-sm text-text-muted leading-relaxed mb-3">
+        <h2 class="text-lg font-semibold text-fg mb-2">Vertrauen in die Organisator:in</h2>
+        <p class="text-sm text-fg-muted leading-relaxed mb-3">
           Die App ist <strong>kein Zero-Trust-System</strong>. Die Organisator:in hat den
           privaten Admin-Schlüssel und kann damit technisch alle Gebote entschlüsseln —
           das Frontend zeigt ihr nur die Auswertungstabelle, aber der Zugriff auf Rohwerte
           wäre im Code möglich.
         </p>
-        <p class="text-sm text-text-muted leading-relaxed mb-3">
+        <p class="text-sm text-fg-muted leading-relaxed mb-3">
           Teilnehmer:innen hingegen können <strong>keine</strong> Gebote anderer sehen:
           Gebote sind mit dem öffentlichen Admin-Schlüssel verschlüsselt und nur mit dem
           privaten Schlüssel der Organisator:in lesbar.
         </p>
-        <p class="text-sm text-text-muted leading-relaxed">
+        <p class="text-sm text-fg-muted leading-relaxed">
           Vertrauen in die Organisator:in ist Teil des Modells — vergleichbar mit einer
           Kassenprüfer:in in einer Genossenschaft: Kontrolle durch Transparenz, nicht durch
           technische Sperre.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,10 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="Solidarische Gruppenfinanzierung" fullWidth>
   <section class="w-full min-h-[80vh] flex items-center justify-center px-6 py-32">
     <div class="max-w-3xl mx-auto text-center space-y-8">
-      <h1 class="text-[clamp(2rem,8vw,3.75rem)] font-bold leading-tight tracking-tight text-slate-900 dark:text-slate-100">
+      <h1 class="text-[clamp(2rem,8vw,3.75rem)] font-bold leading-tight tracking-tight text-text">
         Teile Kosten solidarisch. Zahle, was du kannst.
       </h1>
-      <p class="text-xl text-slate-500 dark:text-slate-400 max-w-xl mx-auto leading-relaxed">
+      <p class="text-xl text-text-muted max-w-xl mx-auto leading-relaxed">
         FairShare hilft Gruppen, Kosten fair aufzuteilen. Jede Person gibt ihr Gebot ab — anonym und verschlüsselt.
       </p>
       <div class="flex flex-col items-center gap-3">
@@ -21,7 +21,7 @@ import Layout from '../layouts/Layout.astro';
         <a
           id="cta-meine-runden"
           href="/meine-runden"
-          class="hidden items-center gap-2 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors px-4 py-2"
+          class="hidden items-center gap-2 text-sm text-text-muted hover:text-text-strong transition-colors px-4 py-2"
         >
           Meine gespeicherten Runden →
         </a>
@@ -33,11 +33,11 @@ import Layout from '../layouts/Layout.astro';
     <div class="mx-auto max-w-2xl px-6 space-y-6">
       <p data-animate class="text-sm font-semibold text-slate-400 tracking-widest uppercase">Wie es funktioniert</p>
 
-      <div class="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
-        <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">Zero-Knowledge-Prinzip</h2>
-        <p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed mb-4">
+      <div class="rounded-xl border border-border bg-surface-raised p-6">
+        <h2 class="text-lg font-semibold text-text mb-2">Zero-Knowledge-Prinzip</h2>
+        <p class="text-sm text-text-muted leading-relaxed mb-4">
           Alle Inhalte werden im Browser verschlüsselt, bevor sie den Server erreichen.
-          Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-slate-100 dark:bg-slate-700 dark:text-slate-300 px-1 py-0.5 rounded">#…</code>)
+          Schlüssel stecken im Link-Fragment (<code class="font-mono text-xs bg-surface-elevated text-text-secondary px-1 py-0.5 rounded">#…</code>)
           — diesen Teil schickt der Browser laut RFC&nbsp;3986 nie ans Backend.
           Die App folgt dem <strong>Zero-Knowledge-Prinzip</strong>: mit einigen
           bewussten Einschränkungen, die wir transparent machen.
@@ -47,41 +47,41 @@ import Layout from '../layouts/Layout.astro';
             <span class="transition-transform group-open:rotate-90 inline-block">›</span>
             Was der Server theoretisch inferieren kann (Threat Model)
           </summary>
-          <div class="mt-3 text-sm text-slate-600 dark:text-slate-400 space-y-3 pl-4 border-l-2 border-slate-200 dark:border-slate-700">
+          <div class="mt-3 text-sm text-text-muted space-y-3 pl-4 border-l-2 border-border">
             <div>
-              <p class="font-medium text-slate-800 dark:text-slate-200">Anzahl der Teilnehmer:innen</p>
+              <p class="font-medium text-text-strong">Anzahl der Teilnehmer:innen</p>
               <p class="mt-0.5">Jedes Gebot ist ein separater verschlüsselter Eintrag im Server-Store — der Server kann Einträge zählen und so die ungefähre Teilnehmerzahl inferieren.</p>
             </div>
             <div>
-              <p class="font-medium text-slate-800 dark:text-slate-200">Zeitpunkte der Gebots-Einreichung</p>
+              <p class="font-medium text-text-strong">Zeitpunkte der Gebots-Einreichung</p>
               <p class="mt-0.5">Der Server sieht, wann ein Gebot einging. Muster (z.&nbsp;B. alle binnen 5 Minuten) können auf Gruppenverhalten hindeuten.</p>
             </div>
             <div>
-              <p class="font-medium text-slate-800 dark:text-slate-200">Existenz einer Runde</p>
+              <p class="font-medium text-text-strong">Existenz einer Runde</p>
               <p class="mt-0.5">Eine Runden-ID existiert auf dem Server und ist aktiv oder nicht — ohne Klartext-Bezug zum Inhalt.</p>
             </div>
             <div class="pt-1">
-              <p class="font-medium text-slate-800 dark:text-slate-200">Was der Server <em>nicht</em> sieht</p>
+              <p class="font-medium text-text-strong">Was der Server <em>nicht</em> sieht</p>
               <p class="mt-0.5">Namen, Gebotsbeträge, Typen-Auswahl, Emoji-IDs, Admin-Schlüssel — all das bleibt verschlüsselt.</p>
             </div>
           </div>
         </details>
       </div>
 
-      <div class="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
-        <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">Vertrauen in die Organisator:in</h2>
-        <p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed mb-3">
+      <div class="rounded-xl border border-border bg-surface-raised p-6">
+        <h2 class="text-lg font-semibold text-text mb-2">Vertrauen in die Organisator:in</h2>
+        <p class="text-sm text-text-muted leading-relaxed mb-3">
           Die App ist <strong>kein Zero-Trust-System</strong>. Die Organisator:in hat den
           privaten Admin-Schlüssel und kann damit technisch alle Gebote entschlüsseln —
           das Frontend zeigt ihr nur die Auswertungstabelle, aber der Zugriff auf Rohwerte
           wäre im Code möglich.
         </p>
-        <p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed mb-3">
+        <p class="text-sm text-text-muted leading-relaxed mb-3">
           Teilnehmer:innen hingegen können <strong>keine</strong> Gebote anderer sehen:
           Gebote sind mit dem öffentlichen Admin-Schlüssel verschlüsselt und nur mit dem
           privaten Schlüssel der Organisator:in lesbar.
         </p>
-        <p class="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">
+        <p class="text-sm text-text-muted leading-relaxed">
           Vertrauen in die Organisator:in ist Teil des Modells — vergleichbar mit einer
           Kassenprüfer:in in einer Genossenschaft: Kontrolle durch Transparenz, nicht durch
           technische Sperre.

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -28,7 +28,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           <hr class="my-1 border-border" />
           <button
             id="zuruecksetzen-btn"
-            class="w-full text-left px-3 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+            class="w-full text-left px-3 py-2 text-sm text-danger-fg hover:bg-danger-subtle dark:hover:bg-red-900/20 rounded-lg transition-colors"
           >
             Zurücksetzen
           </button>
@@ -134,7 +134,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           ` : ''}
           <button
             data-id="${runde.id}"
-            class="loeschen-btn ml-auto text-xs text-red-400 hover:text-red-600 transition-colors"
+            class="loeschen-btn ml-auto text-xs text-fg-muted hover:text-danger-fg transition-colors"
           >
             Löschen
           </button>

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -8,24 +8,24 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-2xl font-semibold mb-1">Meine Runden</h1>
-        <p class="text-slate-500 dark:text-slate-400 text-sm">Gespeichert in deinem Browser.</p>
+        <p class="text-text-muted text-sm">Gespeichert in deinem Browser.</p>
       </div>
       <details class="relative">
-        <summary class="cursor-pointer text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
-        <div class="absolute right-0 top-9 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg z-10 min-w-36 p-1">
+        <summary class="cursor-pointer text-text-faint hover:text-text-secondary transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
+        <div class="absolute right-0 top-9 bg-surface-raised border border-border rounded-xl shadow-lg z-10 min-w-36 p-1">
           <button
             id="export-btn"
-            class="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 rounded-lg transition-colors"
+            class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:bg-surface-elevated rounded-lg transition-colors"
           >
             Exportieren
           </button>
           <button
             id="import-btn"
-            class="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 rounded-lg transition-colors"
+            class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:bg-surface-elevated rounded-lg transition-colors"
           >
             Importieren
           </button>
-          <hr class="my-1 border-slate-100 dark:border-slate-700" />
+          <hr class="my-1 border-border" />
           <button
             id="zuruecksetzen-btn"
             class="w-full text-left px-3 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
@@ -41,7 +41,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <FeedbackBox id="import-fehler" />
 
     <!-- Leer-Zustand -->
-    <div id="leer-zustand" class="hidden text-center py-16 text-slate-500 dark:text-slate-400">
+    <div id="leer-zustand" class="hidden text-center py-16 text-text-muted">
       <p class="mb-4">Noch keine Runden gespeichert.</p>
       <a href="/neu" class="inline-block bg-brand text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-brand-dark transition-colors">
         Neue Runde erstellen
@@ -101,26 +101,26 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     for (const runde of runden) {
       const istAdmin = !!runde.adminLink;
       const karte = document.createElement('div');
-      karte.className = 'bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-4 space-y-3';
+      karte.className = 'bg-surface-raised border border-border rounded-xl p-4 space-y-3';
 
       const badge = istAdmin
         ? '<span class="text-xs font-medium text-amber-700 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 rounded-full">Admin</span>'
-        : '<span class="text-xs font-medium text-slate-600 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 px-2 py-0.5 rounded-full">Teilnehmer:in</span>';
+        : '<span class="text-xs font-medium text-text-muted bg-surface-elevated px-2 py-0.5 rounded-full">Teilnehmer:in</span>';
 
       karte.innerHTML = `
         <div class="flex items-start justify-between gap-2">
           <div class="space-y-1">
             <div class="flex items-center gap-2 flex-wrap">
               ${badge}
-              <span class="text-sm font-medium text-slate-800 dark:text-slate-200">${runde.name}</span>
+              <span class="text-sm font-medium text-text-strong">${runde.name}</span>
             </div>
-            <p class="text-xs text-slate-400 dark:text-slate-500">Hinzugefügt am ${formatDatum(runde.hinzugefuegtAm)}</p>
+            <p class="text-xs text-text-faint">Hinzugefügt am ${formatDatum(runde.hinzugefuegtAm)}</p>
           </div>
         </div>
         <div class="flex flex-wrap items-center gap-2">
           <a
             href="${runde.teilnehmerLink}"
-            class="inline-flex items-center gap-1 border border-slate-300 dark:border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+            class="inline-flex items-center gap-1 border border-border-strong rounded-lg px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-elevated transition-colors"
           >
             Runde öffnen ↗
           </a>

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -8,20 +8,20 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-2xl font-semibold mb-1">Meine Runden</h1>
-        <p class="text-text-muted text-sm">Gespeichert in deinem Browser.</p>
+        <p class="text-fg-muted text-sm">Gespeichert in deinem Browser.</p>
       </div>
       <details class="relative">
-        <summary class="cursor-pointer text-text-faint hover:text-text-secondary transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
+        <summary class="cursor-pointer text-fg-faint hover:text-fg-secondary transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
         <div class="absolute right-0 top-9 bg-surface-raised border border-border rounded-xl shadow-lg z-10 min-w-36 p-1">
           <button
             id="export-btn"
-            class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:bg-surface-elevated rounded-lg transition-colors"
+            class="w-full text-left px-3 py-2 text-sm text-fg-secondary hover:bg-surface-elevated rounded-lg transition-colors"
           >
             Exportieren
           </button>
           <button
             id="import-btn"
-            class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:bg-surface-elevated rounded-lg transition-colors"
+            class="w-full text-left px-3 py-2 text-sm text-fg-secondary hover:bg-surface-elevated rounded-lg transition-colors"
           >
             Importieren
           </button>
@@ -41,7 +41,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <FeedbackBox id="import-fehler" />
 
     <!-- Leer-Zustand -->
-    <div id="leer-zustand" class="hidden text-center py-16 text-text-muted">
+    <div id="leer-zustand" class="hidden text-center py-16 text-fg-muted">
       <p class="mb-4">Noch keine Runden gespeichert.</p>
       <a href="/neu" class="inline-block bg-brand text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-brand-dark transition-colors">
         Neue Runde erstellen
@@ -105,22 +105,22 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 
       const badge = istAdmin
         ? '<span class="text-xs font-medium text-amber-700 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 rounded-full">Admin</span>'
-        : '<span class="text-xs font-medium text-text-muted bg-surface-elevated px-2 py-0.5 rounded-full">Teilnehmer:in</span>';
+        : '<span class="text-xs font-medium text-fg-muted bg-surface-elevated px-2 py-0.5 rounded-full">Teilnehmer:in</span>';
 
       karte.innerHTML = `
         <div class="flex items-start justify-between gap-2">
           <div class="space-y-1">
             <div class="flex items-center gap-2 flex-wrap">
               ${badge}
-              <span class="text-sm font-medium text-text-strong">${runde.name}</span>
+              <span class="text-sm font-medium text-fg-strong">${runde.name}</span>
             </div>
-            <p class="text-xs text-text-faint">Hinzugefügt am ${formatDatum(runde.hinzugefuegtAm)}</p>
+            <p class="text-xs text-fg-faint">Hinzugefügt am ${formatDatum(runde.hinzugefuegtAm)}</p>
           </div>
         </div>
         <div class="flex flex-wrap items-center gap-2">
           <a
             href="${runde.teilnehmerLink}"
-            class="inline-flex items-center gap-1 border border-border-strong rounded-lg px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-elevated transition-colors"
+            class="inline-flex items-center gap-1 border border-border-strong rounded-lg px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-elevated transition-colors"
           >
             Runde öffnen ↗
           </a>

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -10,10 +10,10 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       <h1 class="text-2xl font-semibold">Neue Runde erstellen</h1>
       <div class="relative">
         <button id="power-menu-btn" type="button" aria-label="Weitere Optionen" aria-expanded="false"
-          class="text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 text-xl leading-none px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">⋯</button>
-        <div id="power-menu" class="hidden absolute right-0 mt-1 w-52 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg z-10 py-1">
+          class="text-text-faint hover:text-text-secondary text-xl leading-none px-2 py-1 rounded hover:bg-surface-hover transition-colors">⋯</button>
+        <div id="power-menu" class="hidden absolute right-0 mt-1 w-52 bg-surface-raised border border-border rounded-lg shadow-lg z-10 py-1">
           <button id="splid-import-btn" type="button"
-            class="w-full text-left text-sm px-4 py-2 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors">Abrechnung importieren</button>
+            class="w-full text-left text-sm px-4 py-2 text-text-secondary hover:bg-surface-elevated transition-colors">Abrechnung importieren</button>
         </div>
       </div>
     </div>
@@ -24,7 +24,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <form id="runde-form" class="space-y-6">
       <!-- Runden-Name -->
       <div>
-        <label for="rundeName" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+        <label for="rundeName" class="block text-sm font-medium text-text-secondary mb-1">
           Name der Runde
         </label>
         <input
@@ -33,13 +33,13 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           name="rundeName"
           required
           placeholder="z.B. Haushaltskasse Oktober"
-          class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
         />
       </div>
 
       <!-- Gesamtkosten -->
       <div>
-        <label for="gesamtkosten" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+        <label for="gesamtkosten" class="block text-sm font-medium text-text-secondary mb-1">
           Gesamtkosten (€)
         </label>
         <input
@@ -49,14 +49,14 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           name="gesamtkosten"
           required
           placeholder="z.B. 1200"
-          class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
         />
       </div>
 
       <!-- Personen -->
       <div>
         <div class="flex items-center justify-between mb-2">
-          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300">Personen</label>
+          <label class="block text-sm font-medium text-text-secondary">Personen</label>
           <div class="flex items-center gap-3">
             <button
               type="button"
@@ -69,62 +69,62 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         </div>
         <div id="slots-container" class="space-y-2">
           <!-- Initial ein Slot -->
-          <div class="slot-eintrag bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3 space-y-2">
+          <div class="slot-eintrag bg-surface-raised border border-border rounded-lg p-3 space-y-2">
             <div class="flex items-center gap-2 min-w-0">
               <input
                 type="text"
                 name="label[]"
                 placeholder="Erwachsen"
-                class="min-w-0 flex-1 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+                class="min-w-0 flex-1 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
               />
               <!-- Ausgaben inline (nur sichtbar wenn Toggle aktiv) -->
               <div class="ausgaben-inline hidden flex items-center gap-1 shrink-0">
-                <span class="text-xs text-slate-400 dark:text-slate-500">€</span>
+                <span class="text-xs text-text-faint">€</span>
                 <input
                   type="text"
                   inputmode="decimal"
                   name="ausgaben[]"
                   placeholder="0,00"
-                  class="w-20 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                  class="w-20 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                 />
               </div>
               <button
                 type="button"
-                class="slot-entfernen shrink-0 text-slate-400 dark:text-slate-600 hover:text-red-500 text-lg leading-none hidden"
+                class="slot-entfernen shrink-0 text-text-faint hover:text-red-500 text-lg leading-none hidden"
                 aria-label="Slot entfernen"
               >×</button>
             </div>
-            <span class="standardgebot-richtwert text-xs text-slate-400 dark:text-slate-500"></span>
+            <span class="standardgebot-richtwert text-xs text-text-faint"></span>
 
             <!-- Erweiterte Optionen (eingeklappt) -->
             <details class="slot-erweitert-details">
-              <summary class="text-xs text-slate-400 dark:text-slate-500 cursor-pointer hover:text-slate-600 dark:hover:text-slate-300 transition-colors select-none list-none flex items-center gap-1">
+              <summary class="text-xs text-text-faint cursor-pointer hover:text-text-secondary transition-colors select-none list-none flex items-center gap-1">
                 <span class="inline-block transition-transform details-arrow">›</span> Erweitert
               </summary>
               <div class="pt-3 space-y-3">
                 <!-- Gewichtungs-Kategorien -->
                 <div class="slot-gewichtung-gruppe">
-                  <p class="text-xs text-slate-500 dark:text-slate-400 mb-1.5">Gewichtung</p>
+                  <p class="text-xs text-text-muted mb-1.5">Gewichtung</p>
                   <div class="flex flex-wrap gap-1.5">
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="1.0" checked />
-                      <span class="slot-gewichtung-badge inline-block border border-slate-200 dark:border-slate-600 rounded-md px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-green-500 transition-colors">Erwachsen</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-text-secondary hover:border-green-500 transition-colors">Erwachsen</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.75" />
-                      <span class="slot-gewichtung-badge inline-block border border-slate-200 dark:border-slate-600 rounded-md px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-green-500 transition-colors">Ermäßigt</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-text-secondary hover:border-green-500 transition-colors">Ermäßigt</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.5" />
-                      <span class="slot-gewichtung-badge inline-block border border-slate-200 dark:border-slate-600 rounded-md px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-green-500 transition-colors">Kind</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-text-secondary hover:border-green-500 transition-colors">Kind</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="manuell" />
-                      <span class="slot-gewichtung-badge inline-block border border-slate-200 dark:border-slate-600 rounded-md px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-green-500 transition-colors">Manuell</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-text-secondary hover:border-green-500 transition-colors">Manuell</span>
                     </label>
                     <input
                       type="number"
-                      class="slot-gewichtung-manuell w-16 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-green-600"
                       min="0.1"
                       max="2"
                       step="0.05"
@@ -137,7 +137,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                 </div>
                 <!-- Anzahl -->
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-slate-500 dark:text-slate-400">Anzahl</span>
+                  <span class="text-xs text-text-muted">Anzahl</span>
                   <input
                     type="number"
                     name="anzahl[]"
@@ -145,12 +145,12 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                     min="1"
                     step="1"
                     required
-                    class="w-16 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
+                    class="w-16 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
                   />
                 </div>
                 <!-- Standardgebot -->
                 <div class="standardgebot-zeile flex items-center gap-2 flex-wrap">
-                  <label class="flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400 cursor-pointer select-none">
+                  <label class="flex items-center gap-1 text-xs text-text-muted cursor-pointer select-none">
                     <input type="checkbox" class="standardgebot-checkbox accent-green-700" />
                     Standardgebot festlegen
                   </label>
@@ -160,7 +160,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       inputmode="decimal"
                       name="standardgebot[]"
                       data-auto="true"
-                      class="w-28 border border-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="w-28 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                     />
                   </div>
                 </div>
@@ -172,7 +172,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           type="button"
           id="ausgaben-link"
           aria-expanded="false"
-          class="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 mt-1 transition-colors"
+          class="text-xs text-text-faint hover:text-text-secondary mt-1 transition-colors"
         >+ Ausgaben erfassen</button>
       </div>
 
@@ -195,21 +195,21 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <!-- Header -->
     <div class="text-center pt-4 pb-2">
       <div class="text-5xl text-brand mb-3">✓</div>
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-1">Runde erstellt!</h1>
-      <p class="text-sm text-slate-500 dark:text-slate-400">Speichere beide Links — sie werden hier nicht erneut angezeigt.</p>
+      <h1 class="text-2xl font-bold text-text mb-1">Runde erstellt!</h1>
+      <p class="text-sm text-text-muted">Speichere beide Links — sie werden hier nicht erneut angezeigt.</p>
     </div>
 
     <!-- Teilnehmer-Link (primär) -->
-    <div class="bg-white dark:bg-slate-800 border border-brand/30 dark:border-brand/40 rounded-xl p-5 space-y-3">
+    <div class="bg-surface-raised border border-brand/30 dark:border-brand/40 rounded-xl p-5 space-y-3">
       <div>
-        <p class="text-sm font-semibold text-slate-900 dark:text-slate-100">Teilnehmer:innen-Link</p>
-        <p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">Diesen Link mit allen Teilnehmenden teilen</p>
+        <p class="text-sm font-semibold text-text">Teilnehmer:innen-Link</p>
+        <p class="text-xs text-text-muted mt-0.5">Diesen Link mit allen Teilnehmenden teilen</p>
       </div>
       <input
         id="teilnehmer-link"
         type="text"
         readonly
-        class="w-full border border-slate-200 dark:border-slate-600 rounded-md px-2 py-1.5 text-xs text-slate-600 dark:text-slate-300 bg-slate-50 dark:bg-slate-700 font-mono"
+        class="w-full border border-border-strong rounded-md px-2 py-1.5 text-xs text-text-secondary bg-surface-elevated font-mono"
       />
       <div class="flex gap-2">
         <button
@@ -223,7 +223,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           href="#"
           target="_blank"
           rel="noopener"
-          class="border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-2 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors whitespace-nowrap"
+          class="border border-border-strong rounded-lg px-4 py-2 text-sm text-text-secondary hover:bg-surface-elevated transition-colors whitespace-nowrap"
         >
           Öffnen ↗
         </a>
@@ -266,7 +266,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 
     <a
       href="/neu"
-      class="block text-center text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+      class="block text-center text-sm text-text-muted hover:text-text-strong transition-colors"
     >
       Weitere Runde erstellen →
     </a>

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -10,10 +10,10 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       <h1 class="text-2xl font-semibold">Neue Runde erstellen</h1>
       <div class="relative">
         <button id="power-menu-btn" type="button" aria-label="Weitere Optionen" aria-expanded="false"
-          class="text-text-faint hover:text-text-secondary text-xl leading-none px-2 py-1 rounded hover:bg-surface-hover transition-colors">⋯</button>
+          class="text-fg-faint hover:text-fg-secondary text-xl leading-none px-2 py-1 rounded hover:bg-surface-hover transition-colors">⋯</button>
         <div id="power-menu" class="hidden absolute right-0 mt-1 w-52 bg-surface-raised border border-border rounded-lg shadow-lg z-10 py-1">
           <button id="splid-import-btn" type="button"
-            class="w-full text-left text-sm px-4 py-2 text-text-secondary hover:bg-surface-elevated transition-colors">Abrechnung importieren</button>
+            class="w-full text-left text-sm px-4 py-2 text-fg-secondary hover:bg-surface-elevated transition-colors">Abrechnung importieren</button>
         </div>
       </div>
     </div>
@@ -24,7 +24,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <form id="runde-form" class="space-y-6">
       <!-- Runden-Name -->
       <div>
-        <label for="rundeName" class="block text-sm font-medium text-text-secondary mb-1">
+        <label for="rundeName" class="block text-sm font-medium text-fg-secondary mb-1">
           Name der Runde
         </label>
         <input
@@ -33,13 +33,13 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           name="rundeName"
           required
           placeholder="z.B. Haushaltskasse Oktober"
-          class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
         />
       </div>
 
       <!-- Gesamtkosten -->
       <div>
-        <label for="gesamtkosten" class="block text-sm font-medium text-text-secondary mb-1">
+        <label for="gesamtkosten" class="block text-sm font-medium text-fg-secondary mb-1">
           Gesamtkosten (€)
         </label>
         <input
@@ -49,14 +49,14 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           name="gesamtkosten"
           required
           placeholder="z.B. 1200"
-          class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
         />
       </div>
 
       <!-- Personen -->
       <div>
         <div class="flex items-center justify-between mb-2">
-          <label class="block text-sm font-medium text-text-secondary">Personen</label>
+          <label class="block text-sm font-medium text-fg-secondary">Personen</label>
           <div class="flex items-center gap-3">
             <button
               type="button"
@@ -75,56 +75,56 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                 type="text"
                 name="label[]"
                 placeholder="Erwachsen"
-                class="min-w-0 flex-1 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+                class="min-w-0 flex-1 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
               />
               <!-- Ausgaben inline (nur sichtbar wenn Toggle aktiv) -->
               <div class="ausgaben-inline hidden flex items-center gap-1 shrink-0">
-                <span class="text-xs text-text-faint">€</span>
+                <span class="text-xs text-fg-faint">€</span>
                 <input
                   type="text"
                   inputmode="decimal"
                   name="ausgaben[]"
                   placeholder="0,00"
-                  class="w-20 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                  class="w-20 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                 />
               </div>
               <button
                 type="button"
-                class="slot-entfernen shrink-0 text-text-faint hover:text-red-500 text-lg leading-none hidden"
+                class="slot-entfernen shrink-0 text-fg-faint hover:text-red-500 text-lg leading-none hidden"
                 aria-label="Slot entfernen"
               >×</button>
             </div>
-            <span class="standardgebot-richtwert text-xs text-text-faint"></span>
+            <span class="standardgebot-richtwert text-xs text-fg-faint"></span>
 
             <!-- Erweiterte Optionen (eingeklappt) -->
             <details class="slot-erweitert-details">
-              <summary class="text-xs text-text-faint cursor-pointer hover:text-text-secondary transition-colors select-none list-none flex items-center gap-1">
+              <summary class="text-xs text-fg-faint cursor-pointer hover:text-fg-secondary transition-colors select-none list-none flex items-center gap-1">
                 <span class="inline-block transition-transform details-arrow">›</span> Erweitert
               </summary>
               <div class="pt-3 space-y-3">
                 <!-- Gewichtungs-Kategorien -->
                 <div class="slot-gewichtung-gruppe">
-                  <p class="text-xs text-text-muted mb-1.5">Gewichtung</p>
+                  <p class="text-xs text-fg-muted mb-1.5">Gewichtung</p>
                   <div class="flex flex-wrap gap-1.5">
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="1.0" checked />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-text-secondary hover:border-green-500 transition-colors">Erwachsen</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-green-500 transition-colors">Erwachsen</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.75" />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-text-secondary hover:border-green-500 transition-colors">Ermäßigt</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-green-500 transition-colors">Ermäßigt</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.5" />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-text-secondary hover:border-green-500 transition-colors">Kind</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-green-500 transition-colors">Kind</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="manuell" />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-text-secondary hover:border-green-500 transition-colors">Manuell</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-green-500 transition-colors">Manuell</span>
                     </label>
                     <input
                       type="number"
-                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-green-600"
                       min="0.1"
                       max="2"
                       step="0.05"
@@ -137,7 +137,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                 </div>
                 <!-- Anzahl -->
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-text-muted">Anzahl</span>
+                  <span class="text-xs text-fg-muted">Anzahl</span>
                   <input
                     type="number"
                     name="anzahl[]"
@@ -145,12 +145,12 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                     min="1"
                     step="1"
                     required
-                    class="w-16 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
+                    class="w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
                   />
                 </div>
                 <!-- Standardgebot -->
                 <div class="standardgebot-zeile flex items-center gap-2 flex-wrap">
-                  <label class="flex items-center gap-1 text-xs text-text-muted cursor-pointer select-none">
+                  <label class="flex items-center gap-1 text-xs text-fg-muted cursor-pointer select-none">
                     <input type="checkbox" class="standardgebot-checkbox accent-green-700" />
                     Standardgebot festlegen
                   </label>
@@ -160,7 +160,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       inputmode="decimal"
                       name="standardgebot[]"
                       data-auto="true"
-                      class="w-28 border border-border-strong bg-surface-elevated text-text rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="w-28 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
                     />
                   </div>
                 </div>
@@ -172,7 +172,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           type="button"
           id="ausgaben-link"
           aria-expanded="false"
-          class="text-xs text-text-faint hover:text-text-secondary mt-1 transition-colors"
+          class="text-xs text-fg-faint hover:text-fg-secondary mt-1 transition-colors"
         >+ Ausgaben erfassen</button>
       </div>
 
@@ -195,21 +195,21 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <!-- Header -->
     <div class="text-center pt-4 pb-2">
       <div class="text-5xl text-brand mb-3">✓</div>
-      <h1 class="text-2xl font-bold text-text mb-1">Runde erstellt!</h1>
-      <p class="text-sm text-text-muted">Speichere beide Links — sie werden hier nicht erneut angezeigt.</p>
+      <h1 class="text-2xl font-bold text-fg mb-1">Runde erstellt!</h1>
+      <p class="text-sm text-fg-muted">Speichere beide Links — sie werden hier nicht erneut angezeigt.</p>
     </div>
 
     <!-- Teilnehmer-Link (primär) -->
     <div class="bg-surface-raised border border-brand/30 dark:border-brand/40 rounded-xl p-5 space-y-3">
       <div>
-        <p class="text-sm font-semibold text-text">Teilnehmer:innen-Link</p>
-        <p class="text-xs text-text-muted mt-0.5">Diesen Link mit allen Teilnehmenden teilen</p>
+        <p class="text-sm font-semibold text-fg">Teilnehmer:innen-Link</p>
+        <p class="text-xs text-fg-muted mt-0.5">Diesen Link mit allen Teilnehmenden teilen</p>
       </div>
       <input
         id="teilnehmer-link"
         type="text"
         readonly
-        class="w-full border border-border-strong rounded-md px-2 py-1.5 text-xs text-text-secondary bg-surface-elevated font-mono"
+        class="w-full border border-border-strong rounded-md px-2 py-1.5 text-xs text-fg-secondary bg-surface-elevated font-mono"
       />
       <div class="flex gap-2">
         <button
@@ -223,7 +223,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           href="#"
           target="_blank"
           rel="noopener"
-          class="border border-border-strong rounded-lg px-4 py-2 text-sm text-text-secondary hover:bg-surface-elevated transition-colors whitespace-nowrap"
+          class="border border-border-strong rounded-lg px-4 py-2 text-sm text-fg-secondary hover:bg-surface-elevated transition-colors whitespace-nowrap"
         >
           Öffnen ↗
         </a>
@@ -231,7 +231,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     </div>
 
     <!-- Admin-Link (sekundär) -->
-    <div class="bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded-xl p-5 space-y-3">
+    <div class="bg-warning-subtle dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded-xl p-5 space-y-3">
       <div>
         <p class="text-sm font-semibold text-amber-900 dark:text-amber-300">⚠ Admin-Link</p>
         <p class="text-xs text-amber-700 dark:text-amber-400 mt-0.5">Nur für dich — sicher aufbewahren</p>
@@ -266,7 +266,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 
     <a
       href="/neu"
-      class="block text-center text-sm text-text-muted hover:text-text-strong transition-colors"
+      class="block text-center text-sm text-fg-muted hover:text-fg-strong transition-colors"
     >
       Weitere Runde erstellen →
     </a>

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -33,7 +33,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           name="rundeName"
           required
           placeholder="z.B. Haushaltskasse Oktober"
-          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
         />
       </div>
 
@@ -49,7 +49,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           name="gesamtkosten"
           required
           placeholder="z.B. 1200"
-          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
         />
       </div>
 
@@ -61,7 +61,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
             <button
               type="button"
               id="slot-hinzufuegen"
-              class="text-sm text-green-700 hover:text-green-900 font-medium"
+              class="text-sm text-brand hover:text-brand-dark font-medium"
             >
               + Person hinzufügen
             </button>
@@ -75,7 +75,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                 type="text"
                 name="label[]"
                 placeholder="Erwachsen"
-                class="min-w-0 flex-1 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+                class="min-w-0 flex-1 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
               />
               <!-- Ausgaben inline (nur sichtbar wenn Toggle aktiv) -->
               <div class="ausgaben-inline hidden flex items-center gap-1 shrink-0">
@@ -85,12 +85,12 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                   inputmode="decimal"
                   name="ausgaben[]"
                   placeholder="0,00"
-                  class="w-20 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                  class="w-20 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-brand"
                 />
               </div>
               <button
                 type="button"
-                class="slot-entfernen shrink-0 text-fg-faint hover:text-red-500 text-lg leading-none hidden"
+                class="slot-entfernen shrink-0 text-fg-faint hover:text-danger-fg text-lg leading-none hidden"
                 aria-label="Slot entfernen"
               >×</button>
             </div>
@@ -108,23 +108,23 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                   <div class="flex flex-wrap gap-1.5">
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="1.0" checked />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-green-500 transition-colors">Erwachsen</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Erwachsen</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.75" />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-green-500 transition-colors">Ermäßigt</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Ermäßigt</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.5" />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-green-500 transition-colors">Kind</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Kind</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="manuell" />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-green-500 transition-colors">Manuell</span>
+                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Manuell</span>
                     </label>
                     <input
                       type="number"
-                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand"
                       min="0.1"
                       max="2"
                       step="0.05"
@@ -145,13 +145,13 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                     min="1"
                     step="1"
                     required
-                    class="w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-green-600"
+                    class="w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-center focus:outline-none focus:ring-2 focus:ring-brand"
                   />
                 </div>
                 <!-- Standardgebot -->
                 <div class="standardgebot-zeile flex items-center gap-2 flex-wrap">
                   <label class="flex items-center gap-1 text-xs text-fg-muted cursor-pointer select-none">
-                    <input type="checkbox" class="standardgebot-checkbox accent-green-700" />
+                    <input type="checkbox" class="standardgebot-checkbox accent-brand" />
                     Standardgebot festlegen
                   </label>
                   <div class="standardgebot-eingabe hidden flex items-center gap-1">
@@ -160,7 +160,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       inputmode="decimal"
                       name="standardgebot[]"
                       data-auto="true"
-                      class="w-28 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-600"
+                      class="w-28 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1.5 text-sm text-right focus:outline-none focus:ring-2 focus:ring-brand"
                     />
                   </div>
                 </div>
@@ -183,7 +183,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       <button
         type="submit"
         id="submit-btn"
-        class="w-full bg-green-700 text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-green-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        class="w-full bg-brand text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-brand-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         Runde erstellen
       </button>

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -28,7 +28,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     <div class="flex border-b border-border">
       <button
         id="tab-abgeben"
-        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-success-fg -mb-px transition-colors"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-brand -mb-px transition-colors"
       >
         Gebot abgeben
       </button>
@@ -350,11 +350,11 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     function zeigeTab(tab: 'abgeben' | 'korrigieren') {
       const istAbgeben = tab === 'abgeben';
       tabAbgeben.classList.toggle('border-green-600', istAbgeben);
-      tabAbgeben.classList.toggle('text-success-fg', istAbgeben);
+      tabAbgeben.classList.toggle('text-brand', istAbgeben);
       tabAbgeben.classList.toggle('border-transparent', !istAbgeben);
       tabAbgeben.classList.toggle('text-fg-muted', !istAbgeben);
       tabKorrigieren.classList.toggle('border-green-600', !istAbgeben);
-      tabKorrigieren.classList.toggle('text-success-fg', !istAbgeben);
+      tabKorrigieren.classList.toggle('text-brand', !istAbgeben);
       tabKorrigieren.classList.toggle('border-transparent', istAbgeben);
       tabKorrigieren.classList.toggle('text-fg-muted', istAbgeben);
       panelAbgeben.classList.toggle('hidden', !istAbgeben);
@@ -532,7 +532,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
           r.disabled = true;
         });
         korrekturSlotHinweis.textContent = `Slot aus deinem ursprünglichen Gebot: ${bekannterSlot}`;
-        korrekturSlotHinweis.className = 'text-xs text-success-fg mt-1';
+        korrekturSlotHinweis.className = 'text-xs text-brand mt-1';
         betragFeldAktualisieren(slotIdx, 'korrektur-betrag', 'korrektur-richtwert-hinweis');
       } else {
         radios.forEach((r) => { r.disabled = false; });

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -28,7 +28,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     <div class="flex border-b border-border">
       <button
         id="tab-abgeben"
-        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-brand -mb-px transition-colors"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-brand text-brand -mb-px transition-colors"
       >
         Gebot abgeben
       </button>
@@ -62,7 +62,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
-            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
           <p id="betrag-richtwert-hinweis" class="text-xs text-fg-faint mt-1"></p>
         </div>
@@ -93,7 +93,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         <button
           type="submit"
           id="gebot-btn"
-          class="w-full bg-green-700 text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-green-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          class="w-full bg-brand text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-brand-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Gebot abgeben
         </button>
@@ -120,7 +120,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             name="emojiId"
             required
             placeholder="z.B. 🦊🌙⭐"
-            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
           <p class="text-xs text-fg-faint mt-1">Die 3 Emojis, die dir beim Abgeben angezeigt wurden.</p>
         </div>
@@ -145,7 +145,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
-            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
           <p id="korrektur-richtwert-hinweis" class="text-xs text-fg-faint mt-1"></p>
         </div>
@@ -156,7 +156,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         <button
           type="submit"
           id="korrektur-btn"
-          class="w-full bg-green-700 text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-green-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          class="w-full bg-brand text-white rounded-lg px-4 py-2.5 text-sm font-medium hover:bg-brand-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Gebot ersetzen
         </button>
@@ -288,13 +288,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         const bereitsGeboten = slotBereitsGeboten(slot.label);
         const label = document.createElement('label');
         label.className =
-          'flex items-center gap-3 bg-surface-raised border border-border rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-success-subtle dark:has-[:checked]:bg-green-950/40 transition-colors';
+          'flex items-center gap-3 bg-surface-raised border border-border rounded-lg p-3 cursor-pointer hover:border-brand has-[:checked]:border-brand has-[:checked]:bg-success-subtle dark:has-[:checked]:bg-green-950/40 transition-colors';
         label.innerHTML = `
-          <input type="radio" name="${nameAttr}" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
+          <input type="radio" name="${nameAttr}" value="${idx}" class="accent-brand" ${idx === 0 ? 'checked' : ''} />
           <span class="flex-1">
             <span class="text-sm font-medium text-fg-strong">${slot.label}</span>
             <span class="text-xs text-fg-muted ml-2">Richtwert: ${formatEur(richtwertSlot)}</span>
-            ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-green-600 ml-1 text-xs">✓ abgegeben</span>' : ''}
+            ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-success-fg ml-1 text-xs">✓ abgegeben</span>' : ''}
           </span>
         `;
         container.appendChild(label);
@@ -349,11 +349,11 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
     function zeigeTab(tab: 'abgeben' | 'korrigieren') {
       const istAbgeben = tab === 'abgeben';
-      tabAbgeben.classList.toggle('border-green-600', istAbgeben);
+      tabAbgeben.classList.toggle('border-brand', istAbgeben);
       tabAbgeben.classList.toggle('text-brand', istAbgeben);
       tabAbgeben.classList.toggle('border-transparent', !istAbgeben);
       tabAbgeben.classList.toggle('text-fg-muted', !istAbgeben);
-      tabKorrigieren.classList.toggle('border-green-600', !istAbgeben);
+      tabKorrigieren.classList.toggle('border-brand', !istAbgeben);
       tabKorrigieren.classList.toggle('text-brand', !istAbgeben);
       tabKorrigieren.classList.toggle('border-transparent', istAbgeben);
       tabKorrigieren.classList.toggle('text-fg-muted', istAbgeben);

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -5,12 +5,12 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
 <Layout title="Runde">
   <!-- Laden -->
-  <div id="zustand-laden" class="text-center py-12 text-slate-500 dark:text-slate-400 text-sm">
+  <div id="zustand-laden" class="text-center py-12 text-text-muted text-sm">
     Lade Runde…
   </div>
 
   <!-- Fehler -->
-  <div id="zustand-fehler" class="hidden bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-xl p-5">
+  <div id="zustand-fehler" class="hidden bg-danger-bg border border-danger-border text-danger-text rounded-xl p-5">
     <p class="font-medium mb-1">Fehler</p>
     <p id="fehler-text" class="text-sm"></p>
   </div>
@@ -19,22 +19,22 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   <div id="zustand-formular" class="hidden space-y-6">
     <div>
       <h1 id="runde-name" class="text-2xl font-semibold mb-1"></h1>
-      <p class="text-slate-500 dark:text-slate-400 text-sm">
-        Gesamtkosten: <span id="gesamtkosten" class="font-medium text-slate-700 dark:text-slate-200"></span>
+      <p class="text-text-muted text-sm">
+        Gesamtkosten: <span id="gesamtkosten" class="font-medium text-text-strong"></span>
       </p>
     </div>
 
     <!-- Tab-Navigation -->
-    <div class="flex border-b border-slate-200 dark:border-slate-700">
+    <div class="flex border-b border-border">
       <button
         id="tab-abgeben"
-        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-green-700 dark:text-green-400 -mb-px transition-colors"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-success-text -mb-px transition-colors"
       >
         Gebot abgeben
       </button>
       <button
         id="tab-korrigieren"
-        class="hidden px-4 py-2 text-sm font-medium border-b-2 border-transparent text-slate-500 dark:text-slate-400 -mb-px hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+        class="hidden px-4 py-2 text-sm font-medium border-b-2 border-transparent text-text-muted -mb-px hover:text-text-strong transition-colors"
       >
         Gebot korrigieren
       </button>
@@ -45,13 +45,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       <form id="gebot-form" class="space-y-5">
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Wähle deinen Slot</p>
+          <p class="text-sm font-medium text-text-secondary mb-2">Wähle deinen Slot</p>
           <div id="slot-auswahl" class="space-y-2"></div>
         </div>
 
         <!-- Betrag -->
         <div>
-          <label for="betrag" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          <label for="betrag" class="block text-sm font-medium text-text-secondary mb-1">
             Dein Gebot (€)
           </label>
           <input
@@ -62,9 +62,9 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
-            class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
-          <p id="betrag-richtwert-hinweis" class="text-xs text-slate-400 dark:text-slate-500 mt-1"></p>
+          <p id="betrag-richtwert-hinweis" class="text-xs text-text-faint mt-1"></p>
         </div>
 
         <!-- Fehler -->
@@ -99,7 +99,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         </button>
 
         <p class="text-center mt-1">
-          <button type="button" id="korrektur-link-btn" class="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 underline transition-colors">
+          <button type="button" id="korrektur-link-btn" class="text-xs text-text-faint hover:text-text-secondary underline transition-colors">
             Gebot korrigieren →
           </button>
         </p>
@@ -111,7 +111,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       <form id="korrektur-form" class="space-y-5">
         <!-- Emoji-ID -->
         <div>
-          <label for="korrektur-emoji" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          <label for="korrektur-emoji" class="block text-sm font-medium text-text-secondary mb-1">
             Deine Emoji-ID
           </label>
           <input
@@ -120,21 +120,21 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             name="emojiId"
             required
             placeholder="z.B. 🦊🌙⭐"
-            class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
-          <p class="text-xs text-slate-400 dark:text-slate-500 mt-1">Die 3 Emojis, die dir beim Abgeben angezeigt wurden.</p>
+          <p class="text-xs text-text-faint mt-1">Die 3 Emojis, die dir beim Abgeben angezeigt wurden.</p>
         </div>
 
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Slot</p>
+          <p class="text-sm font-medium text-text-secondary mb-2">Slot</p>
           <div id="slot-auswahl-korrektur" class="space-y-2"></div>
           <p id="korrektur-slot-hinweis" class="text-xs mt-1"></p>
         </div>
 
         <!-- Betrag -->
         <div>
-          <label for="korrektur-betrag" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          <label for="korrektur-betrag" class="block text-sm font-medium text-text-secondary mb-1">
             Neues Gebot (€)
           </label>
           <input
@@ -145,7 +145,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
-            class="w-full border border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
           <p id="korrektur-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
         </div>
@@ -167,9 +167,9 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   <!-- Bestätigung -->
   <div id="zustand-bestaetigung" class="hidden text-center space-y-4 py-8">
     <h2 id="bestaetigung-titel" class="text-xl font-semibold">Gebot abgegeben</h2>
-    <p id="bestaetigung-text" class="text-slate-500 dark:text-slate-400 text-sm max-w-sm mx-auto"></p>
+    <p id="bestaetigung-text" class="text-text-muted text-sm max-w-sm mx-auto"></p>
     <div id="emoji-anzeige" class="text-6xl tracking-widest mb-2"></div>
-    <p class="text-xs text-slate-500 dark:text-slate-400">Deine Emoji-ID</p>
+    <p class="text-xs text-text-muted">Deine Emoji-ID</p>
   </div>
 </Layout>
 
@@ -288,12 +288,12 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         const bereitsGeboten = slotBereitsGeboten(slot.label);
         const label = document.createElement('label');
         label.className =
-          'flex items-center gap-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 dark:has-[:checked]:bg-green-950/40 transition-colors';
+          'flex items-center gap-3 bg-surface-raised border border-border rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 dark:has-[:checked]:bg-green-950/40 transition-colors';
         label.innerHTML = `
           <input type="radio" name="${nameAttr}" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
           <span class="flex-1">
-            <span class="text-sm font-medium text-slate-800 dark:text-slate-200">${slot.label}</span>
-            <span class="text-xs text-slate-500 dark:text-slate-400 ml-2">Richtwert: ${formatEur(richtwertSlot)}</span>
+            <span class="text-sm font-medium text-text-strong">${slot.label}</span>
+            <span class="text-xs text-text-muted ml-2">Richtwert: ${formatEur(richtwertSlot)}</span>
             ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-green-600 ml-1 text-xs">✓ abgegeben</span>' : ''}
           </span>
         `;
@@ -350,17 +350,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     function zeigeTab(tab: 'abgeben' | 'korrigieren') {
       const istAbgeben = tab === 'abgeben';
       tabAbgeben.classList.toggle('border-green-600', istAbgeben);
-      tabAbgeben.classList.toggle('text-green-700', istAbgeben);
-      tabAbgeben.classList.toggle('dark:text-green-400', istAbgeben);
+      tabAbgeben.classList.toggle('text-success-text', istAbgeben);
       tabAbgeben.classList.toggle('border-transparent', !istAbgeben);
-      tabAbgeben.classList.toggle('text-slate-500', !istAbgeben);
-      tabAbgeben.classList.toggle('dark:text-slate-400', !istAbgeben);
+      tabAbgeben.classList.toggle('text-text-muted', !istAbgeben);
       tabKorrigieren.classList.toggle('border-green-600', !istAbgeben);
-      tabKorrigieren.classList.toggle('text-green-700', !istAbgeben);
-      tabKorrigieren.classList.toggle('dark:text-green-400', !istAbgeben);
+      tabKorrigieren.classList.toggle('text-success-text', !istAbgeben);
       tabKorrigieren.classList.toggle('border-transparent', istAbgeben);
-      tabKorrigieren.classList.toggle('text-slate-500', istAbgeben);
-      tabKorrigieren.classList.toggle('dark:text-slate-400', istAbgeben);
+      tabKorrigieren.classList.toggle('text-text-muted', istAbgeben);
       panelAbgeben.classList.toggle('hidden', !istAbgeben);
       panelKorrigieren.classList.toggle('hidden', istAbgeben);
     }

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -5,12 +5,12 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
 <Layout title="Runde">
   <!-- Laden -->
-  <div id="zustand-laden" class="text-center py-12 text-text-muted text-sm">
+  <div id="zustand-laden" class="text-center py-12 text-fg-muted text-sm">
     Lade Runde…
   </div>
 
   <!-- Fehler -->
-  <div id="zustand-fehler" class="hidden bg-danger-bg border border-danger-border text-danger-text rounded-xl p-5">
+  <div id="zustand-fehler" class="hidden bg-danger-subtle border border-danger-outline text-danger-fg rounded-xl p-5">
     <p class="font-medium mb-1">Fehler</p>
     <p id="fehler-text" class="text-sm"></p>
   </div>
@@ -19,8 +19,8 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   <div id="zustand-formular" class="hidden space-y-6">
     <div>
       <h1 id="runde-name" class="text-2xl font-semibold mb-1"></h1>
-      <p class="text-text-muted text-sm">
-        Gesamtkosten: <span id="gesamtkosten" class="font-medium text-text-strong"></span>
+      <p class="text-fg-muted text-sm">
+        Gesamtkosten: <span id="gesamtkosten" class="font-medium text-fg-strong"></span>
       </p>
     </div>
 
@@ -28,13 +28,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     <div class="flex border-b border-border">
       <button
         id="tab-abgeben"
-        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-success-text -mb-px transition-colors"
+        class="px-4 py-2 text-sm font-medium border-b-2 border-green-600 text-success-fg -mb-px transition-colors"
       >
         Gebot abgeben
       </button>
       <button
         id="tab-korrigieren"
-        class="hidden px-4 py-2 text-sm font-medium border-b-2 border-transparent text-text-muted -mb-px hover:text-text-strong transition-colors"
+        class="hidden px-4 py-2 text-sm font-medium border-b-2 border-transparent text-fg-muted -mb-px hover:text-fg-strong transition-colors"
       >
         Gebot korrigieren
       </button>
@@ -45,13 +45,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       <form id="gebot-form" class="space-y-5">
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-text-secondary mb-2">Wähle deinen Slot</p>
+          <p class="text-sm font-medium text-fg-secondary mb-2">Wähle deinen Slot</p>
           <div id="slot-auswahl" class="space-y-2"></div>
         </div>
 
         <!-- Betrag -->
         <div>
-          <label for="betrag" class="block text-sm font-medium text-text-secondary mb-1">
+          <label for="betrag" class="block text-sm font-medium text-fg-secondary mb-1">
             Dein Gebot (€)
           </label>
           <input
@@ -62,16 +62,16 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
-            class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
-          <p id="betrag-richtwert-hinweis" class="text-xs text-text-faint mt-1"></p>
+          <p id="betrag-richtwert-hinweis" class="text-xs text-fg-faint mt-1"></p>
         </div>
 
         <!-- Fehler -->
         <FeedbackBox id="gebot-fehler" />
 
         <!-- Duplikat-Warnung Two-Step (Soft-Warning, kein Hard-Block) -->
-        <div id="duplikat-warnung" class="hidden bg-amber-50 dark:bg-amber-950/50 border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-300 rounded-lg p-3 text-sm">
+        <div id="duplikat-warnung" class="hidden bg-warning-subtle dark:bg-amber-950/50 border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-300 rounded-lg p-3 text-sm">
           <!-- Schritt 1 -->
           <div id="duplikat-schritt1">
             <p class="font-medium">Du hast für diesen Slot bereits geboten.</p>
@@ -99,7 +99,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         </button>
 
         <p class="text-center mt-1">
-          <button type="button" id="korrektur-link-btn" class="text-xs text-text-faint hover:text-text-secondary underline transition-colors">
+          <button type="button" id="korrektur-link-btn" class="text-xs text-fg-faint hover:text-fg-secondary underline transition-colors">
             Gebot korrigieren →
           </button>
         </p>
@@ -111,7 +111,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       <form id="korrektur-form" class="space-y-5">
         <!-- Emoji-ID -->
         <div>
-          <label for="korrektur-emoji" class="block text-sm font-medium text-text-secondary mb-1">
+          <label for="korrektur-emoji" class="block text-sm font-medium text-fg-secondary mb-1">
             Deine Emoji-ID
           </label>
           <input
@@ -120,21 +120,21 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             name="emojiId"
             required
             placeholder="z.B. 🦊🌙⭐"
-            class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
-          <p class="text-xs text-text-faint mt-1">Die 3 Emojis, die dir beim Abgeben angezeigt wurden.</p>
+          <p class="text-xs text-fg-faint mt-1">Die 3 Emojis, die dir beim Abgeben angezeigt wurden.</p>
         </div>
 
         <!-- Slot-Auswahl -->
         <div>
-          <p class="text-sm font-medium text-text-secondary mb-2">Slot</p>
+          <p class="text-sm font-medium text-fg-secondary mb-2">Slot</p>
           <div id="slot-auswahl-korrektur" class="space-y-2"></div>
           <p id="korrektur-slot-hinweis" class="text-xs mt-1"></p>
         </div>
 
         <!-- Betrag -->
         <div>
-          <label for="korrektur-betrag" class="block text-sm font-medium text-text-secondary mb-1">
+          <label for="korrektur-betrag" class="block text-sm font-medium text-fg-secondary mb-1">
             Neues Gebot (€)
           </label>
           <input
@@ -145,9 +145,9 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
-            class="w-full border border-border-strong bg-surface-raised text-text rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
+            class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-600"
           />
-          <p id="korrektur-richtwert-hinweis" class="text-xs text-slate-400 mt-1"></p>
+          <p id="korrektur-richtwert-hinweis" class="text-xs text-fg-faint mt-1"></p>
         </div>
 
         <!-- Fehler -->
@@ -167,9 +167,9 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   <!-- Bestätigung -->
   <div id="zustand-bestaetigung" class="hidden text-center space-y-4 py-8">
     <h2 id="bestaetigung-titel" class="text-xl font-semibold">Gebot abgegeben</h2>
-    <p id="bestaetigung-text" class="text-text-muted text-sm max-w-sm mx-auto"></p>
+    <p id="bestaetigung-text" class="text-fg-muted text-sm max-w-sm mx-auto"></p>
     <div id="emoji-anzeige" class="text-6xl tracking-widest mb-2"></div>
-    <p class="text-xs text-text-muted">Deine Emoji-ID</p>
+    <p class="text-xs text-fg-muted">Deine Emoji-ID</p>
   </div>
 </Layout>
 
@@ -288,12 +288,12 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         const bereitsGeboten = slotBereitsGeboten(slot.label);
         const label = document.createElement('label');
         label.className =
-          'flex items-center gap-3 bg-surface-raised border border-border rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-green-50 dark:has-[:checked]:bg-green-950/40 transition-colors';
+          'flex items-center gap-3 bg-surface-raised border border-border rounded-lg p-3 cursor-pointer hover:border-green-500 has-[:checked]:border-green-600 has-[:checked]:bg-success-subtle dark:has-[:checked]:bg-green-950/40 transition-colors';
         label.innerHTML = `
           <input type="radio" name="${nameAttr}" value="${idx}" class="accent-green-700" ${idx === 0 ? 'checked' : ''} />
           <span class="flex-1">
-            <span class="text-sm font-medium text-text-strong">${slot.label}</span>
-            <span class="text-xs text-text-muted ml-2">Richtwert: ${formatEur(richtwertSlot)}</span>
+            <span class="text-sm font-medium text-fg-strong">${slot.label}</span>
+            <span class="text-xs text-fg-muted ml-2">Richtwert: ${formatEur(richtwertSlot)}</span>
             ${bereitsGeboten && nameAttr === 'slot' ? '<span class="text-green-600 ml-1 text-xs">✓ abgegeben</span>' : ''}
           </span>
         `;
@@ -350,13 +350,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     function zeigeTab(tab: 'abgeben' | 'korrigieren') {
       const istAbgeben = tab === 'abgeben';
       tabAbgeben.classList.toggle('border-green-600', istAbgeben);
-      tabAbgeben.classList.toggle('text-success-text', istAbgeben);
+      tabAbgeben.classList.toggle('text-success-fg', istAbgeben);
       tabAbgeben.classList.toggle('border-transparent', !istAbgeben);
-      tabAbgeben.classList.toggle('text-text-muted', !istAbgeben);
+      tabAbgeben.classList.toggle('text-fg-muted', !istAbgeben);
       tabKorrigieren.classList.toggle('border-green-600', !istAbgeben);
-      tabKorrigieren.classList.toggle('text-success-text', !istAbgeben);
+      tabKorrigieren.classList.toggle('text-success-fg', !istAbgeben);
       tabKorrigieren.classList.toggle('border-transparent', istAbgeben);
-      tabKorrigieren.classList.toggle('text-text-muted', istAbgeben);
+      tabKorrigieren.classList.toggle('text-fg-muted', istAbgeben);
       panelAbgeben.classList.toggle('hidden', !istAbgeben);
       panelKorrigieren.classList.toggle('hidden', istAbgeben);
     }
@@ -524,7 +524,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         if (slotIdx < 0) {
           radios.forEach((r) => { r.disabled = false; });
           korrekturSlotHinweis.textContent = 'Dein ursprünglicher Slot existiert nicht mehr — bitte wähle einen Slot.';
-          korrekturSlotHinweis.className = 'text-xs text-amber-600 mt-1';
+          korrekturSlotHinweis.className = 'text-xs text-warning-fg mt-1';
           return;
         }
         radios.forEach((r, i) => {
@@ -532,13 +532,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
           r.disabled = true;
         });
         korrekturSlotHinweis.textContent = `Slot aus deinem ursprünglichen Gebot: ${bekannterSlot}`;
-        korrekturSlotHinweis.className = 'text-xs text-green-700 mt-1';
+        korrekturSlotHinweis.className = 'text-xs text-success-fg mt-1';
         betragFeldAktualisieren(slotIdx, 'korrektur-betrag', 'korrektur-richtwert-hinweis');
       } else {
         radios.forEach((r) => { r.disabled = false; });
         if (emojiId) {
           korrekturSlotHinweis.textContent = 'Gebot auf diesem Gerät nicht gefunden — wähle denselben Slot wie beim ursprünglichen Gebot.';
-          korrekturSlotHinweis.className = 'text-xs text-amber-600 mt-1';
+          korrekturSlotHinweis.className = 'text-xs text-warning-fg mt-1';
         } else {
           korrekturSlotHinweis.textContent = '';
           korrekturSlotHinweis.className = '';

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -5,12 +5,12 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
 <Layout title="Auswertung">
   <!-- Laden -->
-  <div id="zustand-laden" class="text-center py-12 text-slate-500 text-sm">
+  <div id="zustand-laden" class="text-center py-12 text-fg-muted text-sm">
     Lade und entschlüssele…
   </div>
 
   <!-- Fehler -->
-  <div id="zustand-fehler" class="hidden bg-danger-bg border border-danger-border text-danger-text rounded-xl p-5">
+  <div id="zustand-fehler" class="hidden bg-danger-subtle border border-danger-outline text-danger-fg rounded-xl p-5">
     <p class="font-medium mb-1">Fehler</p>
     <p id="fehler-text" class="text-sm"></p>
   </div>
@@ -19,7 +19,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   <div id="zustand-auswertung" class="hidden space-y-8 print:space-y-4">
     <div class="print:mb-2">
       <h1 id="runde-name" class="text-2xl font-semibold mb-1 print:text-xl"></h1>
-      <p class="text-text-muted text-sm print:text-xs">
+      <p class="text-fg-muted text-sm print:text-xs">
         Admin-Auswertung · alle Daten wurden lokal entschlüsselt
       </p>
     </div>
@@ -27,24 +27,24 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
     <!-- Kennzahlen -->
     <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 print:grid-cols-3 print:gap-2">
       <div class="bg-surface-raised border border-border rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-text-muted mb-0.5">Gesamtkosten</p>
+        <p class="text-xs text-fg-muted mb-0.5">Gesamtkosten</p>
         <p id="kz-gesamtkosten" class="text-lg font-semibold print:text-base"></p>
       </div>
       <div class="bg-surface-raised border border-border rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-text-muted mb-0.5">Richtwert / Einheit</p>
+        <p class="text-xs text-fg-muted mb-0.5">Richtwert / Einheit</p>
         <p id="kz-richtwert" class="text-lg font-semibold print:text-base"></p>
       </div>
       <div class="vollstaendig-spalte hidden bg-surface-raised border border-border rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-text-muted mb-0.5">Summe Beiträge</p>
+        <p class="text-xs text-fg-muted mb-0.5">Summe Beiträge</p>
         <p id="kz-summe-beitraege" class="text-lg font-semibold print:text-base"></p>
       </div>
     </div>
 
     <!-- Duplikat-Warnung -->
-    <div id="duplikat-box" class="hidden bg-danger-bg border border-danger-border rounded-xl p-4 print:rounded-md print:p-3">
-      <p class="text-sm font-medium text-danger-text">⚠️ Zu viele Gebote — Auswertung nicht möglich</p>
-      <p class="text-xs text-danger-text mt-1 mb-2">Für folgende Slots sind mehr Gebote eingegangen als erwartet. Bitte kläre die Doppeleinreichung und bitte die betroffene Person, nicht nochmals zu bieten.</p>
-      <ul id="duplikat-liste" class="text-xs text-danger-text space-y-0.5 list-disc list-inside"></ul>
+    <div id="duplikat-box" class="hidden bg-danger-subtle border border-danger-outline rounded-xl p-4 print:rounded-md print:p-3">
+      <p class="text-sm font-medium text-danger-fg">⚠️ Zu viele Gebote — Auswertung nicht möglich</p>
+      <p class="text-xs text-danger-fg mt-1 mb-2">Für folgende Slots sind mehr Gebote eingegangen als erwartet. Bitte kläre die Doppeleinreichung und bitte die betroffene Person, nicht nochmals zu bieten.</p>
+      <ul id="duplikat-liste" class="text-xs text-danger-fg space-y-0.5 list-disc list-inside"></ul>
     </div>
 
     <!-- Status-Banner -->
@@ -55,12 +55,12 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
     <!-- Ausgleichszahlungen -->
     <div id="ausgleich-section" class="hidden space-y-2">
-      <h2 class="text-sm font-medium text-text-secondary print:text-xs">Ausgleichszahlungen</h2>
+      <h2 class="text-sm font-medium text-fg-secondary print:text-xs">Ausgleichszahlungen</h2>
       <div id="ausgleich-liste" class="rounded-xl border border-border bg-surface-raised px-4 py-3 space-y-2 print:text-xs"></div>
     </div>
 
     <!-- Status (klein, ergänzend zum Banner) -->
-    <p id="gebote-anzahl" class="text-xs text-slate-400 print:hidden"></p>
+    <p id="gebote-anzahl" class="text-xs text-fg-faint print:hidden"></p>
 
     <!-- Drucken / Wiederholen -->
     <div class="flex gap-3 print:hidden">
@@ -72,7 +72,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
       </button>
       <button
         id="wiederholen-btn"
-        class="border border-border-strong rounded-lg px-4 py-2 text-sm text-text-secondary hover:bg-surface-hover transition-colors"
+        class="border border-border-strong rounded-lg px-4 py-2 text-sm text-fg-secondary hover:bg-surface-hover transition-colors"
       >
         Runde wiederholen
       </button>
@@ -108,9 +108,9 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   function zeigeBanner(text: string, farbe: 'green' | 'amber' | 'red') {
     const banner = document.getElementById('status-banner')!;
     const farbenKlassen: Record<string, string> = {
-      green: 'bg-success-bg border border-success-border text-success-text',
-      amber: 'bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300',
-      red:   'bg-danger-bg border border-danger-border text-danger-text',
+      green: 'bg-success-subtle border border-success-outline text-success-fg',
+      amber: 'bg-warning-subtle dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300',
+      red:   'bg-danger-subtle border border-danger-outline text-danger-fg',
     };
     banner.className = `rounded-xl px-4 py-3 text-sm font-medium print:hidden ${farbenKlassen[farbe]}`;
     banner.textContent = text;
@@ -303,22 +303,22 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
       // Slot-Header-Farbe
       const headerBg = zuViele
-        ? 'bg-red-50 dark:bg-red-950/50 border-b border-red-200 dark:border-red-800'
+        ? 'bg-danger-subtle dark:bg-red-950/50 border-b border-danger-outline dark:border-red-800'
         : vollstaendig
-          ? 'bg-green-50 dark:bg-green-950/50 border-b border-green-200 dark:border-green-800'
-          : 'bg-amber-50 dark:bg-amber-950/50 border-b border-amber-200 dark:border-amber-800';
+          ? 'bg-success-subtle dark:bg-green-950/50 border-b border-success-outline dark:border-green-800'
+          : 'bg-warning-subtle dark:bg-amber-950/50 border-b border-warning-outline dark:border-amber-800';
       const headerTextFarbe = zuViele
-        ? 'text-danger-text'
+        ? 'text-danger-fg'
         : vollstaendig
-          ? 'text-success-text'
-          : 'text-warning-text';
+          ? 'text-success-fg'
+          : 'text-warning-fg';
       const headerIcon = zuViele ? '⚠️' : vollstaendig ? '✓' : '○';
 
       karte.innerHTML = `
         <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 px-3 py-1.5 ${headerBg}">
           <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 min-w-0">
             <span class="text-sm font-semibold ${headerTextFarbe} shrink-0">${slot.label}</span>
-            <span class="text-xs text-text-muted shrink-0">Faktor ${slot.gewichtung}x · ~${formatEur(richtwertAnteil)}</span>
+            <span class="text-xs text-fg-muted shrink-0">Faktor ${slot.gewichtung}x · ~${formatEur(richtwertAnteil)}</span>
           </div>
           <span class="text-xs font-semibold ${headerTextFarbe} shrink-0">${headerIcon} ${eingegangen}/${erwartet}${autoVollstaendig ? ' (auto)' : ''}</span>
         </div>
@@ -338,13 +338,13 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
             <span class="text-base w-16 shrink-0">${g.emojiId}</span>
             <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">geboten</span>
             ${zeigeBeitraege && e ? `
-              <span class="hidden sm:inline text-xs text-text-faint shrink-0">Beitrag</span>
-              <span class="hidden sm:inline text-sm font-semibold text-text shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
+              <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Beitrag</span>
+              <span class="hidden sm:inline text-sm font-semibold text-fg shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
             ` : ''}
             ${zeigeBeitraege && e && hatSplidDaten ? `
-              <span class="hidden sm:inline text-xs text-text-faint shrink-0">Ausgaben</span>
-              <span class="hidden sm:inline text-xs font-semibold text-text shrink-0">${formatEur(ausgaben)}</span>
-              <span class="hidden sm:inline text-xs text-text-faint shrink-0">Noch zu zahlen</span>
+              <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Ausgaben</span>
+              <span class="hidden sm:inline text-xs font-semibold text-fg shrink-0">${formatEur(ausgaben)}</span>
+              <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Noch zu zahlen</span>
               <span class="hidden sm:inline text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
             ` : ''}
             <span class="ml-auto"><button class="loeschen-btn w-6 h-6 flex items-center justify-center rounded-full text-slate-300 dark:text-slate-600 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50 transition-colors" data-emoji-hmac="${emojiHmac}" data-slot="${slot.label}" aria-label="Gebot löschen">×</button></span>
@@ -352,16 +352,16 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           ${zeigeBeitraege && e ? `
             <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
               <div class="flex justify-between items-baseline">
-                <span class="text-xs text-text-faint">Beitrag</span>
-                <span class="text-sm font-semibold text-text">${formatEur(e.solidarischerBeitrag)}</span>
+                <span class="text-xs text-fg-faint">Beitrag</span>
+                <span class="text-sm font-semibold text-fg">${formatEur(e.solidarischerBeitrag)}</span>
               </div>
               ${hatSplidDaten ? `
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-text-faint">Ausgaben</span>
-                  <span class="text-xs font-semibold text-text">${formatEur(ausgaben)}</span>
+                  <span class="text-xs text-fg-faint">Ausgaben</span>
+                  <span class="text-xs font-semibold text-fg">${formatEur(ausgaben)}</span>
                 </div>
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-text-faint">Noch zu zahlen</span>
+                  <span class="text-xs text-fg-faint">Noch zu zahlen</span>
                   <span class="text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'}">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
                 </div>
               ` : ''}
@@ -384,29 +384,29 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
               <span class="text-base w-16 shrink-0 text-slate-300 dark:text-slate-600">—</span>
               <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
               ${e ? `
-                <span class="hidden sm:inline text-xs text-text-faint shrink-0">Beitrag</span>
-                <span class="hidden sm:inline text-sm font-semibold text-text shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
+                <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Beitrag</span>
+                <span class="hidden sm:inline text-sm font-semibold text-fg shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
               ` : ''}
               ${e && hatSplidDaten ? `
-                <span class="hidden sm:inline text-xs text-text-faint shrink-0">Ausgaben</span>
-                <span class="hidden sm:inline text-xs font-semibold text-text shrink-0">${formatEur(ausgaben)}</span>
-                <span class="hidden sm:inline text-xs text-text-faint shrink-0">Noch zu zahlen</span>
+                <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Ausgaben</span>
+                <span class="hidden sm:inline text-xs font-semibold text-fg shrink-0">${formatEur(ausgaben)}</span>
+                <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Noch zu zahlen</span>
                 <span class="hidden sm:inline text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
               ` : ''}
             </div>
             ${e ? `
               <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-text-faint">Beitrag</span>
-                  <span class="text-sm font-semibold text-text">${formatEur(e.solidarischerBeitrag)}</span>
+                  <span class="text-xs text-fg-faint">Beitrag</span>
+                  <span class="text-sm font-semibold text-fg">${formatEur(e.solidarischerBeitrag)}</span>
                 </div>
                 ${hatSplidDaten ? `
                   <div class="flex justify-between items-baseline">
-                    <span class="text-xs text-text-faint">Ausgaben</span>
-                    <span class="text-xs font-semibold text-text">${formatEur(ausgaben)}</span>
+                    <span class="text-xs text-fg-faint">Ausgaben</span>
+                    <span class="text-xs font-semibold text-fg">${formatEur(ausgaben)}</span>
                   </div>
                   <div class="flex justify-between items-baseline">
-                    <span class="text-xs text-text-faint">Noch zu zahlen</span>
+                    <span class="text-xs text-fg-faint">Noch zu zahlen</span>
                     <span class="text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'}">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
                   </div>
                 ` : ''}
@@ -424,7 +424,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         zeile.className = 'flex items-center gap-2 px-3 py-1';
         zeile.innerHTML = `
           <span class="text-base w-16 shrink-0 text-slate-300 dark:text-slate-600">—</span>
-          <span class="text-xs bg-surface-elevated text-text-muted rounded px-1.5 py-0.5 shrink-0">fehlt</span>
+          <span class="text-xs bg-surface-elevated text-fg-muted rounded px-1.5 py-0.5 shrink-0">fehlt</span>
         `;
         zeilenContainer.appendChild(zeile);
       }
@@ -484,10 +484,10 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           zeile.className = `grid items-center gap-x-3 text-sm${idx < zahlungen.length - 1 ? ' pb-2 border-b border-border' : ''}`;
           zeile.style.gridTemplateColumns = '1fr auto 1fr auto';
           zeile.innerHTML = `
-            <span class="text-text-secondary text-right">${vonLabel}</span>
-            <span class="text-text-faint">→</span>
-            <span class="text-text-secondary">${anLabel}</span>
-            <span class="font-semibold text-text text-right">${formatEur(z.betrag)}</span>
+            <span class="text-fg-secondary text-right">${vonLabel}</span>
+            <span class="text-fg-faint">→</span>
+            <span class="text-fg-secondary">${anLabel}</span>
+            <span class="font-semibold text-fg text-right">${formatEur(z.betrag)}</span>
           `;
           liste.appendChild(zeile);
         });

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -10,7 +10,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   </div>
 
   <!-- Fehler -->
-  <div id="zustand-fehler" class="hidden bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-xl p-5">
+  <div id="zustand-fehler" class="hidden bg-danger-bg border border-danger-border text-danger-text rounded-xl p-5">
     <p class="font-medium mb-1">Fehler</p>
     <p id="fehler-text" class="text-sm"></p>
   </div>
@@ -19,32 +19,32 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   <div id="zustand-auswertung" class="hidden space-y-8 print:space-y-4">
     <div class="print:mb-2">
       <h1 id="runde-name" class="text-2xl font-semibold mb-1 print:text-xl"></h1>
-      <p class="text-slate-500 dark:text-slate-400 text-sm print:text-xs">
+      <p class="text-text-muted text-sm print:text-xs">
         Admin-Auswertung · alle Daten wurden lokal entschlüsselt
       </p>
     </div>
 
     <!-- Kennzahlen -->
     <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 print:grid-cols-3 print:gap-2">
-      <div class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-slate-500 dark:text-slate-400 mb-0.5">Gesamtkosten</p>
+      <div class="bg-surface-raised border border-border rounded-xl p-3 print:rounded-md print:p-2">
+        <p class="text-xs text-text-muted mb-0.5">Gesamtkosten</p>
         <p id="kz-gesamtkosten" class="text-lg font-semibold print:text-base"></p>
       </div>
-      <div class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-slate-500 dark:text-slate-400 mb-0.5">Richtwert / Einheit</p>
+      <div class="bg-surface-raised border border-border rounded-xl p-3 print:rounded-md print:p-2">
+        <p class="text-xs text-text-muted mb-0.5">Richtwert / Einheit</p>
         <p id="kz-richtwert" class="text-lg font-semibold print:text-base"></p>
       </div>
-      <div class="vollstaendig-spalte hidden bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-3 print:rounded-md print:p-2">
-        <p class="text-xs text-slate-500 dark:text-slate-400 mb-0.5">Summe Beiträge</p>
+      <div class="vollstaendig-spalte hidden bg-surface-raised border border-border rounded-xl p-3 print:rounded-md print:p-2">
+        <p class="text-xs text-text-muted mb-0.5">Summe Beiträge</p>
         <p id="kz-summe-beitraege" class="text-lg font-semibold print:text-base"></p>
       </div>
     </div>
 
     <!-- Duplikat-Warnung -->
-    <div id="duplikat-box" class="hidden bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-xl p-4 print:rounded-md print:p-3">
-      <p class="text-sm font-medium text-red-800 dark:text-red-300">⚠️ Zu viele Gebote — Auswertung nicht möglich</p>
-      <p class="text-xs text-red-700 dark:text-red-400 mt-1 mb-2">Für folgende Slots sind mehr Gebote eingegangen als erwartet. Bitte kläre die Doppeleinreichung und bitte die betroffene Person, nicht nochmals zu bieten.</p>
-      <ul id="duplikat-liste" class="text-xs text-red-700 dark:text-red-400 space-y-0.5 list-disc list-inside"></ul>
+    <div id="duplikat-box" class="hidden bg-danger-bg border border-danger-border rounded-xl p-4 print:rounded-md print:p-3">
+      <p class="text-sm font-medium text-danger-text">⚠️ Zu viele Gebote — Auswertung nicht möglich</p>
+      <p class="text-xs text-danger-text mt-1 mb-2">Für folgende Slots sind mehr Gebote eingegangen als erwartet. Bitte kläre die Doppeleinreichung und bitte die betroffene Person, nicht nochmals zu bieten.</p>
+      <ul id="duplikat-liste" class="text-xs text-danger-text space-y-0.5 list-disc list-inside"></ul>
     </div>
 
     <!-- Status-Banner -->
@@ -55,8 +55,8 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
     <!-- Ausgleichszahlungen -->
     <div id="ausgleich-section" class="hidden space-y-2">
-      <h2 class="text-sm font-medium text-slate-700 dark:text-slate-300 print:text-xs">Ausgleichszahlungen</h2>
-      <div id="ausgleich-liste" class="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-4 py-3 space-y-2 print:text-xs"></div>
+      <h2 class="text-sm font-medium text-text-secondary print:text-xs">Ausgleichszahlungen</h2>
+      <div id="ausgleich-liste" class="rounded-xl border border-border bg-surface-raised px-4 py-3 space-y-2 print:text-xs"></div>
     </div>
 
     <!-- Status (klein, ergänzend zum Banner) -->
@@ -72,7 +72,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
       </button>
       <button
         id="wiederholen-btn"
-        class="border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-2 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+        class="border border-border-strong rounded-lg px-4 py-2 text-sm text-text-secondary hover:bg-surface-hover transition-colors"
       >
         Runde wiederholen
       </button>
@@ -108,9 +108,9 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   function zeigeBanner(text: string, farbe: 'green' | 'amber' | 'red') {
     const banner = document.getElementById('status-banner')!;
     const farbenKlassen: Record<string, string> = {
-      green: 'bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-300',
+      green: 'bg-success-bg border border-success-border text-success-text',
       amber: 'bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300',
-      red:   'bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-300',
+      red:   'bg-danger-bg border border-danger-border text-danger-text',
     };
     banner.className = `rounded-xl px-4 py-3 text-sm font-medium print:hidden ${farbenKlassen[farbe]}`;
     banner.textContent = text;
@@ -299,7 +299,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
       // Slot-Karte
       const karte = document.createElement('div');
-      karte.className = 'border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden bg-white dark:bg-slate-800';
+      karte.className = 'border border-border rounded-xl overflow-hidden bg-surface-raised';
 
       // Slot-Header-Farbe
       const headerBg = zuViele
@@ -308,21 +308,21 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           ? 'bg-green-50 dark:bg-green-950/50 border-b border-green-200 dark:border-green-800'
           : 'bg-amber-50 dark:bg-amber-950/50 border-b border-amber-200 dark:border-amber-800';
       const headerTextFarbe = zuViele
-        ? 'text-red-800 dark:text-red-300'
+        ? 'text-danger-text'
         : vollstaendig
-          ? 'text-green-800 dark:text-green-300'
-          : 'text-amber-800 dark:text-amber-300';
+          ? 'text-success-text'
+          : 'text-warning-text';
       const headerIcon = zuViele ? '⚠️' : vollstaendig ? '✓' : '○';
 
       karte.innerHTML = `
         <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 px-3 py-1.5 ${headerBg}">
           <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 min-w-0">
             <span class="text-sm font-semibold ${headerTextFarbe} shrink-0">${slot.label}</span>
-            <span class="text-xs text-slate-500 dark:text-slate-400 shrink-0">Faktor ${slot.gewichtung}x · ~${formatEur(richtwertAnteil)}</span>
+            <span class="text-xs text-text-muted shrink-0">Faktor ${slot.gewichtung}x · ~${formatEur(richtwertAnteil)}</span>
           </div>
           <span class="text-xs font-semibold ${headerTextFarbe} shrink-0">${headerIcon} ${eingegangen}/${erwartet}${autoVollstaendig ? ' (auto)' : ''}</span>
         </div>
-        <div class="slot-zeilen divide-y divide-slate-100 dark:divide-slate-700"></div>
+        <div class="slot-zeilen divide-y divide-border"></div>
       `;
 
       const zeilenContainer = karte.querySelector<HTMLDivElement>('.slot-zeilen')!;
@@ -338,13 +338,13 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
             <span class="text-base w-16 shrink-0">${g.emojiId}</span>
             <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">geboten</span>
             ${zeigeBeitraege && e ? `
-              <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Beitrag</span>
-              <span class="hidden sm:inline text-sm font-semibold text-slate-900 dark:text-slate-100 shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
+              <span class="hidden sm:inline text-xs text-text-faint shrink-0">Beitrag</span>
+              <span class="hidden sm:inline text-sm font-semibold text-text shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
             ` : ''}
             ${zeigeBeitraege && e && hatSplidDaten ? `
-              <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Ausgaben</span>
-              <span class="hidden sm:inline text-xs font-semibold text-slate-900 dark:text-slate-100 shrink-0">${formatEur(ausgaben)}</span>
-              <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Noch zu zahlen</span>
+              <span class="hidden sm:inline text-xs text-text-faint shrink-0">Ausgaben</span>
+              <span class="hidden sm:inline text-xs font-semibold text-text shrink-0">${formatEur(ausgaben)}</span>
+              <span class="hidden sm:inline text-xs text-text-faint shrink-0">Noch zu zahlen</span>
               <span class="hidden sm:inline text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
             ` : ''}
             <span class="ml-auto"><button class="loeschen-btn w-6 h-6 flex items-center justify-center rounded-full text-slate-300 dark:text-slate-600 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50 transition-colors" data-emoji-hmac="${emojiHmac}" data-slot="${slot.label}" aria-label="Gebot löschen">×</button></span>
@@ -352,16 +352,16 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           ${zeigeBeitraege && e ? `
             <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
               <div class="flex justify-between items-baseline">
-                <span class="text-xs text-slate-400 dark:text-slate-500">Beitrag</span>
-                <span class="text-sm font-semibold text-slate-900 dark:text-slate-100">${formatEur(e.solidarischerBeitrag)}</span>
+                <span class="text-xs text-text-faint">Beitrag</span>
+                <span class="text-sm font-semibold text-text">${formatEur(e.solidarischerBeitrag)}</span>
               </div>
               ${hatSplidDaten ? `
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-slate-400 dark:text-slate-500">Ausgaben</span>
-                  <span class="text-xs font-semibold text-slate-900 dark:text-slate-100">${formatEur(ausgaben)}</span>
+                  <span class="text-xs text-text-faint">Ausgaben</span>
+                  <span class="text-xs font-semibold text-text">${formatEur(ausgaben)}</span>
                 </div>
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-slate-400 dark:text-slate-500">Noch zu zahlen</span>
+                  <span class="text-xs text-text-faint">Noch zu zahlen</span>
                   <span class="text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'}">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
                 </div>
               ` : ''}
@@ -384,29 +384,29 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
               <span class="text-base w-16 shrink-0 text-slate-300 dark:text-slate-600">—</span>
               <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
               ${e ? `
-                <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Beitrag</span>
-                <span class="hidden sm:inline text-sm font-semibold text-slate-900 dark:text-slate-100 shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
+                <span class="hidden sm:inline text-xs text-text-faint shrink-0">Beitrag</span>
+                <span class="hidden sm:inline text-sm font-semibold text-text shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
               ` : ''}
               ${e && hatSplidDaten ? `
-                <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Ausgaben</span>
-                <span class="hidden sm:inline text-xs font-semibold text-slate-900 dark:text-slate-100 shrink-0">${formatEur(ausgaben)}</span>
-                <span class="hidden sm:inline text-xs text-slate-400 dark:text-slate-500 shrink-0">Noch zu zahlen</span>
+                <span class="hidden sm:inline text-xs text-text-faint shrink-0">Ausgaben</span>
+                <span class="hidden sm:inline text-xs font-semibold text-text shrink-0">${formatEur(ausgaben)}</span>
+                <span class="hidden sm:inline text-xs text-text-faint shrink-0">Noch zu zahlen</span>
                 <span class="hidden sm:inline text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
               ` : ''}
             </div>
             ${e ? `
               <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
                 <div class="flex justify-between items-baseline">
-                  <span class="text-xs text-slate-400 dark:text-slate-500">Beitrag</span>
-                  <span class="text-sm font-semibold text-slate-900 dark:text-slate-100">${formatEur(e.solidarischerBeitrag)}</span>
+                  <span class="text-xs text-text-faint">Beitrag</span>
+                  <span class="text-sm font-semibold text-text">${formatEur(e.solidarischerBeitrag)}</span>
                 </div>
                 ${hatSplidDaten ? `
                   <div class="flex justify-between items-baseline">
-                    <span class="text-xs text-slate-400 dark:text-slate-500">Ausgaben</span>
-                    <span class="text-xs font-semibold text-slate-900 dark:text-slate-100">${formatEur(ausgaben)}</span>
+                    <span class="text-xs text-text-faint">Ausgaben</span>
+                    <span class="text-xs font-semibold text-text">${formatEur(ausgaben)}</span>
                   </div>
                   <div class="flex justify-between items-baseline">
-                    <span class="text-xs text-slate-400 dark:text-slate-500">Noch zu zahlen</span>
+                    <span class="text-xs text-text-faint">Noch zu zahlen</span>
                     <span class="text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'}">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
                   </div>
                 ` : ''}
@@ -424,7 +424,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         zeile.className = 'flex items-center gap-2 px-3 py-1';
         zeile.innerHTML = `
           <span class="text-base w-16 shrink-0 text-slate-300 dark:text-slate-600">—</span>
-          <span class="text-xs bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 rounded px-1.5 py-0.5 shrink-0">fehlt</span>
+          <span class="text-xs bg-surface-elevated text-text-muted rounded px-1.5 py-0.5 shrink-0">fehlt</span>
         `;
         zeilenContainer.appendChild(zeile);
       }
@@ -481,13 +481,13 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           const zeile = document.createElement('div');
           const vonLabel = emojiZuLabel.get(z.von) ?? z.von;
           const anLabel = emojiZuLabel.get(z.an) ?? z.an;
-          zeile.className = `grid items-center gap-x-3 text-sm${idx < zahlungen.length - 1 ? ' pb-2 border-b border-slate-100 dark:border-slate-700' : ''}`;
+          zeile.className = `grid items-center gap-x-3 text-sm${idx < zahlungen.length - 1 ? ' pb-2 border-b border-border' : ''}`;
           zeile.style.gridTemplateColumns = '1fr auto 1fr auto';
           zeile.innerHTML = `
-            <span class="text-slate-700 dark:text-slate-300 text-right">${vonLabel}</span>
-            <span class="text-slate-400 dark:text-slate-500">→</span>
-            <span class="text-slate-700 dark:text-slate-300">${anLabel}</span>
-            <span class="font-semibold text-slate-900 dark:text-slate-100 text-right">${formatEur(z.betrag)}</span>
+            <span class="text-text-secondary text-right">${vonLabel}</span>
+            <span class="text-text-faint">→</span>
+            <span class="text-text-secondary">${anLabel}</span>
+            <span class="font-semibold text-text text-right">${formatEur(z.betrag)}</span>
           `;
           liste.appendChild(zeile);
         });

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -336,7 +336,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         zeile.innerHTML = `
           <div class="flex items-center gap-2 w-full">
             <span class="text-base w-16 shrink-0">${g.emojiId}</span>
-            <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">geboten</span>
+            <span class="text-xs bg-success-tinted text-success-fg rounded px-1.5 py-0.5 font-medium shrink-0">geboten</span>
             ${zeigeBeitraege && e ? `
               <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Beitrag</span>
               <span class="hidden sm:inline text-sm font-semibold text-fg shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
@@ -345,9 +345,9 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
               <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Ausgaben</span>
               <span class="hidden sm:inline text-xs font-semibold text-fg shrink-0">${formatEur(ausgaben)}</span>
               <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Noch zu zahlen</span>
-              <span class="hidden sm:inline text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
+              <span class="hidden sm:inline text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-danger-fg' : 'text-success-fg'} shrink-0">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
             ` : ''}
-            <span class="ml-auto"><button class="loeschen-btn w-6 h-6 flex items-center justify-center rounded-full text-slate-300 dark:text-slate-600 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50 transition-colors" data-emoji-hmac="${emojiHmac}" data-slot="${slot.label}" aria-label="Gebot löschen">×</button></span>
+            <span class="ml-auto"><button class="loeschen-btn w-6 h-6 flex items-center justify-center rounded-full text-fg-ghost hover:text-danger-fg hover:bg-danger-subtle dark:hover:bg-red-950/50 transition-colors" data-emoji-hmac="${emojiHmac}" data-slot="${slot.label}" aria-label="Gebot löschen">×</button></span>
           </div>
           ${zeigeBeitraege && e ? `
             <div class="flex flex-col gap-0.5 pl-[4.5rem] sm:hidden pb-1">
@@ -362,7 +362,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
                 </div>
                 <div class="flex justify-between items-baseline">
                   <span class="text-xs text-fg-faint">Noch zu zahlen</span>
-                  <span class="text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-red-600' : 'text-green-700'}">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
+                  <span class="text-xs font-semibold ${(e.solidarischerBeitrag - ausgaben) > 0.005 ? 'text-danger-fg' : 'text-success-fg'}">${(e.solidarischerBeitrag - ausgaben) > 0 ? '+' : ''}${formatEur(e.solidarischerBeitrag - ausgaben)}</span>
                 </div>
               ` : ''}
             </div>
@@ -382,7 +382,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
           zeile.innerHTML = `
             <div class="flex items-center gap-2 w-full">
               <span class="text-base w-16 shrink-0 text-slate-300 dark:text-slate-600">—</span>
-              <span class="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
+              <span class="text-xs bg-success-tinted text-success-fg rounded px-1.5 py-0.5 font-medium shrink-0">auto</span>
               ${e ? `
                 <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Beitrag</span>
                 <span class="hidden sm:inline text-sm font-semibold text-fg shrink-0">${formatEur(e.solidarischerBeitrag)}</span>
@@ -391,7 +391,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
                 <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Ausgaben</span>
                 <span class="hidden sm:inline text-xs font-semibold text-fg shrink-0">${formatEur(ausgaben)}</span>
                 <span class="hidden sm:inline text-xs text-fg-faint shrink-0">Noch zu zahlen</span>
-                <span class="hidden sm:inline text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'} shrink-0">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
+                <span class="hidden sm:inline text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-danger-fg' : 'text-success-fg'} shrink-0">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
               ` : ''}
             </div>
             ${e ? `
@@ -407,7 +407,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
                   </div>
                   <div class="flex justify-between items-baseline">
                     <span class="text-xs text-fg-faint">Noch zu zahlen</span>
-                    <span class="text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-red-600' : 'text-green-700'}">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
+                    <span class="text-xs font-semibold ${nochZuZahlen > 0.005 ? 'text-danger-fg' : 'text-success-fg'}">${nochZuZahlen > 0 ? '+' : ''}${formatEur(nochZuZahlen)}</span>
                   </div>
                 ` : ''}
               </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,39 @@
 @theme {
   --color-brand: #3B6D11;
   --color-brand-dark: #27500A;
+
+  /* Surface */
+  --color-surface:          #ffffff;
+  --color-surface-raised:   #ffffff;
+  --color-surface-hover:    #f1f5f9;
+  --color-surface-elevated: #f1f5f9;
+
+  /* Text */
+  --color-text:           #0f172a;
+  --color-text-strong:    #1e293b;
+  --color-text-secondary: #475569;
+  --color-text-muted:     #64748b;
+  --color-text-faint:     #94a3b8;
+
+  /* Border */
+  --color-border-subtle: #f1f5f9;
+  --color-border:        #e2e8f0;
+  --color-border-strong: #cbd5e1;
+
+  /* Status: Danger */
+  --color-danger-text:   #b91c1c;
+  --color-danger-border: #fecaca;
+  --color-danger-bg:     #fef2f2;
+
+  /* Status: Success */
+  --color-success-text:   #15803d;
+  --color-success-border: #bbf7d0;
+  --color-success-bg:     #f0fdf4;
+
+  /* Status: Warning */
+  --color-warning-text:   #92400e;
+  --color-warning-border: #fde68a;
+  --color-warning-bg:     #fffbeb;
 }
 
 @layer base {
@@ -15,6 +48,39 @@
       --color-brand: #6AAB23;
       --color-brand-dark: #5a9d18;
       color-scheme: dark;
+
+      /* Surface */
+      --color-surface:          #0f172a;
+      --color-surface-raised:   #1e293b;
+      --color-surface-hover:    #1e293b;
+      --color-surface-elevated: #334155;
+
+      /* Text */
+      --color-text:           #f1f5f9;
+      --color-text-strong:    #e2e8f0;
+      --color-text-secondary: #cbd5e1;
+      --color-text-muted:     #94a3b8;
+      --color-text-faint:     #64748b;
+
+      /* Border */
+      --color-border-subtle: #1e293b;
+      --color-border:        #334155;
+      --color-border-strong: #475569;
+
+      /* Status: Danger */
+      --color-danger-text:   #fca5a5;
+      --color-danger-border: #991b1b;
+      --color-danger-bg:     #450a0a;
+
+      /* Status: Success */
+      --color-success-text:   #4ade80;
+      --color-success-border: #166534;
+      --color-success-bg:     #052e16;
+
+      /* Status: Warning */
+      --color-warning-text:   #fcd34d;
+      --color-warning-border: #b45309;
+      --color-warning-bg:     #431407;
     }
   }
 }
@@ -78,10 +144,10 @@
 
 @media (max-width: 639px) and (prefers-color-scheme: dark) {
   .results-table tr {
-    border-color: var(--color-slate-700);
+    border-color: var(--color-border);
   }
   .results-table td::before {
-    color: var(--color-slate-500);
+    color: var(--color-text-faint);
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,12 +10,12 @@
   --color-surface-hover:    #f1f5f9;
   --color-surface-elevated: #f1f5f9;
 
-  /* Text */
-  --color-text:           #0f172a;
-  --color-text-strong:    #1e293b;
-  --color-text-secondary: #475569;
-  --color-text-muted:     #64748b;
-  --color-text-faint:     #94a3b8;
+  /* Foreground (Text) */
+  --color-fg:           #0f172a;
+  --color-fg-strong:    #1e293b;
+  --color-fg-secondary: #475569;
+  --color-fg-muted:     #64748b;
+  --color-fg-faint:     #94a3b8;
 
   /* Border */
   --color-border-subtle: #f1f5f9;
@@ -23,19 +23,19 @@
   --color-border-strong: #cbd5e1;
 
   /* Status: Danger */
-  --color-danger-text:   #b91c1c;
-  --color-danger-border: #fecaca;
-  --color-danger-bg:     #fef2f2;
+  --color-danger-fg:      #b91c1c;
+  --color-danger-outline: #fecaca;
+  --color-danger-subtle:  #fef2f2;
 
   /* Status: Success */
-  --color-success-text:   #15803d;
-  --color-success-border: #bbf7d0;
-  --color-success-bg:     #f0fdf4;
+  --color-success-fg:      #15803d;
+  --color-success-outline: #bbf7d0;
+  --color-success-subtle:  #f0fdf4;
 
   /* Status: Warning */
-  --color-warning-text:   #92400e;
-  --color-warning-border: #fde68a;
-  --color-warning-bg:     #fffbeb;
+  --color-warning-fg:      #92400e;
+  --color-warning-outline: #fde68a;
+  --color-warning-subtle:  #fffbeb;
 }
 
 @layer base {
@@ -55,12 +55,12 @@
       --color-surface-hover:    #1e293b;
       --color-surface-elevated: #334155;
 
-      /* Text */
-      --color-text:           #f1f5f9;
-      --color-text-strong:    #e2e8f0;
-      --color-text-secondary: #cbd5e1;
-      --color-text-muted:     #94a3b8;
-      --color-text-faint:     #64748b;
+      /* Foreground (Text) */
+      --color-fg:           #f1f5f9;
+      --color-fg-strong:    #e2e8f0;
+      --color-fg-secondary: #cbd5e1;
+      --color-fg-muted:     #94a3b8;
+      --color-fg-faint:     #64748b;
 
       /* Border */
       --color-border-subtle: #1e293b;
@@ -68,19 +68,19 @@
       --color-border-strong: #475569;
 
       /* Status: Danger */
-      --color-danger-text:   #fca5a5;
-      --color-danger-border: #991b1b;
-      --color-danger-bg:     #450a0a;
+      --color-danger-fg:      #fca5a5;
+      --color-danger-outline: #991b1b;
+      --color-danger-subtle:  #450a0a;
 
       /* Status: Success */
-      --color-success-text:   #4ade80;
-      --color-success-border: #166534;
-      --color-success-bg:     #052e16;
+      --color-success-fg:      #4ade80;
+      --color-success-outline: #166534;
+      --color-success-subtle:  #052e16;
 
       /* Status: Warning */
-      --color-warning-text:   #fcd34d;
-      --color-warning-border: #b45309;
-      --color-warning-bg:     #431407;
+      --color-warning-fg:      #fcd34d;
+      --color-warning-outline: #b45309;
+      --color-warning-subtle:  #431407;
     }
   }
 }
@@ -121,7 +121,7 @@
   .results-table thead { display: none; }
   .results-table tr {
     display: block;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--color-border);
     border-radius: 0.75rem;
     margin-bottom: 0.75rem;
     padding: 0.75rem;
@@ -135,19 +135,10 @@
   }
   .results-table td::before {
     content: attr(data-label);
-    color: #94a3b8;
+    color: var(--color-fg-faint);
     font-size: 0.75rem;
     flex-shrink: 0;
     margin-right: 0.5rem;
-  }
-}
-
-@media (max-width: 639px) and (prefers-color-scheme: dark) {
-  .results-table tr {
-    border-color: var(--color-border);
-  }
-  .results-table td::before {
-    color: var(--color-text-faint);
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,7 @@
   --color-surface-raised:   #ffffff;
   --color-surface-hover:    #f1f5f9;
   --color-surface-elevated: #f1f5f9;
+  --color-surface-tinted:   #f8fafc;
 
   /* Foreground (Text) */
   --color-fg:           #0f172a;
@@ -54,6 +55,7 @@
       --color-surface-raised:   #1e293b;
       --color-surface-hover:    #1e293b;
       --color-surface-elevated: #334155;
+      --color-surface-tinted:   #141c2f;
 
       /* Foreground (Text) */
       --color-fg:           #f1f5f9;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,10 @@
   --color-fg-secondary: #475569;
   --color-fg-muted:     #64748b;
   --color-fg-faint:     #94a3b8;
+  --color-fg-ghost:     #cbd5e1;
+
+  /* Status: Success (extended) */
+  --color-success-tinted: #dcfce7;
 
   /* Border */
   --color-border-subtle: #f1f5f9;
@@ -63,6 +67,10 @@
       --color-fg-secondary: #cbd5e1;
       --color-fg-muted:     #94a3b8;
       --color-fg-faint:     #64748b;
+      --color-fg-ghost:     #475569;
+
+      /* Status: Success (extended) */
+      --color-success-tinted: #0a2318;
 
       /* Border */
       --color-border-subtle: #1e293b;


### PR DESCRIPTION
## Summary

- Semantische CSS-Custom-Properties für Surface, Text, Border und Status-Farben in `global.css` definiert — Light-Werte in `@theme`, Dark-Overrides zentral im Media-Query in `@layer base`
- Alle ~190 `dark:`-Klassen aus 9 Dateien durch semantische Token-Utilities ersetzt (`bg-surface`, `text-text-muted`, `border-border` etc.)
- Echte Ausnahmen mit `dark:` behalten: Opacity-Modifier (`/50`, `/40`), brand-Farbe mit Opacity, intentionell dunkle Platzhalter

## Test plan

- [ ] Light Mode visuell geprüft (alle Seiten)
- [ ] Dark Mode visuell geprüft (alle Seiten)
- [ ] Build erfolgreich (`npm run build`)
- [ ] Neue Komponenten erhalten Dark Mode ohne `dark:`-Klassen

Closes #89