### PR TITLE
feat: Drei-Gebot-Modus (Grün/Gelb/Rot) pro Runde

### DIFF
--- a/src/lib/solidarisch.test.ts
+++ b/src/lib/solidarisch.test.ts
@@ -4,10 +4,13 @@ import {
   berechneAusgleich,
   berechneRichtwert,
   generiereEmojiId,
+  ermittleDreiGebotStatus,
+  dreiGebotZuGebote,
   EMOJIS,
   type Gebot,
   type GebotErgebnis,
   type Slot,
+  type DreiGebotTriple,
 } from './solidarisch';
 
 // ---------------------------------------------------------------------------
@@ -571,5 +574,73 @@ describe('Fehlerfälle', () => {
 
   it('wirft bei leerer Slots-Liste', () => {
     expect(() => berechneAuswertung(100, [gebot(1, 50)], [])).toThrow('Keine Slots definiert');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ermittleDreiGebotStatus
+// ---------------------------------------------------------------------------
+
+function triple(
+  betragMin: number,
+  betragMittel: number,
+  betragMax: number,
+  overrides: Partial<DreiGebotTriple> = {},
+): DreiGebotTriple {
+  return { emojiId: '🐼🚀🌈', slotLabel: 'Slot', gewichtung: 1, betragMin, betragMittel, betragMax, ...overrides };
+}
+
+describe('ermittleDreiGebotStatus', () => {
+  it('gibt gruen zurück wenn Minimalgebote die Kosten decken', () => {
+    expect(ermittleDreiGebotStatus(100, [triple(50, 80, 120), triple(60, 80, 120)])).toBe('gruen');
+  });
+
+  it('gibt gelb zurück wenn erst Mittelgebote die Kosten decken', () => {
+    expect(ermittleDreiGebotStatus(100, [triple(30, 60, 120), triple(30, 60, 120)])).toBe('gelb');
+  });
+
+  it('gibt rot zurück wenn erst Maximalgebote die Kosten decken', () => {
+    expect(ermittleDreiGebotStatus(100, [triple(20, 40, 60), triple(20, 40, 60)])).toBe('rot');
+  });
+
+  it('gibt kritisch zurück wenn selbst Maximalgebote nicht reichen', () => {
+    expect(ermittleDreiGebotStatus(100, [triple(10, 20, 30), triple(10, 20, 30)])).toBe('kritisch');
+  });
+
+  it('wertet genau die Summe als ausreichend (Grenzfall)', () => {
+    expect(ermittleDreiGebotStatus(100, [triple(100, 150, 200)])).toBe('gruen');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dreiGebotZuGebote
+// ---------------------------------------------------------------------------
+
+describe('dreiGebotZuGebote', () => {
+  const gebote = [triple(10, 20, 30), triple(40, 50, 60)];
+
+  it('wählt betragMin bei gruen', () => {
+    const result = dreiGebotZuGebote('gruen', gebote);
+    expect(result.map(g => g.betrag)).toEqual([10, 40]);
+  });
+
+  it('wählt betragMittel bei gelb', () => {
+    const result = dreiGebotZuGebote('gelb', gebote);
+    expect(result.map(g => g.betrag)).toEqual([20, 50]);
+  });
+
+  it('wählt betragMax bei rot', () => {
+    const result = dreiGebotZuGebote('rot', gebote);
+    expect(result.map(g => g.betrag)).toEqual([30, 60]);
+  });
+
+  it('wählt betragMax bei kritisch', () => {
+    const result = dreiGebotZuGebote('kritisch', gebote);
+    expect(result.map(g => g.betrag)).toEqual([30, 60]);
+  });
+
+  it('überträgt emojiId, slotLabel und gewichtung korrekt', () => {
+    const [g] = dreiGebotZuGebote('gruen', [triple(10, 20, 30, { emojiId: '🦊🌙⭐', slotLabel: 'Erwachsen', gewichtung: 0.75 })]);
+    expect(g).toMatchObject({ emojiId: '🦊🌙⭐', slotLabel: 'Erwachsen', gewichtung: 0.75 });
   });
 });

--- a/src/lib/solidarisch.ts
+++ b/src/lib/solidarisch.ts
@@ -193,6 +193,43 @@ export function berechneAuswertung(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Drei-Gebot-Modus
+// ---------------------------------------------------------------------------
+
+export type DreiGebotStatus = 'gruen' | 'gelb' | 'rot' | 'kritisch';
+
+export interface DreiGebotTriple {
+  emojiId: string;
+  slotLabel: string;
+  gewichtung: number;
+  betragMin: number;
+  betragMittel: number;
+  betragMax: number;
+}
+
+/** Ermittelt das niedrigste Level, auf dem die Gesamtkosten gedeckt sind. */
+export function ermittleDreiGebotStatus(
+  gesamtkosten: number,
+  gebote: DreiGebotTriple[],
+): DreiGebotStatus {
+  if (gebote.reduce((s, g) => s + g.betragMin, 0) >= gesamtkosten) return 'gruen';
+  if (gebote.reduce((s, g) => s + g.betragMittel, 0) >= gesamtkosten) return 'gelb';
+  if (gebote.reduce((s, g) => s + g.betragMax, 0) >= gesamtkosten) return 'rot';
+  return 'kritisch';
+}
+
+/** Wandelt Drei-Gebot-Tripel in einfache Gebote um (Betrag je nach Status). */
+export function dreiGebotZuGebote(status: DreiGebotStatus, gebote: DreiGebotTriple[]): Gebot[] {
+  return gebote.map((t) => ({
+    emojiId: t.emojiId,
+    slotLabel: t.slotLabel,
+    gewichtung: t.gewichtung,
+    betrag: status === 'gruen' ? t.betragMin : status === 'gelb' ? t.betragMittel : t.betragMax,
+  }));
+}
+
+// ---------------------------------------------------------------------------
 /**
  * Berechnet Ausgleichszahlungen (minimale Anzahl Überweisungen).
  *

--- a/src/pages/api/runde/[id]/gebot.test.ts
+++ b/src/pages/api/runde/[id]/gebot.test.ts
@@ -192,8 +192,8 @@ describe('POST /api/runde/[id]/gebot', () => {
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
-  it('encGebot über 1000 Zeichen gibt 400', async () => {
-    const longGebot = `${'A'.repeat(500)}.${'B'.repeat(100)}.${'C'.repeat(401)}`;
+  it('encGebot über 1500 Zeichen gibt 400', async () => {
+    const longGebot = `${'A'.repeat(700)}.${'B'.repeat(400)}.${'C'.repeat(401)}`;
     const res = await handler({
       params: { id: 'abc12345' },
       request: makeRequest({ emojiHmac: EMOJI_HMAC, encGebot: longGebot }),

--- a/src/pages/api/runde/[id]/gebot.ts
+++ b/src/pages/api/runde/[id]/gebot.ts
@@ -55,7 +55,7 @@ export const POST: APIRoute = async ({ params, request }) => {
       headers: { 'Content-Type': 'application/json' },
     });
   }
-  if (typeof b.encGebot !== 'string' || !GEBOT_FORMAT.test(b.encGebot) || b.encGebot.length > 1_000) {
+  if (typeof b.encGebot !== 'string' || !GEBOT_FORMAT.test(b.encGebot) || b.encGebot.length > 1_500) {
     return new Response(JSON.stringify({ error: 'encGebot fehlt oder hat ungültiges Format' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -14,6 +14,14 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         <div id="power-menu" class="hidden absolute right-0 mt-1 w-52 bg-surface-raised border border-border rounded-lg shadow-lg z-10 py-1">
           <button id="splid-import-btn" type="button"
             class="w-full text-left text-sm px-4 py-2 text-fg-secondary hover:bg-surface-elevated transition-colors">Abrechnung importieren</button>
+          <label class="flex items-center justify-between px-4 py-2 cursor-pointer hover:bg-surface-elevated transition-colors select-none">
+            <span class="text-sm text-fg-secondary">Drei-Gebot-Modus</span>
+            <input type="checkbox" id="drei-gebot-toggle" class="sr-only peer" />
+            <div class="w-9 h-5 bg-gray-300 rounded-full peer-checked:bg-brand relative shrink-0
+                        after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4
+                        after:bg-white after:rounded-full after:transition-all
+                        peer-checked:after:translate-x-4"></div>
+          </label>
         </div>
       </div>
     </div>

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -49,8 +49,8 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
           <div id="slot-auswahl" class="space-y-2"></div>
         </div>
 
-        <!-- Betrag -->
-        <div>
+        <!-- Betrag (Einzel-Modus) -->
+        <div id="betrag-einzel">
           <label for="betrag" class="block text-sm font-medium text-fg-secondary mb-1">
             Dein Gebot (€)
           </label>
@@ -58,13 +58,55 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             type="number"
             id="betrag"
             name="betrag"
-            required
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
             class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
           <p id="betrag-richtwert-hinweis" class="text-xs text-fg-faint mt-1"></p>
+        </div>
+
+        <!-- Betrag (Drei-Gebot-Modus, hidden by default) -->
+        <div id="betrag-drei" class="hidden space-y-3">
+          <div>
+            <label for="betrag-min" class="block text-sm font-medium text-fg-secondary mb-1">
+              Minimalgebot (€)
+            </label>
+            <input
+              type="number"
+              id="betrag-min"
+              min="0.01"
+              step="0.01"
+              placeholder="z.B. 60"
+              class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+            />
+          </div>
+          <div>
+            <label for="betrag-mittel" class="block text-sm font-medium text-fg-secondary mb-1">
+              Mittleres Gebot (€)
+            </label>
+            <input
+              type="number"
+              id="betrag-mittel"
+              min="0.01"
+              step="0.01"
+              placeholder="z.B. 80"
+              class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+            />
+          </div>
+          <div>
+            <label for="betrag-max" class="block text-sm font-medium text-fg-secondary mb-1">
+              Maximalgebot (€)
+            </label>
+            <input
+              type="number"
+              id="betrag-max"
+              min="0.01"
+              step="0.01"
+              placeholder="z.B. 110"
+              class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+            />
+          </div>
         </div>
 
         <!-- Fehler -->

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -4,7 +4,15 @@ import {
   decrypt,
   decryptGebot,
 } from '../lib/crypto';
-import { berechneAuswertung, berechneAusgleich, type Gebot, type GebotErgebnis } from '../lib/solidarisch';
+import {
+  berechneAuswertung,
+  berechneAusgleich,
+  ermittleDreiGebotStatus,
+  dreiGebotZuGebote,
+  type Gebot,
+  type GebotErgebnis,
+  type DreiGebotTriple,
+} from '../lib/solidarisch';
 import { formatEur } from '../lib/ui';
 
 interface TeilnehmerBlob {
@@ -13,6 +21,18 @@ interface TeilnehmerBlob {
   adminPubKey: string;
   hmacKey: string;
   slots: { label: string; gewichtung: number; anzahl: number; ausgaben?: number; standardgebot?: number }[];
+  dreiGebotModus?: boolean;
+}
+
+interface RawGebotPayload {
+  emojiId: string;
+  slotLabel: string;
+  gewichtung: number;
+  betrag?: number;
+  betragMin?: number;
+  betragMittel?: number;
+  betragMax?: number;
+  istStandard?: boolean;
 }
 
 export async function initAdmin(): Promise<void> {
@@ -94,11 +114,21 @@ export async function initAdmin(): Promise<void> {
   const dedupGebote = [...latestByHmac.values()];
 
   // Gebote entschlüsseln
+  const dreiGebotModus = blob.dreiGebotModus === true;
   const geboteWithHmac: Array<{ emojiHmac: string; gebot: Gebot }> = [];
+  const dreiGebotTriples: DreiGebotTriple[] = [];
+
   for (const { emojiHmac, encGebot } of dedupGebote) {
     try {
-      const g = JSON.parse(await decryptGebot(adminPrivKey, encGebot)) as Gebot;
-      geboteWithHmac.push({ emojiHmac, gebot: g });
+      const raw = JSON.parse(await decryptGebot(adminPrivKey, encGebot)) as RawGebotPayload;
+      if (raw.betragMin !== undefined && raw.betragMittel !== undefined && raw.betragMax !== undefined) {
+        dreiGebotTriples.push({
+          emojiId: raw.emojiId, slotLabel: raw.slotLabel, gewichtung: raw.gewichtung,
+          betragMin: raw.betragMin, betragMittel: raw.betragMittel, betragMax: raw.betragMax,
+        });
+      }
+      // Für Anzeige und Vollständigkeits-Check immer als Gebot (betrag irrelevant bis Auswertung)
+      geboteWithHmac.push({ emojiHmac, gebot: { emojiId: raw.emojiId, slotLabel: raw.slotLabel, gewichtung: raw.gewichtung, betrag: raw.betrag ?? 0 } });
     } catch { /* korruptes Gebot überspringen */ }
   }
   const gebote = geboteWithHmac.map(({ gebot }) => gebot);
@@ -159,9 +189,20 @@ export async function initAdmin(): Promise<void> {
     document.getElementById('duplikat-box')!.classList.remove('hidden');
   }
 
+  // Drei-Gebot-Modus: Status ermitteln und Gebote für Berechnung konvertieren
+  let dreiGebotStatus: ReturnType<typeof ermittleDreiGebotStatus> | null = null;
+  let geboteFuerBerechnung = alleGebote;
+  if (dreiGebotModus && allesDa && dreiGebotTriples.length > 0) {
+    dreiGebotStatus = ermittleDreiGebotStatus(blob.gesamtkosten, dreiGebotTriples);
+    const konvertiert = dreiGebotZuGebote(dreiGebotStatus, dreiGebotTriples);
+    // Standard-Slots weiterhin ergänzen
+    const standardGebote = alleGebote.filter((g) => g.istStandard);
+    geboteFuerBerechnung = [...konvertiert, ...standardGebote];
+  }
+
   // Auswertung berechnen (nur wenn Gebote vorhanden)
-  const auswertung = alleGebote.length > 0
-    ? berechneAuswertung(blob.gesamtkosten, alleGebote, blob.slots)
+  const auswertung = geboteFuerBerechnung.length > 0
+    ? berechneAuswertung(blob.gesamtkosten, geboteFuerBerechnung, blob.slots)
     : null;
 
   // Richtwert für Anzeige + "fehlt"-Zeilen
@@ -437,6 +478,15 @@ export async function initAdmin(): Promise<void> {
     const fehlbetragVorhanden = auswertung && auswertung.fehlbetrag > 0.005;
     if (fehlbetragVorhanden) {
       zeigeBanner(`Fehlbetrag: ${formatEur(auswertung!.fehlbetrag)} — Runde muss wiederholt werden.`, 'red');
+    } else if (dreiGebotStatus) {
+      const statusTexte: Record<string, string> = {
+        gruen: '🟢 Grün — Minimalgebote decken die Kosten. Auswertung mit Minimalgeboten.',
+        gelb:  '🟡 Gelb — Erst mittlere Gebote decken die Kosten. Auswertung mit mittleren Geboten.',
+        rot:   '🔴 Rot — Erst Maximalgebote decken die Kosten. Auswertung mit Maximalgeboten.',
+        kritisch: '⚫ Kritisch — Selbst Maximalgebote reichen nicht. Auswertung mit Maximalgeboten als Näherung.',
+      };
+      const bannerFarbe = dreiGebotStatus === 'gruen' ? 'green' : dreiGebotStatus === 'kritisch' ? 'red' : 'amber';
+      zeigeBanner(statusTexte[dreiGebotStatus], bannerFarbe);
     } else {
       zeigeBanner('Alle Beiträge vollständig. Auswertung abgeschlossen.', 'green');
     }

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -30,8 +30,15 @@ function setupDom() {
     <div id="panel-korrigieren" class="hidden"></div>
     <form id="gebot-form">
       <input type="radio" name="slot" value="0" checked />
-      <input type="number" id="betrag" />
-      <p id="betrag-richtwert-hinweis"></p>
+      <div id="betrag-einzel">
+        <input type="number" id="betrag" />
+        <p id="betrag-richtwert-hinweis"></p>
+      </div>
+      <div id="betrag-drei" class="hidden">
+        <input type="number" id="betrag-min" />
+        <input type="number" id="betrag-mittel" />
+        <input type="number" id="betrag-max" />
+      </div>
       <div id="duplikat-warnung" class="hidden"></div>
       <div id="duplikat-schritt1"></div>
       <div id="duplikat-schritt2" class="hidden"></div>

--- a/src/scripts/gebot.ts
+++ b/src/scripts/gebot.ts
@@ -19,6 +19,7 @@ interface TeilnehmerBlob {
   adminPubKey: string;
   hmacKey: string;
   slots: { label: string; gewichtung: number; anzahl: number; standardgebot?: number }[];
+  dreiGebotModus?: boolean;
 }
 
 export async function initGebot(): Promise<void> {
@@ -197,6 +198,11 @@ export async function initGebot(): Promise<void> {
   zustandFormular.classList.remove('hidden');
   zustandFormular.classList.add('animate-fade-in');
 
+  // Drei-Gebot-Modus: UI umschalten
+  const dreiGebotModus = blob.dreiGebotModus === true;
+  document.getElementById('betrag-einzel')!.classList.toggle('hidden', dreiGebotModus);
+  document.getElementById('betrag-drei')!.classList.toggle('hidden', !dreiGebotModus);
+
   // Korrektur-Tab einblenden falls bereits geboten
   if (blob.slots.some(s => slotBereitsGeboten(s.label))) {
     document.getElementById('tab-korrigieren')!.classList.remove('hidden');
@@ -240,9 +246,29 @@ export async function initGebot(): Promise<void> {
         10,
       );
       const selectedSlot = blob.slots[selectedIdx];
-      const betrag = parseFloat(
-        (gebotForm.querySelector('#betrag') as HTMLInputElement).value.replace(',', '.'),
-      );
+
+      let payload: object;
+      if (dreiGebotModus) {
+        const betragMin = parseFloat((document.getElementById('betrag-min') as HTMLInputElement).value.replace(',', '.'));
+        const betragMittel = parseFloat((document.getElementById('betrag-mittel') as HTMLInputElement).value.replace(',', '.'));
+        const betragMax = parseFloat((document.getElementById('betrag-max') as HTMLInputElement).value.replace(',', '.'));
+        if (!betragMin || !betragMittel || !betragMax || betragMin <= 0 || betragMittel <= 0 || betragMax <= 0) {
+          zeigeFeedback('gebot-fehler', 'Bitte alle drei Beträge ausfüllen.', 'rot');
+          return;
+        }
+        if (betragMin > betragMittel || betragMittel > betragMax) {
+          zeigeFeedback('gebot-fehler', 'Die Beträge müssen aufsteigend sein: Min ≤ Mittel ≤ Max.', 'rot');
+          return;
+        }
+        payload = { slotLabel: selectedSlot.label, gewichtung: selectedSlot.gewichtung, betragMin, betragMittel, betragMax };
+      } else {
+        const betrag = parseFloat((gebotForm.querySelector('#betrag') as HTMLInputElement).value.replace(',', '.'));
+        if (!betrag || betrag <= 0) {
+          zeigeFeedback('gebot-fehler', 'Bitte einen gültigen Betrag eingeben.', 'rot');
+          return;
+        }
+        payload = { slotLabel: selectedSlot.label, gewichtung: selectedSlot.gewichtung, betrag };
+      }
 
       let emojiId: string;
       let emojiHmac: string;
@@ -255,12 +281,7 @@ export async function initGebot(): Promise<void> {
         versuche++;
         emojiId = generiereEmojiId();
         emojiHmac = await hmac(hmacKey, emojiId);
-        encGebot = await encryptGebot(adminPubKey, JSON.stringify({
-          emojiId,
-          slotLabel: selectedSlot.label,
-          gewichtung: selectedSlot.gewichtung,
-          betrag,
-        }));
+        encGebot = await encryptGebot(adminPubKey, JSON.stringify({ emojiId, ...payload }));
         res = await fetch(`/api/runde/${rundenId}/gebot`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -500,6 +500,9 @@ export function initNeu(): void {
       const { publicKey: adminPubKey, privateKey: adminPrivKey } = await generateAdminKeyPair();
       const hmacKey = await generateHmacKey();
 
+      const dreiGebotModus =
+        (document.getElementById('drei-gebot-toggle') as HTMLInputElement)?.checked ?? false;
+
       // Blob zusammenstellen + verschlüsseln
       const blob = {
         rundeName,
@@ -507,6 +510,7 @@ export function initNeu(): void {
         adminPubKey: await exportKey(adminPubKey),
         hmacKey: await exportKey(hmacKey),
         slots: finalSlots,
+        dreiGebotModus,
       };
       const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blob));
 


### PR DESCRIPTION
## Summary

- Neue Option im `...`-Menü von `neu.astro`: Drei-Gebot-Modus per Tailwind-Toggle aktivierbar
- Teilnehmer geben Min/Mittel/Max-Gebote ab; alle drei werden ECDH-verschlüsselt in einem Payload gespeichert
- Admin-View ermittelt das niedrigste Level, das die Kosten deckt (🟢/🟡/🔴/⚫), und berechnet den Richtwert mit den passenden Geboten
- Kein Breaking Change: bestehende Runden ohne Drei-Gebot-Modus funktionieren unverändert

## Test plan

- [ ] Runde ohne Drei-Gebot-Modus erstellen → normales Einzelfeld im Teilnehmer-View
- [ ] Runde mit Drei-Gebot-Modus erstellen → drei Felder (Min/Mittel/Max) im Teilnehmer-View
- [ ] Validierung: Min > Mittel oder Mittel > Max gibt Fehlermeldung
- [ ] Admin-View zeigt korrekten Status-Badge je nach Summen
- [ ] Vitest-Suite grün (`npm run test`)

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)