### PR TITLE
fix: Admin-Ansicht – Subtitle entfernen und Status-Banner im Druck zeigen

### DIFF
--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -19,9 +19,6 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
   <div id="zustand-auswertung" class="hidden space-y-8 print:space-y-4">
     <div class="print:mb-2">
       <h1 id="runde-name" class="text-2xl font-semibold mb-1 print:text-xl"></h1>
-      <p class="text-fg-muted text-sm print:text-xs">
-        Admin-Auswertung · alle Daten wurden lokal entschlüsselt
-      </p>
     </div>
 
     <!-- Kennzahlen -->
@@ -48,7 +45,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
     </div>
 
     <!-- Status-Banner -->
-    <div id="status-banner" class="hidden rounded-xl px-4 py-3 text-sm font-medium print:hidden"></div>
+    <div id="status-banner" class="hidden rounded-xl px-4 py-3 text-sm font-medium"></div>
 
     <!-- Container -->
     <div id="slots-container" class="space-y-4"></div>

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -17,9 +17,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 
   <!-- Auswertung -->
   <div id="zustand-auswertung" class="hidden space-y-8 print:space-y-4">
-    <div class="print:mb-2">
-      <h1 id="runde-name" class="text-2xl font-semibold mb-1 print:text-xl"></h1>
-    </div>
+    <h1 id="runde-name" class="text-2xl font-semibold mb-1 print:text-xl print:mb-2"></h1>
 
     <!-- Kennzahlen -->
     <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 print:grid-cols-3 print:gap-2">

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -50,7 +50,7 @@ export async function initAdmin(): Promise<void> {
       amber: 'bg-amber-subtle border border-amber-outline text-amber-fg',
       red:   'bg-danger-subtle border border-danger-outline text-danger-fg',
     };
-    banner.className = `rounded-xl px-4 py-3 text-sm font-medium print:hidden ${farbenKlassen[farbe]}`;
+    banner.className = `rounded-xl px-4 py-3 text-sm font-medium ${farbenKlassen[farbe]}`;
     banner.textContent = text;
     banner.classList.remove('hidden');
   }


### PR DESCRIPTION
## Summary

- Technischen Subtitle „Admin-Auswertung · alle Daten wurden lokal entschlüsselt" entfernt — war ein Implementierungsdetail ohne Nutzwert
- `print:hidden` vom Status-Banner entfernt (HTML-Template + JS-Klasse) — Fehlbetrag-Warnung und alle anderen Status-Banner erscheinen jetzt im PDF-Export

## Test plan

- [ ] Admin-Ansicht öffnen → kein Subtitle unter dem Rundennamen
- [ ] Runde mit Fehlbetrag: rotes Banner sichtbar → Druckvorschau → Banner erscheint
- [ ] Runde vollständig: grünes Banner → Druckvorschau → Banner erscheint
- [ ] `npm run test` grün

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)