### PR TITLE
test: add unit tests for storage.ts

### DIFF
--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   getRunden,
   saveRunde,
@@ -6,6 +6,7 @@ import {
   clearRunden,
   saveGebotLokal,
   getGebotSlot,
+  exportJson,
   importJson,
   type LocalRunde,
 } from './storage';
@@ -30,6 +31,10 @@ let ls: ReturnType<typeof makeLocalStorageStub>;
 beforeEach(() => {
   ls = makeLocalStorageStub();
   vi.stubGlobal('localStorage', ls);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 // ---------------------------------------------------------------------------
@@ -106,6 +111,14 @@ describe('saveRunde', () => {
     saveRunde(r2);
     expect(getRunden()[0].name).toBe('Original');
   });
+
+  it('überschreibt nicht wenn beide adminLink haben', () => {
+    const r1 = runde({ name: 'Original', adminLink: 'https://example.com/admin1' });
+    saveRunde(r1);
+    const r2 = runde({ name: 'Update', adminLink: 'https://example.com/admin2' });
+    saveRunde(r2);
+    expect(getRunden()[0].adminLink).toBe('https://example.com/admin1');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -168,6 +181,23 @@ describe('saveGebotLokal / getGebotSlot', () => {
     saveGebotLokal('runde2', '🐼🚀🌈', 'SlotB');
     expect(getGebotSlot('runde1', '🐼🚀🌈')).toBe('SlotA');
     expect(getGebotSlot('runde2', '🐼🚀🌈')).toBe('SlotB');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportJson
+// ---------------------------------------------------------------------------
+
+describe('exportJson', () => {
+  it('gibt leeres Array als JSON zurück wenn keine Runden vorhanden', () => {
+    expect(exportJson()).toBe('[]');
+  });
+
+  it('serialisiert vorhandene Runden als formatiertes JSON', () => {
+    const r = runde();
+    saveRunde(r);
+    const parsed = JSON.parse(exportJson());
+    expect(parsed).toEqual([r]);
   });
 });
 

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getRunden,
+  saveRunde,
+  deleteRunde,
+  clearRunden,
+  saveGebotLokal,
+  getGebotSlot,
+  importJson,
+  type LocalRunde,
+} from './storage';
+
+// ---------------------------------------------------------------------------
+// localStorage-Stub
+// ---------------------------------------------------------------------------
+
+function makeLocalStorageStub() {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => { store.set(key, value); }),
+    removeItem: vi.fn((key: string) => { store.delete(key); }),
+    clear: vi.fn(() => store.clear()),
+    store,
+  };
+}
+
+let ls: ReturnType<typeof makeLocalStorageStub>;
+
+beforeEach(() => {
+  ls = makeLocalStorageStub();
+  vi.stubGlobal('localStorage', ls);
+});
+
+// ---------------------------------------------------------------------------
+// Hilfsfunktion
+// ---------------------------------------------------------------------------
+
+function runde(overrides: Partial<LocalRunde> = {}): LocalRunde {
+  return {
+    id: 'abc12345',
+    name: 'Testrunde',
+    hinzugefuegtAm: '2026-04-21T00:00:00.000Z',
+    teilnehmerLink: 'https://example.com/runde/abc12345#pk=x',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getRunden
+// ---------------------------------------------------------------------------
+
+describe('getRunden', () => {
+  it('gibt [] zurück wenn kein Eintrag vorhanden', () => {
+    expect(getRunden()).toEqual([]);
+  });
+
+  it('gibt geparste Runden zurück bei validem JSON', () => {
+    const r = runde();
+    ls.store.set('fairshare_runden', JSON.stringify([r]));
+    expect(getRunden()).toEqual([r]);
+  });
+
+  it('wirft bei korruptem JSON', () => {
+    ls.store.set('fairshare_runden', '{kaputt}');
+    expect(() => getRunden()).toThrow();
+  });
+
+  it('wirft wenn JSON kein Array ist', () => {
+    ls.store.set('fairshare_runden', JSON.stringify({ nicht: 'array' }));
+    expect(() => getRunden()).toThrow('Ungültiges Format in localStorage');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveRunde
+// ---------------------------------------------------------------------------
+
+describe('saveRunde', () => {
+  it('fügt neue Runde hinzu', () => {
+    const r = runde();
+    saveRunde(r);
+    expect(getRunden()).toEqual([r]);
+  });
+
+  it('überschreibt nicht wenn bestehender Eintrag adminLink hat (kein Downgrade)', () => {
+    const mitAdmin = runde({ adminLink: 'https://example.com/admin' });
+    saveRunde(mitAdmin);
+    const ohneAdmin = runde({ adminLink: undefined });
+    saveRunde(ohneAdmin);
+    expect(getRunden()[0].adminLink).toBe('https://example.com/admin');
+  });
+
+  it('überschreibt wenn bestehender Eintrag keinen adminLink hat (Upgrade)', () => {
+    const ohneAdmin = runde({ adminLink: undefined });
+    saveRunde(ohneAdmin);
+    const mitAdmin = runde({ adminLink: 'https://example.com/admin' });
+    saveRunde(mitAdmin);
+    expect(getRunden()[0].adminLink).toBe('https://example.com/admin');
+  });
+
+  it('überschreibt nicht wenn beide keinen adminLink haben', () => {
+    const r1 = runde({ name: 'Original', adminLink: undefined });
+    saveRunde(r1);
+    const r2 = runde({ name: 'Update', adminLink: undefined });
+    saveRunde(r2);
+    expect(getRunden()[0].name).toBe('Original');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteRunde
+// ---------------------------------------------------------------------------
+
+describe('deleteRunde', () => {
+  it('entfernt Runde per ID', () => {
+    saveRunde(runde({ id: 'aaa' }));
+    saveRunde(runde({ id: 'bbb' }));
+    deleteRunde('aaa');
+    const ids = getRunden().map((r) => r.id);
+    expect(ids).toEqual(['bbb']);
+  });
+
+  it('tut nichts bei unbekannter ID', () => {
+    saveRunde(runde({ id: 'aaa' }));
+    deleteRunde('zzz');
+    expect(getRunden()).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearRunden
+// ---------------------------------------------------------------------------
+
+describe('clearRunden', () => {
+  it('löscht alle Runden aus localStorage', () => {
+    saveRunde(runde({ id: 'aaa' }));
+    saveRunde(runde({ id: 'bbb' }));
+    clearRunden();
+    expect(getRunden()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveGebotLokal / getGebotSlot
+// ---------------------------------------------------------------------------
+
+describe('saveGebotLokal / getGebotSlot', () => {
+  it('Roundtrip: gespeichertes Gebot wird korrekt zurückgegeben', () => {
+    saveGebotLokal('runde1', '🐼🚀🌈', 'Erwachsen');
+    expect(getGebotSlot('runde1', '🐼🚀🌈')).toBe('Erwachsen');
+  });
+
+  it('gibt null zurück wenn kein Gebot vorhanden', () => {
+    expect(getGebotSlot('runde1', '🐼🚀🌈')).toBeNull();
+  });
+
+  it('doppeltes Speichern derselben emojiId wird ignoriert', () => {
+    saveGebotLokal('runde1', '🐼🚀🌈', 'Erwachsen');
+    saveGebotLokal('runde1', '🐼🚀🌈', 'Kind');
+    const raw = ls.store.get('fairshare-gebot-runde1')!;
+    expect(JSON.parse(raw)).toHaveLength(1);
+    expect(getGebotSlot('runde1', '🐼🚀🌈')).toBe('Erwachsen');
+  });
+
+  it('verschiedene rundenIds sind unabhängig', () => {
+    saveGebotLokal('runde1', '🐼🚀🌈', 'SlotA');
+    saveGebotLokal('runde2', '🐼🚀🌈', 'SlotB');
+    expect(getGebotSlot('runde1', '🐼🚀🌈')).toBe('SlotA');
+    expect(getGebotSlot('runde2', '🐼🚀🌈')).toBe('SlotB');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// importJson
+// ---------------------------------------------------------------------------
+
+describe('importJson', () => {
+  it('importiert valide Runden', () => {
+    const r = runde();
+    importJson(JSON.stringify([r]));
+    expect(getRunden()).toEqual([r]);
+  });
+
+  it('wirft bei ungültigem JSON', () => {
+    expect(() => importJson('{kaputt}')).toThrow();
+  });
+
+  it('wirft wenn JSON kein Array ist', () => {
+    expect(() => importJson(JSON.stringify({ nicht: 'array' }))).toThrow('Ungültiges Format: kein Array');
+  });
+
+  it('wirft wenn Einträge Pflichtfelder fehlen', () => {
+    expect(() => importJson(JSON.stringify([{ id: 'abc' }]))).toThrow('Pflichtfelder');
+  });
+
+  it('überschreibt bestehende Runden komplett', () => {
+    saveRunde(runde({ id: 'alt' }));
+    importJson(JSON.stringify([runde({ id: 'neu' })]));
+    const ids = getRunden().map((r) => r.id);
+    expect(ids).toEqual(['neu']);
+  });
+});


### PR DESCRIPTION
## Summary

- Neue Testdatei `src/lib/storage.test.ts` mit 20 Tests für alle `storage.ts`-Funktionen
- `localStorage` per `vi.stubGlobal` simuliert — kein jsdom nötig
- Deckt: `getRunden`, `saveRunde` (inkl. Upgrade/Downgrade-Logik), `deleteRunde`, `clearRunden`, `saveGebotLokal`/`getGebotSlot` Roundtrip, `importJson`

## Test plan

- [x] `getRunden()`: kein Eintrag → `[]`
- [x] `getRunden()`: valides JSON → korrektes Array
- [x] `getRunden()`: korruptes JSON → wirft Fehler
- [x] `saveRunde()`: neue Runde wird hinzugefügt
- [x] `saveRunde()`: kein Downgrade (bestehender adminLink bleibt)
- [x] `saveRunde()`: Upgrade (bestehender ohne adminLink wird überschrieben)
- [x] `deleteRunde()`: entfernt Runde per ID
- [x] `clearRunden()`: löscht alle Runden
- [x] `saveGebotLokal`/`getGebotSlot`: Roundtrip funktioniert
- [x] `importJson()`: wirft bei ungültigem Format
- [x] Alle 20 Tests grün

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)