### PR TITLE
chore: configure DATA_DIR via environment variable

### DIFF
--- a/src/pages/api/runde/[id]/blob.ts
+++ b/src/pages/api/runde/[id]/blob.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const ID_FORMAT = /^[a-z0-9]{8}$/;
-const DATA_DIR = join(process.cwd(), 'data', 'runden');
+const DATA_DIR = process.env.DATA_DIR ?? join(process.cwd(), 'data', 'runden');
 
 export const GET: APIRoute = async ({ params }) => {
   const { id } = params;

--- a/src/pages/api/runde/[id]/gebot.ts
+++ b/src/pages/api/runde/[id]/gebot.ts
@@ -14,7 +14,7 @@ const ID_FORMAT = /^[a-z0-9]{8}$/;
 const EMOJI_HMAC_FORMAT = /^[A-Za-z0-9_-]{43}$/;
 // ECDH-Format: <ephemPubKey>.<iv>.<ciphertext> — drei Base64url-Teile
 const GEBOT_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
-const DATA_DIR = join(process.cwd(), 'data', 'runden');
+const DATA_DIR = process.env.DATA_DIR ?? join(process.cwd(), 'data', 'runden');
 
 const locks = new Map<string, Promise<void>>();
 

--- a/src/pages/api/runde/erstellen.ts
+++ b/src/pages/api/runde/erstellen.ts
@@ -40,7 +40,7 @@ function generateId(length: number): string {
 }
 
 const BLOB_FORMAT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
-const DATA_DIR = join(process.cwd(), 'data', 'runden');
+const DATA_DIR = process.env.DATA_DIR ?? join(process.cwd(), 'data', 'runden');
 
 export const POST: APIRoute = async ({ request }) => {
   void cleanupAlteRunden(DATA_DIR);


### PR DESCRIPTION
## Summary

- `DATA_DIR` in allen drei API-Dateien liest jetzt `process.env.DATA_DIR` mit Fallback auf `join(process.cwd(), 'data', 'runden')`
- Ohne gesetzte Umgebungsvariable ändert sich das Verhalten nicht
- Kein gemeinsames Modul — Änderung direkt in den betroffenen Dateien

## Test plan

- [ ] App ohne `DATA_DIR`-Env starten — verhält sich wie bisher
- [ ] App mit `DATA_DIR=/tmp/test` starten — Runden werden im neuen Pfad gespeichert

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)