### PR TITLE
feat: Basis-Import für CSV/XLSX mit automatischer Format-Erkennung

### DIFF
--- a/public/beispiel-basis-import.csv
+++ b/public/beispiel-basis-import.csv
@@ -1,0 +1,5 @@
+Name,Ausgaben,Gewichtung,Anzahl,Standardgebot
+Erwachsene,180.00,1.0,3,
+Ermäßigt,60.00,0.75,1,
+Kinder,45.00,0.5,2,30
+Beitrag,120.00,1.0,1,

--- a/src/lib/basis-import.test.ts
+++ b/src/lib/basis-import.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import * as XLSX from 'xlsx';
+import { parseBasisImport, detectAndParse } from './basis-import';
+
+// ---------------------------------------------------------------------------
+// Hilfsfunktionen zum Erstellen von Test-Buffern
+// ---------------------------------------------------------------------------
+
+function makeXlsxBuffer(rows: unknown[][], sheetName = 'Tabelle1'): ArrayBuffer {
+  const ws = XLSX.utils.aoa_to_sheet(rows);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, sheetName);
+  const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' }) as ArrayBuffer;
+  return buf;
+}
+
+function makeCsvBuffer(rows: unknown[][]): ArrayBuffer {
+  const csv = rows.map((r) => r.join(',')).join('\n');
+  return new TextEncoder().encode(csv).buffer;
+}
+
+const BASIS_HEADER = ['Name', 'Ausgaben', 'Gewichtung', 'Anzahl'];
+const BASIS_HEADER_MIT_STD = [...BASIS_HEADER, 'Standardgebot'];
+
+// ---------------------------------------------------------------------------
+// parseBasisImport
+// ---------------------------------------------------------------------------
+
+describe('parseBasisImport', () => {
+  it('parst XLSX korrekt (alle Pflichtfelder)', () => {
+    const buf = makeXlsxBuffer([
+      BASIS_HEADER,
+      ['Erwachsene', 180, 1.0, 3],
+      ['Kinder', 60, 0.5, 2],
+    ]);
+    const result = parseBasisImport(buf);
+    expect(result.slots).toHaveLength(2);
+    expect(result.slots[0]).toEqual({ name: 'Erwachsene', ausgaben: 180, gewichtung: 1, anzahl: 3 });
+    expect(result.slots[1]).toEqual({ name: 'Kinder', ausgaben: 60, gewichtung: 0.5, anzahl: 2 });
+    expect(result.gesamtkosten).toBe(240);
+  });
+
+  it('parst CSV korrekt', () => {
+    const buf = makeCsvBuffer([
+      BASIS_HEADER,
+      ['Erwachsene', '180.00', '1.0', '3'],
+    ]);
+    const result = parseBasisImport(buf);
+    expect(result.slots).toHaveLength(1);
+    expect(result.slots[0].name).toBe('Erwachsene');
+    expect(result.slots[0].ausgaben).toBe(180);
+  });
+
+  it('parst optionales Standardgebot', () => {
+    const buf = makeXlsxBuffer([
+      BASIS_HEADER_MIT_STD,
+      ['Erwachsene', 180, 1.0, 3, ''],
+      ['Kinder', 60, 0.5, 2, 30],
+    ]);
+    const result = parseBasisImport(buf);
+    expect(result.slots[0].standardgebot).toBeUndefined();
+    expect(result.slots[1].standardgebot).toBe(30);
+  });
+
+  it('behandelt Spaltenköpfe case-insensitiv', () => {
+    const buf = makeXlsxBuffer([
+      ['NAME', 'AUSGABEN', 'GEWICHTUNG', 'ANZAHL'],
+      ['Test', 100, 1.0, 1],
+    ]);
+    const result = parseBasisImport(buf);
+    expect(result.slots).toHaveLength(1);
+    expect(result.slots[0].name).toBe('Test');
+  });
+
+  it('wirft Fehler bei fehlender Pflichtspalte', () => {
+    const buf = makeXlsxBuffer([
+      ['Name', 'Ausgaben', 'Gewichtung'], // Anzahl fehlt
+      ['Test', 100, 1.0],
+    ]);
+    expect(() => parseBasisImport(buf)).toThrow('Pflichtspalte „Anzahl" fehlt');
+  });
+
+  it('überspringt Zeilen mit leerem Name', () => {
+    const buf = makeXlsxBuffer([
+      BASIS_HEADER,
+      ['', 100, 1.0, 1],
+      ['Gültig', 50, 1.0, 1],
+    ]);
+    const result = parseBasisImport(buf);
+    expect(result.slots).toHaveLength(1);
+    expect(result.slots[0].name).toBe('Gültig');
+  });
+
+  it('überspringt Zeilen mit nicht-numerischem Betrag', () => {
+    const buf = makeXlsxBuffer([
+      BASIS_HEADER,
+      ['Test', 'abc', 1.0, 1],
+      ['Gültig', 50, 1.0, 1],
+    ]);
+    const result = parseBasisImport(buf);
+    expect(result.slots).toHaveLength(1);
+  });
+
+  it('überspringt Zeilen mit nicht-numerischer Gewichtung', () => {
+    const buf = makeXlsxBuffer([
+      BASIS_HEADER,
+      ['Test', 100, 'xyz', 1],
+      ['Gültig', 50, 1.0, 1],
+    ]);
+    const result = parseBasisImport(buf);
+    expect(result.slots).toHaveLength(1);
+  });
+
+  it('summiert gesamtkosten korrekt aus Ausgaben', () => {
+    const buf = makeXlsxBuffer([
+      BASIS_HEADER,
+      ['A', 100.50, 1.0, 1],
+      ['B', 49.50, 1.0, 1],
+    ]);
+    const result = parseBasisImport(buf);
+    expect(result.gesamtkosten).toBe(150);
+  });
+
+  it('wirft Fehler wenn keine gültigen Zeilen vorhanden', () => {
+    const buf = makeXlsxBuffer([
+      BASIS_HEADER,
+      ['', 100, 1.0, 1], // leer → übersprungen
+    ]);
+    expect(() => parseBasisImport(buf)).toThrow('Keine gültigen Zeilen');
+  });
+
+  it('wirft Fehler bei leerer Tabelle (nur Header)', () => {
+    const buf = makeXlsxBuffer([BASIS_HEADER]);
+    expect(() => parseBasisImport(buf)).toThrow('keine Datenzeilen');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAndParse
+// ---------------------------------------------------------------------------
+
+describe('detectAndParse', () => {
+  it('routet .csv zu Basis-Import', async () => {
+    const buf = makeCsvBuffer([
+      BASIS_HEADER,
+      ['Erwachsene', '180', '1.0', '2'],
+    ]);
+    const result = await detectAndParse(buf, 'kosten.csv');
+    expect(result.format).toBe('basis');
+    expect(result.slots).toHaveLength(1);
+  });
+
+  it('routet .xlsx ohne Zusammenfassung-Sheet zu Basis-Import', async () => {
+    const buf = makeXlsxBuffer([
+      BASIS_HEADER,
+      ['Erwachsene', 180, 1.0, 3],
+    ], 'Tabelle1');
+    const result = await detectAndParse(buf, 'kosten.xlsx');
+    expect(result.format).toBe('basis');
+  });
+
+  it('routet .xlsx mit Zusammenfassung-Sheet zu Splid', async () => {
+    const ws = XLSX.utils.aoa_to_sheet([
+      ['Meine Runde'],
+      [],
+      ['Von', 'An', 'Betrag', 'Erstellt am', 'Datum', 'Beschreibung', 'Alice', '', 'Bob', ''],
+      ['Alice', 'Bob', 100, '2024-01-01', '', '', 100, 0, 0, 0],
+    ]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+    const buf: ArrayBuffer = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+    const result = await detectAndParse(buf, 'splid.xlsx');
+    expect(result.format).toBe('splid');
+    if (result.format === 'splid') {
+      expect(result.rundenname).toBe('Meine Runde');
+      expect(result.slots[0].gewichtung).toBe(1);
+      expect(result.slots[0].anzahl).toBe(1);
+    }
+  });
+
+  it('wirft Fehler bei unbekanntem Dateiformat', async () => {
+    const buf = new ArrayBuffer(0);
+    await expect(detectAndParse(buf, 'datei.pdf')).rejects.toThrow('Unbekanntes Dateiformat');
+  });
+
+  it('gibt bei Splid-Import slots mit gewichtung=1 und anzahl=1 zurück', async () => {
+    const ws = XLSX.utils.aoa_to_sheet([
+      ['Gruppenreise'],
+      [],
+      ['Von', 'An', 'Betrag', 'Erstellt am', 'Datum', 'Beschreibung', 'Alice', '', 'Bob', ''],
+      ['Alice', 'Bob', 50, '', '', '', 50, 0, 0, 0],
+      ['Bob', 'Alice', 30, '', '', '', 0, 0, 30, 0],
+    ]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Zusammenfassung');
+    const buf: ArrayBuffer = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+    const result = await detectAndParse(buf, 'trip.xlsx');
+    expect(result.format).toBe('splid');
+    if (result.format === 'splid') {
+      result.slots.forEach((s) => {
+        expect(s.gewichtung).toBe(1);
+        expect(s.anzahl).toBe(1);
+      });
+    }
+  });
+});

--- a/src/lib/basis-import.ts
+++ b/src/lib/basis-import.ts
@@ -1,0 +1,118 @@
+import * as XLSX from 'xlsx';
+import { parseSplid } from './splid';
+import type { SplidImport } from './splid';
+
+export interface ImportSlot {
+  name: string;
+  ausgaben: number;
+  gewichtung: number;
+  anzahl: number;
+  standardgebot?: number;
+}
+
+export type DetectedImport =
+  | { format: 'splid'; rundenname: string; gesamtkosten: number; slots: ImportSlot[] }
+  | { format: 'basis'; gesamtkosten: number; slots: ImportSlot[] };
+
+const PFLICHTFELDER = ['name', 'ausgaben', 'gewichtung', 'anzahl'] as const;
+
+function normalisiereKopf(val: unknown): string {
+  return String(val).trim().toLowerCase();
+}
+
+export function parseBasisImport(buffer: ArrayBuffer): { gesamtkosten: number; slots: ImportSlot[] } {
+  const wb = XLSX.read(new Uint8Array(buffer), { type: 'array' });
+  const ws = wb.Sheets[wb.SheetNames[0]];
+  if (!ws) throw new Error('Die Datei enthält keine Tabelle.');
+
+  const rows: unknown[][] = XLSX.utils.sheet_to_json(ws, { header: 1, defval: '' });
+  if (rows.length < 2) throw new Error('Die Tabelle enthält keine Datenzeilen.');
+
+  const headerRow = rows[0].map(normalisiereKopf);
+
+  for (const pflicht of PFLICHTFELDER) {
+    if (!headerRow.includes(pflicht)) {
+      const original = pflicht.charAt(0).toUpperCase() + pflicht.slice(1);
+      throw new Error(`Pflichtspalte „${original}" fehlt in der Tabelle.`);
+    }
+  }
+
+  const idx = {
+    name: headerRow.indexOf('name'),
+    ausgaben: headerRow.indexOf('ausgaben'),
+    gewichtung: headerRow.indexOf('gewichtung'),
+    anzahl: headerRow.indexOf('anzahl'),
+    standardgebot: headerRow.indexOf('standardgebot'),
+  };
+
+  const slots: ImportSlot[] = [];
+
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    const name = String(row[idx.name] ?? '').trim();
+    if (!name) continue;
+
+    const ausgaben = Number(row[idx.ausgaben]);
+    if (!isFinite(ausgaben)) continue;
+
+    const gewichtung = Number(row[idx.gewichtung]);
+    if (!isFinite(gewichtung) || gewichtung <= 0) continue;
+
+    const anzahl = Number(row[idx.anzahl]);
+    if (!isFinite(anzahl) || anzahl < 1) continue;
+
+    const slot: ImportSlot = {
+      name,
+      ausgaben: Math.round(ausgaben * 100) / 100,
+      gewichtung: Math.round(gewichtung * 1000) / 1000,
+      anzahl: Math.round(anzahl),
+    };
+
+    if (idx.standardgebot >= 0) {
+      const std = Number(row[idx.standardgebot]);
+      if (isFinite(std) && std > 0) slot.standardgebot = Math.round(std * 100) / 100;
+    }
+
+    slots.push(slot);
+  }
+
+  if (slots.length === 0) throw new Error('Keine gültigen Zeilen gefunden. Prüfe Name, Ausgaben, Gewichtung und Anzahl.');
+
+  const gesamtkosten = Math.round(slots.reduce((s, sl) => s + sl.ausgaben, 0) * 100) / 100;
+  return { gesamtkosten, slots };
+}
+
+function splidZuSlots(splid: SplidImport): ImportSlot[] {
+  return splid.personen.map((p) => ({
+    name: p.name,
+    ausgaben: p.ausgaben,
+    gewichtung: 1,
+    anzahl: 1,
+  }));
+}
+
+export async function detectAndParse(buffer: ArrayBuffer, filename: string): Promise<DetectedImport> {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+
+  if (ext === 'xls') {
+    const data = await parseSplid(buffer);
+    return { format: 'splid', rundenname: data.rundenname, gesamtkosten: data.gesamtkosten, slots: splidZuSlots(data) };
+  }
+
+  if (ext === 'xlsx') {
+    const wb = XLSX.read(new Uint8Array(buffer), { type: 'array' });
+    if (wb.SheetNames.includes('Zusammenfassung')) {
+      const data = await parseSplid(buffer);
+      return { format: 'splid', rundenname: data.rundenname, gesamtkosten: data.gesamtkosten, slots: splidZuSlots(data) };
+    }
+    const result = parseBasisImport(buffer);
+    return { format: 'basis', ...result };
+  }
+
+  if (ext === 'csv') {
+    const result = parseBasisImport(buffer);
+    return { format: 'basis', ...result };
+  }
+
+  throw new Error(`Unbekanntes Dateiformat „.${ext}". Unterstützt werden: .csv, .xlsx, .xls`);
+}

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -11,18 +11,36 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       <div class="relative">
         <button id="power-menu-btn" type="button" aria-label="Weitere Optionen" aria-expanded="false"
           class="text-fg-faint hover:text-fg-secondary text-xl leading-none px-2 py-1 rounded hover:bg-surface-hover transition-colors">⋯</button>
-        <div id="power-menu" class="hidden absolute right-0 mt-1 w-52 bg-surface-raised border border-border rounded-lg shadow-lg z-10 py-1">
+        <div id="power-menu" class="hidden absolute right-0 mt-1 w-64 bg-surface-raised border border-border rounded-lg shadow-lg z-10 py-1">
           <label class="flex items-center justify-between px-4 py-2 cursor-pointer hover:bg-surface-elevated transition-colors select-none">
-            <span class="text-sm text-fg-secondary">Drei-Gebot-Modus</span>
+            <div>
+              <span class="text-sm text-fg-secondary block">Drei-Gebot-Modus</span>
+              <span class="text-xs text-fg-faint">Teilnehmer nennen drei Betragsoptionen</span>
+            </div>
             <input type="checkbox" id="drei-gebot-toggle" class="sr-only peer" />
-            <div class="w-9 h-5 bg-border-strong rounded-full peer-checked:bg-brand relative shrink-0
+            <div class="w-9 h-5 bg-border-strong rounded-full peer-checked:bg-brand relative shrink-0 ml-3
                         after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4
                         after:bg-white after:rounded-full after:transition-all
                         peer-checked:after:translate-x-4"></div>
           </label>
           <div class="border-t border-border my-1"></div>
-          <button id="splid-import-btn" type="button"
-            class="w-full text-left text-sm px-4 py-2 text-fg-secondary hover:bg-surface-elevated transition-colors">Abrechnung importieren</button>
+          <div>
+            <div class="flex items-center">
+              <button id="splid-import-btn" type="button"
+                class="flex-1 text-left px-4 py-2 hover:bg-surface-elevated transition-colors">
+                <span class="text-sm text-fg-secondary block">Abrechnung importieren</span>
+                <span class="text-xs text-fg-faint">Splid-Export oder eigene CSV/XLSX</span>
+              </button>
+              <button id="import-info-btn" type="button" aria-label="Format-Informationen"
+                class="px-3 py-2 text-fg-faint hover:text-fg-secondary transition-colors text-sm shrink-0">ⓘ</button>
+            </div>
+            <div id="import-info-popover" class="hidden border-t border-border mx-4 pt-2 pb-3 space-y-1">
+              <p class="text-xs text-fg-secondary"><span class="text-fg-faint">Pflicht:</span> Name · Ausgaben · Gewichtung · Anzahl</p>
+              <p class="text-xs text-fg-secondary"><span class="text-fg-faint">Optional:</span> Standardgebot</p>
+              <a href="/beispiel-basis-import.csv" download
+                class="inline-flex items-center gap-1 text-xs text-brand hover:underline pt-0.5">↓ Beispieldatei laden</a>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -25,7 +25,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         </div>
       </div>
     </div>
-    <input type="file" id="splid-file" accept=".xlsx,.xls" class="hidden" />
+    <input type="file" id="splid-file" accept=".xlsx,.xls,.csv" class="hidden" />
     <FeedbackBox id="splid-erfolg" typ="gruen" klasse="mb-3" />
     <FeedbackBox id="splid-fehler" klasse="mb-3" />
 

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -12,8 +12,6 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         <button id="power-menu-btn" type="button" aria-label="Weitere Optionen" aria-expanded="false"
           class="text-fg-faint hover:text-fg-secondary text-xl leading-none px-2 py-1 rounded hover:bg-surface-hover transition-colors">⋯</button>
         <div id="power-menu" class="hidden absolute right-0 mt-1 w-52 bg-surface-raised border border-border rounded-lg shadow-lg z-10 py-1">
-          <button id="splid-import-btn" type="button"
-            class="w-full text-left text-sm px-4 py-2 text-fg-secondary hover:bg-surface-elevated transition-colors">Abrechnung importieren</button>
           <label class="flex items-center justify-between px-4 py-2 cursor-pointer hover:bg-surface-elevated transition-colors select-none">
             <span class="text-sm text-fg-secondary">Drei-Gebot-Modus</span>
             <input type="checkbox" id="drei-gebot-toggle" class="sr-only peer" />
@@ -22,6 +20,9 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                         after:bg-white after:rounded-full after:transition-all
                         peer-checked:after:translate-x-4"></div>
           </label>
+          <div class="border-t border-border my-1"></div>
+          <button id="splid-import-btn" type="button"
+            class="w-full text-left text-sm px-4 py-2 text-fg-secondary hover:bg-surface-elevated transition-colors">Abrechnung importieren</button>
         </div>
       </div>
     </div>

--- a/src/scripts/neu.test.ts
+++ b/src/scripts/neu.test.ts
@@ -13,6 +13,8 @@ function setupDom() {
     <button id="power-menu-btn" aria-expanded="false"></button>
     <div id="power-menu" class="hidden"></div>
     <button id="splid-import-btn"></button>
+    <button id="import-info-btn"></button>
+    <div id="import-info-popover" class="hidden"></div>
     <input type="file" id="splid-file" />
     <div id="splid-erfolg" class="hidden"></div>
     <div id="splid-fehler" class="hidden"></div>

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -184,6 +184,7 @@ export function initNeu(): void {
 
   function closePowerMenu() {
     powerMenu.classList.add('hidden');
+    document.getElementById('import-info-popover')?.classList.add('hidden');
     powerMenuBtn.setAttribute('aria-expanded', 'false');
     document.removeEventListener('click', closePowerMenuOnOutsideClick);
   }
@@ -207,6 +208,10 @@ export function initNeu(): void {
   document.getElementById('splid-import-btn')!.addEventListener('click', () => {
     closePowerMenu();
     splidFileInput.click();
+  });
+
+  document.getElementById('import-info-btn')!.addEventListener('click', () => {
+    document.getElementById('import-info-popover')!.classList.toggle('hidden');
   });
 
   splidFileInput.addEventListener('change', async () => {

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -268,7 +268,8 @@ export function initNeu(): void {
       aktualisiereRichtwert();
 
       const namen = result.slots.map(s => s.name).join(', ');
-      zeigeFeedback('splid-erfolg', `${result.slots.length} Slots importiert: ${namen}`, 'gruen');
+      const einheit = result.format === 'splid' ? 'Personen' : 'Slots';
+      zeigeFeedback('splid-erfolg', `${result.slots.length} ${einheit} importiert: ${namen}`, 'gruen');
     } catch (err) {
       zeigeFeedback('splid-fehler', (err as Error).message, 'rot');
     }

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -5,7 +5,8 @@ import {
   encrypt,
   exportKey,
 } from '../lib/crypto';
-import { parseSplid } from '../lib/splid';
+import { detectAndParse } from '../lib/basis-import';
+import type { ImportSlot } from '../lib/basis-import';
 import { saveRunde } from '../lib/storage';
 import { zeigeFeedback, versteckeFeedback, formatEur } from '../lib/ui';
 
@@ -198,7 +199,7 @@ export function initNeu(): void {
   });
 
   // ---------------------------------------------------------------------------
-  // Splid-Import
+  // Datei-Import (Splid oder Basis-Format)
   // ---------------------------------------------------------------------------
 
   const splidFileInput = document.getElementById('splid-file') as HTMLInputElement;
@@ -214,34 +215,41 @@ export function initNeu(): void {
 
     try {
       const buffer = await file.arrayBuffer();
-      const { rundenname, gesamtkosten, personen } = await parseSplid(buffer);
+      const result = await detectAndParse(buffer, file.name);
 
-      (form.querySelector('#rundeName') as HTMLInputElement).value = rundenname;
-      (form.querySelector('#gesamtkosten') as HTMLInputElement).value = formatBetrag(gesamtkosten);
+      if (result.format === 'splid') {
+        (form.querySelector('#rundeName') as HTMLInputElement).value = result.rundenname;
+      }
+      (form.querySelector('#gesamtkosten') as HTMLInputElement).value = formatBetrag(result.gesamtkosten);
 
       const alleSlots = slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag');
       alleSlots.forEach((s, i) => { if (i > 0) s.remove(); });
 
       const ersterSlot = slotsContainer.querySelector('.slot-eintrag') as HTMLDivElement;
 
-      function befuelleSlot(slotEl: HTMLDivElement, label: string, ausgaben: number) {
-        (slotEl.querySelector('[name="label[]"]') as HTMLInputElement).value = label;
-        (slotEl.querySelector('[name="gewichtung[]"]') as HTMLInputElement).value = '1';
-        (slotEl.querySelector('[name="ausgaben[]"]') as HTMLInputElement).value = formatBetrag(ausgaben);
-        // Erwachsen-Radio als Standard auswählen
-        const erwachsenRadio = slotEl.querySelector<HTMLInputElement>('.slot-gewichtung-radio[value="1.0"]');
-        if (erwachsenRadio) erwachsenRadio.checked = true;
+      function befuelleSlot(slotEl: HTMLDivElement, slot: ImportSlot) {
+        (slotEl.querySelector('[name="label[]"]') as HTMLInputElement).value = slot.name;
+        (slotEl.querySelector('[name="ausgaben[]"]') as HTMLInputElement).value = formatBetrag(slot.ausgaben);
+        setzeGewichtungRadio(slotEl, slot.gewichtung);
+        (slotEl.querySelector('[name="anzahl[]"]') as HTMLInputElement).value = String(slot.anzahl);
+        if (slot.standardgebot !== undefined) {
+          const checkbox = slotEl.querySelector<HTMLInputElement>('.standardgebot-checkbox');
+          const eingabe = slotEl.querySelector<HTMLDivElement>('.standardgebot-eingabe');
+          const stdInput = slotEl.querySelector<HTMLInputElement>('[name="standardgebot[]"]');
+          if (checkbox) checkbox.checked = true;
+          if (eingabe) eingabe.classList.remove('hidden');
+          if (stdInput) stdInput.value = formatBetrag(slot.standardgebot);
+        }
       }
 
-      befuelleSlot(ersterSlot, personen[0].name, personen[0].ausgaben);
+      befuelleSlot(ersterSlot, result.slots[0]);
 
-      for (let i = 1; i < personen.length; i++) {
+      for (let i = 1; i < result.slots.length; i++) {
         const vorlage = slotsContainer.querySelector('.slot-eintrag') as HTMLDivElement;
         const klon = vorlage.cloneNode(true) as HTMLDivElement;
-        // Eindeutigen Namen für Radio-Buttons setzen
         const uid = `gw-slot-${slotCounter++}`;
         klon.querySelectorAll<HTMLInputElement>('.slot-gewichtung-radio').forEach(r => { r.name = uid; });
-        befuelleSlot(klon, personen[i].name, personen[i].ausgaben);
+        befuelleSlot(klon, result.slots[i]);
         aktualisierePresetPlaceholder(klon);
         slotsContainer.appendChild(klon);
       }
@@ -251,8 +259,8 @@ export function initNeu(): void {
       setzeAusgabenSichtbarkeit(true);
       aktualisiereRichtwert();
 
-      const namen = personen.map(p => p.name).join(', ');
-      zeigeFeedback('splid-erfolg', `${personen.length} Personen importiert: ${namen}`, 'gruen');
+      const namen = result.slots.map(s => s.name).join(', ');
+      zeigeFeedback('splid-erfolg', `${result.slots.length} Slots importiert: ${namen}`, 'gruen');
     } catch (err) {
       zeigeFeedback('splid-fehler', (err as Error).message, 'rot');
     }

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -238,7 +238,10 @@ export function initNeu(): void {
           const stdInput = slotEl.querySelector<HTMLInputElement>('[name="standardgebot[]"]');
           if (checkbox) checkbox.checked = true;
           if (eingabe) eingabe.classList.remove('hidden');
-          if (stdInput) stdInput.value = formatBetrag(slot.standardgebot);
+          if (stdInput) {
+            stdInput.value = formatBetrag(slot.standardgebot);
+            stdInput.dataset.auto = 'false';
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Neuer Parser `parseBasisImport` für eigene CSV/XLSX-Tabellen (Spalten: Name, Ausgaben, Gewichtung, Anzahl, optional Standardgebot)
- `detectAndParse`-Funktion erkennt automatisch Splid- vs. Basis-Format anhand Dateiendung und Sheet-Inhalt
- Import-Handler in `neu.ts` auf `detectAndParse` umgestellt; `befuelleSlot` befüllt jetzt alle Felder inkl. Gewichtung, Anzahl und Standardgebot
- Beispieldatei unter `/beispiel-basis-import.csv` als Download verfügbar
- Power-Menü aufgeräumt: Apple-konforme Reihenfolge (Einstellung → Haarlinie → Aktion), Untertitel, ⓘ-Popover mit Formatinfo und Beispieldatei-Link

## Test plan
- [ ] CSV importieren: Felder werden korrekt befüllt, Gesamtkosten stimmen
- [ ] XLSX importieren: analog CSV
- [ ] XLSX mit „Zusammenfassung"-Sheet: wird als Splid erkannt
- [ ] Standardgebot bleibt nach Import erhalten (nicht durch Richtwert überschrieben)
- [ ] Ungültige Datei (.pdf) zeigt Fehlermeldung
- [ ] ⓘ-Button öffnet/schließt Popover; Menü schließen setzt Popover zurück
- [ ] „Beispieldatei laden" triggert Download der CSV
- [ ] Vitest: alle 205 Tests grün

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)