### PR TITLE
fix: Kinder-Faktor auf 0,25 und Manuell-Feld für Dezimalzahlen verbessern

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -151,7 +151,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                     </label>
                     <input
                       type="number"
-                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand [appearance:textfield] [&::-webkit-inner-spin-button]:hidden [&::-webkit-outer-spin-button]:hidden"
+                      class="slot-gewichtung-manuell w-16 appearance-none border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand"
                       min="0"
                       step="any"
                       value="1"

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -142,7 +142,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Ermäßigt</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
-                      <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.5" />
+                      <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.25" />
                       <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Kind</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
@@ -151,12 +151,11 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                     </label>
                     <input
                       type="number"
-                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand"
-                      min="0.1"
-                      max="2"
-                      step="0.05"
+                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand [appearance:textfield] [&::-webkit-inner-spin-button]:hidden [&::-webkit-outer-spin-button]:hidden"
+                      min="0"
+                      step="any"
                       value="1"
-                      placeholder="0,0–2,0"
+                      placeholder="0,xxx"
                       readonly
                     />
                   </div>

--- a/src/scripts/neu.test.ts
+++ b/src/scripts/neu.test.ts
@@ -37,7 +37,7 @@ function setupDom() {
         <div class="ausgaben-inline hidden"></div>
         <input type="radio" class="slot-gewichtung-radio" name="gw-slot-0" value="1.0" checked />
         <input type="radio" class="slot-gewichtung-radio" name="gw-slot-0" value="0.75" />
-        <input type="radio" class="slot-gewichtung-radio" name="gw-slot-0" value="0.5" />
+        <input type="radio" class="slot-gewichtung-radio" name="gw-slot-0" value="0.25" />
         <input type="radio" class="slot-gewichtung-radio" name="gw-slot-0" value="manuell" />
         <input type="number" class="slot-gewichtung-manuell" value="1" readonly />
         <input type="hidden" name="gewichtung[]" value="1" />

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -92,7 +92,7 @@ export function initNeu(): void {
     t.value = formatBetrag(v);
   }, true);
 
-  const presetNamen: Record<string, string> = { '1.0': 'Erwachsen', '0.75': 'Ermäßigt', '0.5': 'Kind' };
+  const presetNamen: Record<string, string> = { '1.0': 'Erwachsen', '0.75': 'Ermäßigt', '0.25': 'Kind' };
   function aktualisierePresetPlaceholder(slotEl: HTMLElement) {
     const labelInput = slotEl.querySelector<HTMLInputElement>('[name="label[]"]');
     if (!labelInput) return;
@@ -336,7 +336,7 @@ export function initNeu(): void {
     if (hiddenInput) hiddenInput.value = String(gewichtung);
 
     // Passendes Radio auswählen oder Manuell
-    const presets = ['1.0', '0.75', '0.5'];
+    const presets = ['1.0', '0.75', '0.25'];
     const matchingValue = presets.find(v => Math.abs(parseFloat(v) - gewichtung) < 0.001);
     if (matchingValue) {
       const radio = slotEl.querySelector<HTMLInputElement>(`.slot-gewichtung-radio[value="${matchingValue}"]`);


### PR DESCRIPTION
## Summary
- Kinder-Gewichtungs-Preset von 0,5 auf 0,25 korrigiert (Radio-Value, `presetNamen`, `presets`-Array in `setzeGewichtungRadio`)
- Manuell-Eingabefeld: Browser-Spinner-Arrows entfernt (`[appearance:textfield]`), `step="any"` für beliebige Dezimalzahlen, Placeholder auf `0,xxx` aktualisiert

## Test plan
- [ ] Neue Runde erstellen — „Kind"-Badge wählen → Gewichtung 0,25 wird übernommen
- [ ] „Manuell" wählen und Werte wie `0.125` oder `0.333` eingeben → kein Validierungsfehler, Wert wird korrekt gesetzt
- [ ] Manuell-Feld zeigt keine Pfeil-Spinner (Chrome, Firefox, Safari)
- [ ] Import einer Runde mit Kinder-Slot (Gewichtung 0,25) → wird korrekt als „Kind"-Preset erkannt
- [ ] `npm run test` → 205 Tests grün

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)