### PR TITLE
test: add integration tests for erstellen and blob API endpoints

### DIFF
--- a/src/pages/api/runde/[id]/blob.test.ts
+++ b/src/pages/api/runde/[id]/blob.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// fs/promises mock — muss vor dem Import des Handlers stehen
+// ---------------------------------------------------------------------------
+
+const mockReadFile = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  readFile: mockReadFile,
+}));
+
+// ---------------------------------------------------------------------------
+// Hilfe
+// ---------------------------------------------------------------------------
+
+function makeRunde() {
+  return JSON.stringify({
+    id: 'abc12345',
+    adminToken: 'tok1234567890abc',
+    encTeilnehmerBlob: 'iv123.cipher456',
+    gebote: [{ emojiHmac: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', encGebot: 'k.iv.ct' }],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/runde/[id]/blob', () => {
+  let handler: (ctx: { params: { id: string } }) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const mod = await import('./blob?t=' + Date.now());
+    handler = mod.GET as typeof handler;
+  });
+
+  it('happy path: existierende Datei gibt encTeilnehmerBlob und gebote zurück', async () => {
+    mockReadFile.mockResolvedValue(makeRunde());
+    const res = await handler({ params: { id: 'abc12345' } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.encTeilnehmerBlob).toBe('iv123.cipher456');
+    expect(body.gebote).toHaveLength(1);
+  });
+
+  it('gibt adminToken und id nicht zurück (Zero-Knowledge)', async () => {
+    mockReadFile.mockResolvedValue(makeRunde());
+    const res = await handler({ params: { id: 'abc12345' } });
+    const body = await res.json();
+    expect(body.adminToken).toBeUndefined();
+    expect(body.id).toBeUndefined();
+  });
+
+  it('unbekannte ID (ENOENT) → 404', async () => {
+    const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    mockReadFile.mockRejectedValue(enoent);
+    const res = await handler({ params: { id: 'unbekann' } });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Runde nicht gefunden');
+  });
+
+  it('ungültige ID (zu lang) → 400', async () => {
+    const res = await handler({ params: { id: 'toolongid' } });
+    expect(res.status).toBe(400);
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('ungültige ID (Großbuchstaben) → 400', async () => {
+    const res = await handler({ params: { id: 'ABC12345' } });
+    expect(res.status).toBe(400);
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/api/runde/erstellen.test.ts
+++ b/src/pages/api/runde/erstellen.test.ts
@@ -79,6 +79,13 @@ describe('POST /api/runde/erstellen', () => {
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
+  it('encTeilnehmerBlob zu lang (> 10.000 Zeichen) → 400', async () => {
+    const tooLong = 'A'.repeat(5001) + '.' + 'B'.repeat(5001);
+    const res = await handler({ request: makeRequest({ encTeilnehmerBlob: tooLong }) });
+    expect(res.status).toBe(400);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
   it('kein JSON-Body → 400', async () => {
     const req = new Request('http://localhost/api/runde/erstellen', {
       method: 'POST',

--- a/src/pages/api/runde/erstellen.test.ts
+++ b/src/pages/api/runde/erstellen.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// fs/promises mock — muss vor dem Import des Handlers stehen
+// ---------------------------------------------------------------------------
+
+const mockWriteFile = vi.fn();
+const mockReaddir = vi.fn();
+const mockUnlink = vi.fn();
+const mockStat = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: mockWriteFile,
+  readdir: mockReaddir,
+  unlink: mockUnlink,
+  stat: mockStat,
+}));
+
+// ---------------------------------------------------------------------------
+// Hilfe
+// ---------------------------------------------------------------------------
+
+// Valides Format: base64url.base64url
+const VALID_BLOB = 'aGVsbG8.d29ybGQ';
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/runde/erstellen', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/runde/erstellen', () => {
+  let handler: (ctx: { request: Request }) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mockWriteFile.mockResolvedValue(undefined);
+    mockReaddir.mockResolvedValue([]);
+    const mod = await import('./erstellen?t=' + Date.now());
+    handler = mod.POST as typeof handler;
+  });
+
+  it('happy path: valider Body gibt id (8 Zeichen) und adminToken (16 Zeichen) zurück', async () => {
+    const res = await handler({ request: makeRequest({ encTeilnehmerBlob: VALID_BLOB }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.id).toBe('string');
+    expect(body.id).toHaveLength(8);
+    expect(/^[a-z0-9]{8}$/.test(body.id)).toBe(true);
+    expect(typeof body.adminToken).toBe('string');
+    expect(body.adminToken).toHaveLength(16);
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+  });
+
+  it('geschriebene Datei enthält korrekte Rundenstruktur', async () => {
+    await handler({ request: makeRequest({ encTeilnehmerBlob: VALID_BLOB }) });
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(written.encTeilnehmerBlob).toBe(VALID_BLOB);
+    expect(written.gebote).toEqual([]);
+    expect(typeof written.adminToken).toBe('string');
+    expect(typeof written.id).toBe('string');
+  });
+
+  it('kein encTeilnehmerBlob → 400', async () => {
+    const res = await handler({ request: makeRequest({}) });
+    expect(res.status).toBe(400);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('encTeilnehmerBlob mit ungültigem Format (kein Punkt) → 400', async () => {
+    const res = await handler({ request: makeRequest({ encTeilnehmerBlob: 'keinPunktFormat' }) });
+    expect(res.status).toBe(400);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('kein JSON-Body → 400', async () => {
+    const req = new Request('http://localhost/api/runde/erstellen', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: 'kein json',
+    });
+    const res = await handler({ request: req });
+    expect(res.status).toBe(400);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('writeFile ENOSPC → 507', async () => {
+    const enospc = Object.assign(new Error('ENOSPC'), { code: 'ENOSPC' });
+    mockWriteFile.mockRejectedValue(enospc);
+    const res = await handler({ request: makeRequest({ encTeilnehmerBlob: VALID_BLOB }) });
+    expect(res.status).toBe(507);
+    const body = await res.json();
+    expect(body.error).toBe('Kein Speicherplatz verfügbar');
+  });
+
+  it('writeFile generischer Fehler → 503', async () => {
+    mockWriteFile.mockRejectedValue(new Error('EIO'));
+    const res = await handler({ request: makeRequest({ encTeilnehmerBlob: VALID_BLOB }) });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe('Fehler beim Speichern');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
   test: {
     environment: 'node',
   },


### PR DESCRIPTION
## Summary

- Neue Testdateien für `POST /api/runde/erstellen` und `GET /api/runde/[id]/blob`
- `node:fs/promises` per `vi.mock` gemockt (gleiche Strategie wie `gebot.test.ts`)
- Fix: `@/` Pfad-Alias fehlte in `vitest.config.ts` — hat `gebot.test.ts` und alle API-Tests gebrochen

## Test plan

- [x] `erstellen`: Happy Path — gibt `id` (8 Zeichen) und `adminToken` (16 Zeichen) zurück
- [x] `erstellen`: Dateiinhalt korrekt (encTeilnehmerBlob, leere gebote)
- [x] `erstellen`: kein `encTeilnehmerBlob` → 400
- [x] `erstellen`: ungültiges Blob-Format → 400
- [x] `erstellen`: kein JSON-Body → 400
- [x] `erstellen`: `writeFile` ENOSPC → 507
- [x] `erstellen`: `writeFile` generischer Fehler → 503
- [x] `blob`: Happy Path — gibt `encTeilnehmerBlob` und `gebote` zurück
- [x] `blob`: gibt `adminToken` und `id` nicht zurück (Zero-Knowledge)
- [x] `blob`: unbekannte ID → 404
- [x] `blob`: ungültige ID → 400
- [x] Alle 104 Tests grün

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)