### PR TITLE
feat: add GET /api/health liveness endpoint

### DIFF
--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,8 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify({ status: 'ok' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -2,7 +2,6 @@ import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = () => {
   return new Response(JSON.stringify({ status: 'ok' }), {
-    status: 200,
     headers: { 'Content-Type': 'application/json' },
   });
 };


### PR DESCRIPTION
## Summary
- Adds `GET /api/health` endpoint returning `{ "status": "ok" }` with HTTP 200
- No auth, no body, no filesystem access — pure liveness check

## Test plan
- [ ] `curl http://localhost:4321/api/health` returns `{"status":"ok"}` with 200
- [ ] No side effects on repeated calls

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)