### PR TITLE
fix: Manuell-Gewichtungsfeld auf type=text umstellen

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -150,10 +150,9 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Manuell</span>
                     </label>
                     <input
-                      type="number"
-                      class="slot-gewichtung-manuell w-16 appearance-none border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand"
-                      min="0"
-                      step="any"
+                      type="text"
+                      inputmode="decimal"
+                      class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand"
                       value="1"
                       placeholder="0,xxx"
                       readonly

--- a/src/scripts/neu.test.ts
+++ b/src/scripts/neu.test.ts
@@ -39,7 +39,7 @@ function setupDom() {
         <input type="radio" class="slot-gewichtung-radio" name="gw-slot-0" value="0.75" />
         <input type="radio" class="slot-gewichtung-radio" name="gw-slot-0" value="0.25" />
         <input type="radio" class="slot-gewichtung-radio" name="gw-slot-0" value="manuell" />
-        <input type="number" class="slot-gewichtung-manuell" value="1" readonly />
+        <input type="text" inputmode="decimal" class="slot-gewichtung-manuell" value="1" readonly />
         <input type="hidden" name="gewichtung[]" value="1" />
         <input type="number" name="anzahl[]" value="1" />
         <input type="checkbox" class="standardgebot-checkbox" />
@@ -172,6 +172,37 @@ describe('initNeu', () => {
 
     expect(document.getElementById('fehler')!.classList.contains('hidden')).toBe(false);
     expect(document.getElementById('fehler')!.textContent).toContain('Rate limit');
+  });
+
+  it('normalisiert Komma zu Punkt im Manuell-Gewichtungsfeld', () => {
+    initNeu();
+
+    const manuellRadio = document.querySelector<HTMLInputElement>('.slot-gewichtung-radio[value="manuell"]')!;
+    manuellRadio.checked = true;
+    manuellRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const manuellInput = document.querySelector<HTMLInputElement>('.slot-gewichtung-manuell')!;
+    const hiddenInput = document.querySelector<HTMLInputElement>('[name="gewichtung[]"]')!;
+
+    manuellInput.value = '0,25';
+    manuellInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(hiddenInput.value).toBe('0.25');
+  });
+
+  it('leert Manuell-Gewichtungsfeld bei ungültiger Eingabe nach Blur', () => {
+    initNeu();
+
+    const manuellRadio = document.querySelector<HTMLInputElement>('.slot-gewichtung-radio[value="manuell"]')!;
+    manuellRadio.checked = true;
+    manuellRadio.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const manuellInput = document.querySelector<HTMLInputElement>('.slot-gewichtung-manuell')!;
+    manuellInput.value = 'abc';
+    manuellInput.dispatchEvent(new Event('input', { bubbles: true }));
+    manuellInput.dispatchEvent(new FocusEvent('blur', { bubbles: true }));
+
+    expect(manuellInput.value).toBe('');
   });
 
   it('zeigt Fehler bei ungültigen Gesamtkosten (0)', async () => {

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -117,6 +117,18 @@ export function initNeu(): void {
     }
   });
 
+  slotsContainer.addEventListener('blur', (e) => {
+    const target = e.target as HTMLInputElement;
+    if (!target.classList.contains('slot-gewichtung-manuell') || target.readOnly) return;
+    const v = parseFloat(target.value.replace(',', '.'));
+    if (isNaN(v) || v <= 0) {
+      target.value = '';
+      const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
+      const hiddenInput = eintrag?.querySelector<HTMLInputElement>('[name="gewichtung[]"]');
+      if (hiddenInput) hiddenInput.value = '';
+    }
+  }, true);
+
   slotsContainer.addEventListener('change', (e) => {
     const target = e.target as HTMLInputElement;
 

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -111,7 +111,7 @@ export function initNeu(): void {
       const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
       const hiddenInput = eintrag.querySelector<HTMLInputElement>('[name="gewichtung[]"]');
       if (hiddenInput && target.value) {
-        hiddenInput.value = target.value;
+        hiddenInput.value = target.value.replace(',', '.');
         aktualisiereRichtwert();
       }
     }


### PR DESCRIPTION
## Summary
- `type="number"` → `type="text" inputmode="decimal"` im Manuell-Gewichtungsfeld, konsistent mit allen anderen Dezimalfeldern im Projekt (Gesamtkosten, Standardgebot)
- Komma-zu-Punkt-Normalisierung im Input-Handler, damit `0,25` nicht lautlos zu `0` wird wenn es via `parseFloat()` in den Hidden-Input übernommen wird

## Test plan
- [ ] Neue Runde erstellen — „Manuell" wählen und `0,25` eingeben → Richtwert-Vorschau aktualisiert sich korrekt
- [ ] `0.333` mit Punkt eingeben → funktioniert ebenfalls
- [ ] Keine Spinner-Arrows sichtbar (Chrome, Firefox, Safari)
- [ ] Auf Mobile: Zifferntastatur erscheint beim Tippen ins Manuell-Feld
- [ ] `npm run test` → 205 Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)