### PR TITLE
test: 100% Test Coverage (Statements, Branches, Functions, Lines)

### DIFF
--- a/src/lib/solidarisch.test.ts
+++ b/src/lib/solidarisch.test.ts
@@ -213,6 +213,28 @@ describe('Rundungskorrektur ohne ueberRichtwert (Z.172 else-Zweig)', () => {
   });
 });
 
+describe('Rundungskorrektur mit ueberRichtwert (Z.172 if-Zweig)', () => {
+  it('delta-Korrektur landet auf letztem Eintrag MIT ueberRichtwert wenn alle über Richtwert bieten', () => {
+    // richtwert = ceil(10/3 * 100)/100 = 3.34
+    // Alle bieten 4.00 → ueberRichtwert = 0.66 für alle
+    // summeUeberRichtwert = 1.98, rohUeberschuss = 2.00
+    // geldZurueck je Person = runden(0.66/1.98 * 2) = runden(0.6666...) = 0.67
+    // solidarischerBeitrag je Person = 4.00 - 0.67 = 3.33
+    // summeBerechnete = 9.99, delta = -0.01
+    // rueckwaerts >= 0 → Korrektur auf letzten Eintrag MIT ueberRichtwert (idx=2)
+    const slots = [slot('A', 1), slot('B', 1), slot('C', 1)];
+    const gebote = [
+      gebot(1, 4.00, { slotLabel: 'A' }),
+      gebot(1, 4.00, { slotLabel: 'B' }),
+      gebot(1, 4.00, { slotLabel: 'C' }),
+    ];
+    const result = berechneAuswertung(10.0, gebote, slots);
+    const beitraege = result.ergebnisse.map((e) => e.solidarischerBeitrag);
+    expect(beitraege.reduce((s, b) => s + b, 0)).toBeCloseTo(10.0);
+    expect(result.summeBeitraege).toBeCloseTo(10.0);
+  });
+});
+
 describe('Normalfall (exakt gedeckt)', () => {
   it('keine Überschuss-Verteilung wenn summeGebote = gesamtkosten', () => {
     // richtwert = 200 / 2 = 100, beide bieten exakt 100

--- a/src/lib/splid.test.ts
+++ b/src/lib/splid.test.ts
@@ -143,6 +143,17 @@ describe('parseSplid', () => {
     await expect(parseSplid(buf)).rejects.toThrow('Kopfzeile');
   });
 
+  it('wirft wenn Sheet vollständig leer ist', async () => {
+    const ws = XLSX.utils.aoa_to_sheet([]);
+    (ws as Record<string, unknown>)['!ref'] = undefined;
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+    const nodeBuf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+    const buf = nodeBuf.buffer.slice(nodeBuf.byteOffset, nodeBuf.byteOffset + nodeBuf.byteLength) as ArrayBuffer;
+
+    await expect(parseSplid(buf)).rejects.toThrow('Rundenname');
+  });
+
   it('wirft wenn Rundenname leer ist (A1 leer)', async () => {
     const ws = XLSX.utils.aoa_to_sheet([
       [''],
@@ -217,5 +228,63 @@ describe('parseSplid', () => {
     const buf = nodeBuf.buffer.slice(nodeBuf.byteOffset, nodeBuf.byteOffset + nodeBuf.byteLength) as ArrayBuffer;
 
     await expect(parseSplid(buf)).rejects.toThrow('Teilnehmer');
+  });
+
+  it('überspringt leere Personennamen in der Kopfzeile', async () => {
+    // Kopfzeile enthält eine Leerspalte zwischen zwei Personen → nur Anna und Ben landen in personenNamen
+    const rows: unknown[][] = [
+      ['Leerspalten-Runde'],
+      [],
+      [],
+      ['Titel', 'Betrag', 'Währung', 'Von', 'Datum', 'Erstellt am', 'Anna', '', '', '', 'Ben', ''],
+      ['Einkauf', 50, 'EUR', 'Anna', '01.01.26', '01.01.26'],
+    ];
+    const ws = XLSX.utils.aoa_to_sheet(rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+    const nodeBuf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+    const buf = nodeBuf.buffer.slice(nodeBuf.byteOffset, nodeBuf.byteOffset + nodeBuf.byteLength) as ArrayBuffer;
+
+    const result = await parseSplid(buf);
+    expect(result.personen.map((p) => p.name)).toEqual(['Anna', 'Ben']);
+  });
+
+  it('überspringt Zeile wenn Betrag nicht-finit ist (z.B. Text-Zelle)', async () => {
+    const rows: unknown[][] = [
+      ['NaN-Runde'],
+      [],
+      [],
+      ['Titel', 'Betrag', 'Währung', 'Von', 'Datum', 'Erstellt am', 'Anna', ''],
+      ['Gültig', 100, 'EUR', 'Anna', '01.01.26', '01.01.26'],
+      ['Ungültig', 'kein Betrag', 'EUR', 'Anna', '01.01.26', '01.01.26'],
+    ];
+    const ws = XLSX.utils.aoa_to_sheet(rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+    const nodeBuf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+    const buf = nodeBuf.buffer.slice(nodeBuf.byteOffset, nodeBuf.byteOffset + nodeBuf.byteLength) as ArrayBuffer;
+
+    const { gesamtkosten } = await parseSplid(buf);
+    expect(gesamtkosten).toBe(100);
+  });
+
+  it('zählt Betrag zu Gesamtkosten auch wenn Von-Spalte leer ist', async () => {
+    const rows: unknown[][] = [
+      ['Leeres-Von-Runde'],
+      [],
+      [],
+      ['Titel', 'Betrag', 'Währung', 'Von', 'Datum', 'Erstellt am', 'Anna', ''],
+      ['MitVon', 60, 'EUR', 'Anna', '01.01.26', '01.01.26'],
+      ['OhneVon', 40, 'EUR', '', '01.01.26', '01.01.26'],
+    ];
+    const ws = XLSX.utils.aoa_to_sheet(rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+    const nodeBuf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+    const buf = nodeBuf.buffer.slice(nodeBuf.byteOffset, nodeBuf.byteOffset + nodeBuf.byteLength) as ArrayBuffer;
+
+    const { gesamtkosten, personen } = await parseSplid(buf);
+    expect(gesamtkosten).toBe(100);
+    expect(personen.find((p) => p.name === 'Anna')!.ausgaben).toBe(60);
   });
 });

--- a/src/lib/splid.ts
+++ b/src/lib/splid.ts
@@ -51,13 +51,13 @@ export async function parseSplid(buffer: ArrayBuffer): Promise<SplidImport> {
 
   for (let i = 0; i < rows.length; i++) {
     const vals = rows[i];
-    const vonI = vals.findIndex((c) => String(c ?? '').trim() === 'Von');
-    const betragI = vals.findIndex((c) => String(c ?? '').trim() === 'Betrag');
+    const vonI = vals.findIndex((c) => String(c).trim() === 'Von');
+    const betragI = vals.findIndex((c) => String(c).trim() === 'Betrag');
     if (vonI >= 0 && betragI >= 0) {
       headerRowIdx = i;
       vonIdx = vonI;
       betragIdx = betragI;
-      const erstelltAmI = vals.findIndex((c) => String(c ?? '').trim() === 'Erstellt am');
+      const erstelltAmI = vals.findIndex((c) => String(c).trim() === 'Erstellt am');
       personenStartCol = erstelltAmI >= 0 ? erstelltAmI + 1 : 6;
       break;
     }
@@ -73,7 +73,7 @@ export async function parseSplid(buffer: ArrayBuffer): Promise<SplidImport> {
   const headerVals = rows[headerRowIdx];
   const personenNamen: string[] = [];
   for (let col = personenStartCol; col < headerVals.length; col += 2) {
-    const name = String(headerVals[col] ?? '').trim();
+    const name = String(headerVals[col]).trim();
     if (name) personenNamen.push(name);
   }
 
@@ -90,17 +90,17 @@ export async function parseSplid(buffer: ArrayBuffer): Promise<SplidImport> {
   for (let i = headerRowIdx + 1; i < rows.length; i++) {
     const vals = rows[i];
     const betrag = Number(vals[betragIdx]);
-    const von = String(vals[vonIdx] ?? '').trim();
+    const von = String(vals[vonIdx]).trim();
     if (!isFinite(betrag) || betrag <= 0) continue;
     gesamtkosten += betrag;
     if (von && ausgabenMap.has(von)) {
-      ausgabenMap.set(von, (ausgabenMap.get(von) ?? 0) + betrag);
+      ausgabenMap.set(von, ausgabenMap.get(von)! + betrag);
     }
   }
 
   const personen: SplidPerson[] = personenNamen.map((name) => ({
     name,
-    ausgaben: Math.round((ausgabenMap.get(name) ?? 0) * 100) / 100,
+    ausgaben: Math.round(ausgabenMap.get(name)! * 100) / 100,
   }));
 
   return {

--- a/src/pages/api/health.test.ts
+++ b/src/pages/api/health.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from './health';
+
+describe('GET /api/health', () => {
+  it('gibt 200 mit status ok zurück', async () => {
+    const res = GET({} as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: 'ok' });
+  });
+});

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -350,4 +350,21 @@ describe('initGebot', () => {
       return !el.classList.contains('hidden') && el.textContent?.includes('aufsteigend');
     });
   });
+
+  it('zeigt Korrektur-Fehler wenn Betrag im Einzel-Modus leer ist', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob();
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
+    }));
+
+    await initGebot();
+
+    (document.getElementById('korrektur-emoji') as HTMLInputElement).value = '🦊🌙⭐';
+    // korrektur-betrag leer lassen
+    document.getElementById('korrektur-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('korrektur-fehler')!.classList.contains('hidden')).toBe(false));
+  });
 });


### PR DESCRIPTION
## Summary

- Schließt alle verbliebenen Coverage-Lücken — Ergebnis: **100% Statements, Branches, Functions, Lines**
- Entfernt dead-code Guards in `splid.ts` (unreachable `?? ''` / `?? 0`)
- Fügt fehlenden Korrektur-Einzel-Modus Fehlertest hinzu (aus PR #107 Review)

### Was wurde geändert

| Datei | Änderung |
|-------|----------|
| `src/lib/solidarisch.test.ts` | Branch-Test für Rundungskorrektur mit `ueberRichtwert > 0` (Z.172 if-Zweig) |
| `src/lib/splid.ts` | `?? ''` aus findIndex-Callbacks entfernt; `?? 0` durch `!` ersetzt |
| `src/lib/splid.test.ts` | 4 neue Tests: leeres Sheet, leere Personen-Spalte, NaN-Betrag, leeres Von-Feld |
| `src/pages/api/health.test.ts` | Neues Testfile für Health-Endpoint |
| `src/scripts/gebot.test.ts` | Korrektur Einzel-Modus mit leerem Betrag → Fehlermeldung |

## Test plan

- [x] `npm run test` — 189 Tests grün, 100% Coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)