### PR TITLE
test: close coverage gaps in blob.test.ts

### DIFF
--- a/src/pages/api/runde/[id]/blob.test.ts
+++ b/src/pages/api/runde/[id]/blob.test.ts
@@ -43,6 +43,15 @@ describe('GET /api/runde/[id]/blob', () => {
     const body = await res.json();
     expect(body.encTeilnehmerBlob).toBe('iv123.cipher456');
     expect(body.gebote).toHaveLength(1);
+    expect(body.gebote[0]).toEqual({
+      emojiHmac: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      encGebot: 'k.iv.ct',
+    });
+  });
+
+  it('nicht-ENOENT readFile-Fehler wird re-geworfen', async () => {
+    mockReadFile.mockRejectedValue(new Error('EIO'));
+    await expect(handler({ params: { id: 'abc12345' } })).rejects.toThrow('EIO');
   });
 
   it('gibt adminToken und id nicht zurück (Zero-Knowledge)', async () => {


### PR DESCRIPTION
## Summary

- Gebote-Inhalt im Happy Path verifiziert (nicht nur Länge)
- Nicht-ENOENT readFile-Fehler: prüft dass re-throw korrekt funktioniert

🤖 Generated with [Claude Code](https://claude.com/claude-code)