### PR TITLE
chore: add structured stderr logging for 5xx errors

### DIFF
--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,0 +1,5 @@
+export function logError(msg: string, context?: Record<string, unknown>): void {
+  process.stderr.write(
+    JSON.stringify({ level: 'error', msg, ...context, ts: new Date().toISOString() }) + '\n',
+  );
+}

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,5 +1,19 @@
+function serializeErr(err: unknown): unknown {
+  if (err instanceof Error) {
+    return { message: err.message, code: (err as NodeJS.ErrnoException).code };
+  }
+  return err;
+}
+
 export function logError(msg: string, context?: Record<string, unknown>): void {
+  const { err, ...rest } = context ?? {};
   process.stderr.write(
-    JSON.stringify({ level: 'error', msg, ...context, ts: new Date().toISOString() }) + '\n',
+    JSON.stringify({
+      level: 'error',
+      msg,
+      ...rest,
+      ...(err !== undefined && { err: serializeErr(err) }),
+      ts: new Date().toISOString(),
+    }) + '\n',
   );
 }

--- a/src/pages/api/runde/[id]/blob.ts
+++ b/src/pages/api/runde/[id]/blob.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { logError } from '@/lib/log';
 
 const ID_FORMAT = /^[a-z0-9]{8}$/;
 const DATA_DIR = process.env.DATA_DIR ?? join(process.cwd(), 'data', 'runden');
@@ -25,6 +26,7 @@ export const GET: APIRoute = async ({ params }) => {
         headers: { 'Content-Type': 'application/json' },
       });
     }
+    logError('blob: readFile fehlgeschlagen', { id, err });
     throw err;
   }
 

--- a/src/pages/api/runde/[id]/gebot.ts
+++ b/src/pages/api/runde/[id]/gebot.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { timingSafeEqual, createHash } from 'node:crypto';
+import { logError } from '@/lib/log';
 
 interface RundeJSON {
   id: string;
@@ -107,11 +108,13 @@ export const POST: APIRoute = async ({ params, request }) => {
       await writeFile(join(DATA_DIR, `${id}.json`), JSON.stringify(runde, null, 2), 'utf-8');
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code === 'ENOSPC') {
+        logError('gebot POST: writeFile fehlgeschlagen – kein Speicherplatz', { id, err });
         return new Response(JSON.stringify({ error: 'Kein Speicherplatz verfügbar' }), {
           status: 507,
           headers: { 'Content-Type': 'application/json' },
         });
       }
+      logError('gebot POST: writeFile fehlgeschlagen', { id, err });
       return new Response(JSON.stringify({ error: 'Fehler beim Speichern' }), {
         status: 503,
         headers: { 'Content-Type': 'application/json' },
@@ -204,11 +207,13 @@ export const DELETE: APIRoute = async ({ params, request }) => {
       await writeFile(join(DATA_DIR, `${id}.json`), JSON.stringify(runde, null, 2), 'utf-8');
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code === 'ENOSPC') {
+        logError('gebot DELETE: writeFile fehlgeschlagen – kein Speicherplatz', { id, err });
         return new Response(JSON.stringify({ error: 'Kein Speicherplatz verfügbar' }), {
           status: 507,
           headers: { 'Content-Type': 'application/json' },
         });
       }
+      logError('gebot DELETE: writeFile fehlgeschlagen', { id, err });
       return new Response(JSON.stringify({ error: 'Fehler beim Speichern' }), {
         status: 503,
         headers: { 'Content-Type': 'application/json' },

--- a/src/pages/api/runde/erstellen.ts
+++ b/src/pages/api/runde/erstellen.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { writeFile, readdir, unlink, stat } from 'node:fs/promises';
 import { join } from 'node:path';
+import { logError } from '@/lib/log';
 
 interface RundeJSON {
   id: string;
@@ -24,11 +25,11 @@ async function cleanupAlteRunden(dataDir: string): Promise<void> {
           await unlink(filePath);
         }
       } catch (err) {
-        console.error('[cleanup] Datei übersprungen:', filePath, err);
+        logError('cleanup: Datei übersprungen', { filePath, err });
       }
     }
   } catch (err) {
-    console.error('[cleanup] readdir fehlgeschlagen:', dataDir, err);
+    logError('cleanup: readdir fehlgeschlagen', { dataDir, err });
   }
 }
 
@@ -84,7 +85,22 @@ export const POST: APIRoute = async ({ request }) => {
     gebote: [],
   };
 
-  await writeFile(join(DATA_DIR, `${id}.json`), JSON.stringify(runde, null, 2), 'utf-8');
+  try {
+    await writeFile(join(DATA_DIR, `${id}.json`), JSON.stringify(runde, null, 2), 'utf-8');
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOSPC') {
+      logError('erstellen: writeFile fehlgeschlagen – kein Speicherplatz', { id, err });
+      return new Response(JSON.stringify({ error: 'Kein Speicherplatz verfügbar' }), {
+        status: 507,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    logError('erstellen: writeFile fehlgeschlagen', { id, err });
+    return new Response(JSON.stringify({ error: 'Fehler beim Speichern' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
 
   return new Response(JSON.stringify({ id, adminToken }), {
     status: 200,


### PR DESCRIPTION
## Summary
- Adds `src/lib/log.ts` with `logError(msg, context?)` — writes JSON to `process.stderr`, no new dependency
- All 5xx paths in `erstellen.ts`, `blob.ts`, and `gebot.ts` now call `logError()`
- Also migrates existing `console.error` calls in `cleanupAlteRunden` to `logError`
- `erstellen.ts` now catches `writeFile` errors (was previously unhandled)

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] `curl` against a healthy server returns normal responses
- [ ] Simulated ENOSPC returns 507 with log output on stderr

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)