### PR TITLE
fix: Code Review Findings aus PR #106 (Drei-Gebot-Modus)

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -17,7 +17,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           <label class="flex items-center justify-between px-4 py-2 cursor-pointer hover:bg-surface-elevated transition-colors select-none">
             <span class="text-sm text-fg-secondary">Drei-Gebot-Modus</span>
             <input type="checkbox" id="drei-gebot-toggle" class="sr-only peer" />
-            <div class="w-9 h-5 bg-gray-300 rounded-full peer-checked:bg-brand relative shrink-0
+            <div class="w-9 h-5 bg-border-strong rounded-full peer-checked:bg-brand relative shrink-0
                         after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4
                         after:bg-white after:rounded-full after:transition-all
                         peer-checked:after:translate-x-4"></div>

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -174,8 +174,8 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
           <p id="korrektur-slot-hinweis" class="text-xs mt-1"></p>
         </div>
 
-        <!-- Betrag -->
-        <div>
+        <!-- Betrag (Einzel-Modus) -->
+        <div id="korrektur-betrag-einzel">
           <label for="korrektur-betrag" class="block text-sm font-medium text-fg-secondary mb-1">
             Neues Gebot (€)
           </label>
@@ -183,13 +183,55 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
             type="number"
             id="korrektur-betrag"
             name="betrag"
-            required
             min="0.01"
             step="0.01"
             placeholder="z.B. 80"
             class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
           <p id="korrektur-richtwert-hinweis" class="text-xs text-fg-faint mt-1"></p>
+        </div>
+
+        <!-- Betrag (Drei-Gebot-Modus, hidden by default) -->
+        <div id="korrektur-betrag-drei" class="hidden space-y-3">
+          <div>
+            <label for="korrektur-betrag-min" class="block text-sm font-medium text-fg-secondary mb-1">
+              Neues Minimalgebot (€)
+            </label>
+            <input
+              type="number"
+              id="korrektur-betrag-min"
+              min="0.01"
+              step="0.01"
+              placeholder="z.B. 60"
+              class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+            />
+          </div>
+          <div>
+            <label for="korrektur-betrag-mittel" class="block text-sm font-medium text-fg-secondary mb-1">
+              Neues mittleres Gebot (€)
+            </label>
+            <input
+              type="number"
+              id="korrektur-betrag-mittel"
+              min="0.01"
+              step="0.01"
+              placeholder="z.B. 80"
+              class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+            />
+          </div>
+          <div>
+            <label for="korrektur-betrag-max" class="block text-sm font-medium text-fg-secondary mb-1">
+              Neues Maximalgebot (€)
+            </label>
+            <input
+              type="number"
+              id="korrektur-betrag-max"
+              min="0.01"
+              step="0.01"
+              placeholder="z.B. 110"
+              class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+            />
+          </div>
         </div>
 
         <!-- Fehler -->

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -128,7 +128,7 @@ export async function initAdmin(): Promise<void> {
         });
       }
       // Für Anzeige und Vollständigkeits-Check immer als Gebot (betrag irrelevant bis Auswertung)
-      geboteWithHmac.push({ emojiHmac, gebot: { emojiId: raw.emojiId, slotLabel: raw.slotLabel, gewichtung: raw.gewichtung, betrag: raw.betrag ?? 0 } });
+      geboteWithHmac.push({ emojiHmac, gebot: { emojiId: raw.emojiId, slotLabel: raw.slotLabel, gewichtung: raw.gewichtung, betrag: raw.betrag ?? (raw.betragMittel ?? 0) } });
     } catch { /* korruptes Gebot überspringen */ }
   }
   const gebote = geboteWithHmac.map(({ gebot }) => gebot);

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -53,8 +53,15 @@ function setupDom() {
     <form id="korrektur-form">
       <input type="radio" name="slot-korrektur" value="0" checked />
       <input id="korrektur-emoji" type="text" />
-      <input id="korrektur-betrag" type="number" />
-      <p id="korrektur-richtwert-hinweis"></p>
+      <div id="korrektur-betrag-einzel">
+        <input id="korrektur-betrag" type="number" />
+        <p id="korrektur-richtwert-hinweis"></p>
+      </div>
+      <div id="korrektur-betrag-drei" class="hidden">
+        <input type="number" id="korrektur-betrag-min" />
+        <input type="number" id="korrektur-betrag-mittel" />
+        <input type="number" id="korrektur-betrag-max" />
+      </div>
       <p id="korrektur-slot-hinweis"></p>
       <button type="submit" id="korrektur-btn">Gebot ersetzen</button>
     </form>
@@ -68,6 +75,7 @@ function setupDom() {
 async function createEncryptedBlob(overrides?: Partial<{
   rundeName: string;
   gesamtkosten: number;
+  dreiGebotModus: boolean;
 }>) {
   const partKey = await generatePartKey();
   const { publicKey: adminPubKey } = await generateAdminKeyPair();
@@ -83,6 +91,7 @@ async function createEncryptedBlob(overrides?: Partial<{
     adminPubKey: adminPubKeyB64,
     hmacKey: hmacKeyB64,
     slots: [{ label: 'Erwachsen', gewichtung: 1.0, anzahl: 1 }],
+    ...(overrides?.dreiGebotModus !== undefined ? { dreiGebotModus: overrides.dreiGebotModus } : {}),
   };
   const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blobData));
   return { partKeyB64, encTeilnehmerBlob };
@@ -221,5 +230,79 @@ describe('initGebot', () => {
     await initGebot();
 
     expect(history.replaceState).toHaveBeenCalledWith(null, '', '/runde/abc12345');
+  });
+
+  it('schaltet auf Drei-Felder-UI um wenn dreiGebotModus aktiv ist', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob({ dreiGebotModus: true });
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
+    }));
+
+    await initGebot();
+
+    expect(document.getElementById('betrag-einzel')!.classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('betrag-drei')!.classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('korrektur-betrag-einzel')!.classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('korrektur-betrag-drei')!.classList.contains('hidden')).toBe(false);
+  });
+
+  it('reicht Drei-Gebot erfolgreich ein', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob({ dreiGebotModus: true });
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ encTeilnehmerBlob, gebote: [] }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ success: true }) });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await initGebot();
+
+    (document.getElementById('betrag-min') as HTMLInputElement).value = '60';
+    (document.getElementById('betrag-mittel') as HTMLInputElement).value = '80';
+    (document.getElementById('betrag-max') as HTMLInputElement).value = '110';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('zustand-bestaetigung')!.classList.contains('hidden')).toBe(false));
+    const gebotCall = mockFetch.mock.calls[1];
+    const body = JSON.parse(gebotCall[1].body);
+    expect(body.encGebot).toBeTruthy();
+  });
+
+  it('zeigt Fehler bei fehlenden Drei-Gebot-Feldern', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob({ dreiGebotModus: true });
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
+    }));
+
+    await initGebot();
+
+    // Felder leer lassen → submit
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('gebot-fehler')!.classList.contains('hidden')).toBe(false));
+  });
+
+  it('zeigt Fehler wenn Min > Mittel im Drei-Gebot-Modus', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob({ dreiGebotModus: true });
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
+    }));
+
+    await initGebot();
+
+    (document.getElementById('betrag-min') as HTMLInputElement).value = '100';
+    (document.getElementById('betrag-mittel') as HTMLInputElement).value = '50';
+    (document.getElementById('betrag-max') as HTMLInputElement).value = '120';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => {
+      const el = document.getElementById('gebot-fehler')!;
+      return !el.classList.contains('hidden') && el.textContent?.includes('aufsteigend');
+    });
   });
 });

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -91,7 +91,7 @@ async function createEncryptedBlob(overrides?: Partial<{
     adminPubKey: adminPubKeyB64,
     hmacKey: hmacKeyB64,
     slots: [{ label: 'Erwachsen', gewichtung: 1.0, anzahl: 1 }],
-    ...(overrides?.dreiGebotModus !== undefined ? { dreiGebotModus: overrides.dreiGebotModus } : {}),
+    dreiGebotModus: overrides?.dreiGebotModus,
   };
   const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blobData));
   return { partKeyB64, encTeilnehmerBlob };
@@ -302,6 +302,51 @@ describe('initGebot', () => {
 
     await vi.waitFor(() => {
       const el = document.getElementById('gebot-fehler')!;
+      return !el.classList.contains('hidden') && el.textContent?.includes('aufsteigend');
+    });
+  });
+
+  it('korrigiert Drei-Gebot erfolgreich', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob({ dreiGebotModus: true });
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ encTeilnehmerBlob, gebote: [] }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ success: true }) });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await initGebot();
+
+    (document.getElementById('korrektur-emoji') as HTMLInputElement).value = '🦊🌙⭐';
+    (document.getElementById('korrektur-betrag-min') as HTMLInputElement).value = '50';
+    (document.getElementById('korrektur-betrag-mittel') as HTMLInputElement).value = '80';
+    (document.getElementById('korrektur-betrag-max') as HTMLInputElement).value = '120';
+    document.getElementById('korrektur-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('zustand-bestaetigung')!.classList.contains('hidden')).toBe(false));
+    const korrekturCall = mockFetch.mock.calls[1];
+    const body = JSON.parse(korrekturCall[1].body);
+    expect(body.encGebot).toBeTruthy();
+    expect(body.isCorrection).toBe(true);
+  });
+
+  it('zeigt Korrektur-Fehler wenn Drei-Gebot-Beträge nicht aufsteigend', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob({ dreiGebotModus: true });
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
+    }));
+
+    await initGebot();
+
+    (document.getElementById('korrektur-emoji') as HTMLInputElement).value = '🦊🌙⭐';
+    (document.getElementById('korrektur-betrag-min') as HTMLInputElement).value = '90';
+    (document.getElementById('korrektur-betrag-mittel') as HTMLInputElement).value = '50';
+    (document.getElementById('korrektur-betrag-max') as HTMLInputElement).value = '120';
+    document.getElementById('korrektur-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => {
+      const el = document.getElementById('korrektur-fehler')!;
       return !el.classList.contains('hidden') && el.textContent?.includes('aufsteigend');
     });
   });

--- a/src/scripts/gebot.ts
+++ b/src/scripts/gebot.ts
@@ -202,6 +202,8 @@ export async function initGebot(): Promise<void> {
   const dreiGebotModus = blob.dreiGebotModus === true;
   document.getElementById('betrag-einzel')!.classList.toggle('hidden', dreiGebotModus);
   document.getElementById('betrag-drei')!.classList.toggle('hidden', !dreiGebotModus);
+  document.getElementById('korrektur-betrag-einzel')!.classList.toggle('hidden', dreiGebotModus);
+  document.getElementById('korrektur-betrag-drei')!.classList.toggle('hidden', !dreiGebotModus);
 
   // Korrektur-Tab einblenden falls bereits geboten
   if (blob.slots.some(s => slotBereitsGeboten(s.label))) {
@@ -252,7 +254,7 @@ export async function initGebot(): Promise<void> {
         const betragMin = parseFloat((document.getElementById('betrag-min') as HTMLInputElement).value.replace(',', '.'));
         const betragMittel = parseFloat((document.getElementById('betrag-mittel') as HTMLInputElement).value.replace(',', '.'));
         const betragMax = parseFloat((document.getElementById('betrag-max') as HTMLInputElement).value.replace(',', '.'));
-        if (!betragMin || !betragMittel || !betragMax || betragMin <= 0 || betragMittel <= 0 || betragMax <= 0) {
+        if (isNaN(betragMin) || isNaN(betragMittel) || isNaN(betragMax) || betragMin <= 0 || betragMittel <= 0 || betragMax <= 0) {
           zeigeFeedback('gebot-fehler', 'Bitte alle drei Beträge ausfüllen.', 'rot');
           return;
         }
@@ -381,7 +383,7 @@ export async function initGebot(): Promise<void> {
       });
       korrekturSlotHinweis.textContent = `Slot aus deinem ursprünglichen Gebot: ${bekannterSlot}`;
       korrekturSlotHinweis.className = 'text-xs text-brand mt-1';
-      betragFeldAktualisieren(slotIdx, 'korrektur-betrag', 'korrektur-richtwert-hinweis');
+      if (!dreiGebotModus) betragFeldAktualisieren(slotIdx, 'korrektur-betrag', 'korrektur-richtwert-hinweis');
     } else {
       radios.forEach((r) => { r.disabled = false; });
       if (emojiId) {
@@ -409,17 +411,32 @@ export async function initGebot(): Promise<void> {
         10,
       );
       const selectedSlot = blob.slots[selectedIdx];
-      const betrag = parseFloat(
-        (document.getElementById('korrektur-betrag') as HTMLInputElement).value.replace(',', '.'),
-      );
+
+      let korrekturPayload: object;
+      if (dreiGebotModus) {
+        const betragMin = parseFloat((document.getElementById('korrektur-betrag-min') as HTMLInputElement).value.replace(',', '.'));
+        const betragMittel = parseFloat((document.getElementById('korrektur-betrag-mittel') as HTMLInputElement).value.replace(',', '.'));
+        const betragMax = parseFloat((document.getElementById('korrektur-betrag-max') as HTMLInputElement).value.replace(',', '.'));
+        if (isNaN(betragMin) || isNaN(betragMittel) || isNaN(betragMax) || betragMin <= 0 || betragMittel <= 0 || betragMax <= 0) {
+          zeigeFeedback('korrektur-fehler', 'Bitte alle drei Beträge ausfüllen.', 'rot');
+          return;
+        }
+        if (betragMin > betragMittel || betragMittel > betragMax) {
+          zeigeFeedback('korrektur-fehler', 'Die Beträge müssen aufsteigend sein: Min ≤ Mittel ≤ Max.', 'rot');
+          return;
+        }
+        korrekturPayload = { slotLabel: selectedSlot.label, gewichtung: selectedSlot.gewichtung, betragMin, betragMittel, betragMax };
+      } else {
+        const betrag = parseFloat((document.getElementById('korrektur-betrag') as HTMLInputElement).value.replace(',', '.'));
+        if (isNaN(betrag) || betrag <= 0) {
+          zeigeFeedback('korrektur-fehler', 'Bitte einen gültigen Betrag eingeben.', 'rot');
+          return;
+        }
+        korrekturPayload = { slotLabel: selectedSlot.label, gewichtung: selectedSlot.gewichtung, betrag };
+      }
 
       const emojiHmac = await hmac(hmacKey, emojiId);
-      const encGebot = await encryptGebot(adminPubKey, JSON.stringify({
-        emojiId,
-        slotLabel: selectedSlot.label,
-        gewichtung: selectedSlot.gewichtung,
-        betrag,
-      }));
+      const encGebot = await encryptGebot(adminPubKey, JSON.stringify({ emojiId, ...korrekturPayload }));
 
       const res = await fetch(`/api/runde/${rundenId}/gebot`, {
         method: 'POST',


### PR DESCRIPTION
## Summary

Behebt alle 5 Findings aus dem Review von PR #106:

- **`gray-300` → `bg-border-strong`** auf dem Toggle in `neu.astro` (Tailwind-Konvention: keine hartkodierte Farbe)
- **`isNaN`-Validierung** statt redundantem `!betragMin` in `gebot.ts`
- **Korrektur-Tab im Drei-Gebot-Modus** – fehlte komplett; jetzt 3 Korrektur-Felder + Validierung + verschlüsselter Payload analog zur Ersteinreichung
- **Robusterer Fallback-Betrag** in `admin.ts`: `betragMittel` statt `0` wenn drei-gebot-Payload ohne `betrag`
- **4 neue Tests** für Drei-Gebot-UI-Umschaltung, Submission, Validierung (fehlende Felder, Min > Mittel)

## Test plan

- [ ] `npm run test` — 180 Tests grün
- [ ] Runde mit Drei-Gebot-Modus erstellen, Gebot korrigieren → 3 Korrektur-Felder sichtbar
- [ ] Korrektur mit Min > Mittel → Fehlermeldung

Follows up on #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)