### PR TITLE
fix: log errors in cleanupAlteRunden() instead of silently swallowing them

### DIFF
--- a/src/pages/api/runde/erstellen.ts
+++ b/src/pages/api/runde/erstellen.ts
@@ -23,12 +23,12 @@ async function cleanupAlteRunden(dataDir: string): Promise<void> {
         if (now - mtimeMs > SIX_MONTHS_MS) {
           await unlink(filePath);
         }
-      } catch {
-        // Einzelne Datei überspringen bei Fehler
+      } catch (err) {
+        console.error('[cleanup] Datei übersprungen:', filePath, err);
       }
     }
-  } catch {
-    // Cleanup-Fehler nicht an den Client weitergeben
+  } catch (err) {
+    console.error('[cleanup] readdir fehlgeschlagen:', dataDir, err);
   }
 }
 


### PR DESCRIPTION
## Summary

- Äußerer `catch`-Block (readdir-Fehler) loggt jetzt via `console.error` mit Verzeichnis und Fehler-Objekt
- Innerer `catch`-Block (einzelne Datei) loggt via `console.error` mit Dateipfad und Fehler-Objekt
- Fire-and-forget-Verhalten (`void cleanupAlteRunden()`) bleibt unverändert

## Test plan

- [ ] Dev-Server starten, Runde erstellen — kein Fehler im Log
- [ ] `data/runden/` kurz entfernen/umbenennen, Runde erstellen — `[cleanup] readdir fehlgeschlagen:` erscheint im Log

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)