### PR TITLE
fix: technische Sprache im UI durch nutzerverständliche Formulierungen ersetzen

### DIFF
--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -8,7 +8,15 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-2xl font-semibold mb-1">Meine Runden</h1>
-        <p class="text-fg-muted text-sm">Gespeichert in deinem Browser.</p>
+        <div class="flex items-center gap-1">
+          <p class="text-fg-muted text-sm">Nur auf diesem Gerät</p>
+          <details class="relative">
+            <summary class="cursor-pointer text-fg-faint hover:text-fg-secondary transition-colors text-sm select-none list-none leading-none">ⓘ</summary>
+            <div class="absolute left-0 top-6 bg-surface-raised border border-border rounded-xl shadow-lg z-10 w-72 p-3 text-xs text-fg-secondary">
+              Deine Runden werden im Browser dieses Geräts gespeichert und sind auf anderen Geräten nicht sichtbar.
+            </div>
+          </details>
+        </div>
       </div>
       <details class="relative">
         <summary class="cursor-pointer text-fg-faint hover:text-fg-secondary transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>
@@ -79,8 +87,8 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     } catch (err) {
       rundenListe.innerHTML = '';
       const meldung = err instanceof SyntaxError
-        ? 'Deine gespeicherten Runden konnten nicht geladen werden — die Daten im Browser sind beschädigt. Du kannst sie über das ⋯-Menü zurücksetzen.'
-        : 'Deine gespeicherten Runden konnten nicht geladen werden.';
+        ? 'Die gespeicherten Runden konnten nicht gelesen werden. Du kannst sie über das ⋯-Menü zurücksetzen.'
+        : 'Die gespeicherten Runden konnten nicht geladen werden.';
       zeigeFeedback('storage-fehler', meldung, 'rot');
       return;
     }

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -8,15 +8,15 @@ import FeedbackBox from '../components/FeedbackBox.astro';
     <div class="flex items-center justify-between">
       <div>
         <h1 class="text-2xl font-semibold mb-1">Meine Runden</h1>
-        <div class="flex items-center gap-1">
-          <p class="text-fg-muted text-sm">Nur auf diesem Gerät</p>
-          <details class="relative">
-            <summary class="cursor-pointer text-fg-faint hover:text-fg-secondary transition-colors text-sm select-none list-none leading-none">ⓘ</summary>
-            <div class="absolute left-0 top-6 bg-surface-raised border border-border rounded-xl shadow-lg z-10 w-72 p-3 text-xs text-fg-secondary">
-              Deine Runden werden im Browser dieses Geräts gespeichert und sind auf anderen Geräten nicht sichtbar.
-            </div>
-          </details>
-        </div>
+        <details class="text-sm text-fg-muted">
+          <summary class="cursor-pointer list-none select-none flex items-center gap-1 w-fit">
+            <span>Nur auf diesem Gerät</span>
+            <span class="text-fg-faint hover:text-fg-secondary transition-colors text-xs">ⓘ</span>
+          </summary>
+          <p class="text-xs text-fg-secondary mt-1.5 max-w-[280px]">
+            Deine Runden werden im Browser dieses Geräts gespeichert und sind auf anderen Geräten nicht sichtbar.
+          </p>
+        </details>
       </div>
       <details class="relative">
         <summary class="cursor-pointer text-fg-faint hover:text-fg-secondary transition-colors text-xl select-none list-none px-2 py-1">⋯</summary>

--- a/src/pages/meine-runden.astro
+++ b/src/pages/meine-runden.astro
@@ -5,7 +5,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 
 <Layout title="Meine Runden">
   <div class="space-y-6">
-    <div class="flex items-center justify-between">
+    <div class="flex items-start justify-between">
       <div>
         <h1 class="text-2xl font-semibold mb-1">Meine Runden</h1>
         <details class="text-sm text-fg-muted">

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -6,7 +6,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
 <Layout title="Neue Runde">
   <!-- Formular-Bereich -->
   <div id="form-bereich">
-    <div class="flex items-center justify-between mb-4">
+    <div class="flex items-start justify-between mb-4">
       <h1 class="text-2xl font-semibold">Neue Runde erstellen</h1>
       <div class="relative">
         <button id="power-menu-btn" type="button" aria-label="Weitere Optionen" aria-expanded="false"

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -285,7 +285,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         </a>
       </div>
       <p class="text-xs text-amber-fg">
-        Dieser Link enthält deinen privaten Schlüssel. Wer ihn hat, kann alle Gebote einsehen.
+        Wer diesen Link hat, kann alle Gebote einsehen. Teile ihn nicht.
       </p>
     </div>
 

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -6,7 +6,7 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
 <Layout title="Auswertung">
   <!-- Laden -->
   <div id="zustand-laden" class="text-center py-12 text-fg-muted text-sm">
-    Lade und entschlüssele…
+    Lade Auswertung…
   </div>
 
   <!-- Fehler -->

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -96,7 +96,7 @@ export async function initAdmin(): Promise<void> {
       importAdminPrivKey(adminPrivKeyB64),
     ]);
   } catch {
-    zeigeFehler('Schlüssel im Admin-Link sind ungültig.');
+    zeigeFehler('Der Admin-Link ist ungültig oder wurde verändert.');
     return;
   }
 
@@ -105,7 +105,7 @@ export async function initAdmin(): Promise<void> {
   try {
     blob = JSON.parse(await decrypt(partKey, blobData.encTeilnehmerBlob)) as TeilnehmerBlob;
   } catch {
-    zeigeFehler('Blob-Entschlüsselung fehlgeschlagen. Falscher Schlüssel?');
+    zeigeFehler('Auswertung konnte nicht geladen werden. Bitte prüfe, ob der Admin-Link vollständig ist.');
     return;
   }
 

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -146,7 +146,7 @@ describe('initGebot', () => {
     await initGebot();
 
     expect(document.getElementById('zustand-fehler')!.classList.contains('hidden')).toBe(false);
-    expect(document.getElementById('fehler-text')!.textContent).toContain('Schlüssel');
+    expect(document.getElementById('fehler-text')!.textContent).toContain('unvollständig');
   });
 
   it('zeigt Fehler wenn Runde nicht gefunden (fetch 404)', async () => {

--- a/src/scripts/gebot.ts
+++ b/src/scripts/gebot.ts
@@ -37,7 +37,7 @@ export async function initGebot(): Promise<void> {
 
   if (!partKeyB64) {
     zeigeFehler(
-      'Kein Schlüssel im Link gefunden. Bitte verwende den vollständigen Teilnehmer-Link.',
+      'Der Link ist unvollständig oder wurde falsch kopiert.',
     );
     return;
   }
@@ -71,7 +71,7 @@ export async function initGebot(): Promise<void> {
     const partKey = await importPartKey(partKeyB64);
     blob = JSON.parse(await decrypt(partKey, blobData.encTeilnehmerBlob)) as TeilnehmerBlob;
   } catch {
-    zeigeFehler('Entschlüsselung fehlgeschlagen. Ist der Link vollständig?');
+    zeigeFehler('Der Link funktioniert nicht. Bitte prüfe, ob er vollständig kopiert wurde.');
     return;
   }
 
@@ -240,7 +240,7 @@ export async function initGebot(): Promise<void> {
     versteckeFeedback('gebot-fehler');
     duplikatWarnung.classList.add('hidden');
     gebotBtn.disabled = true;
-    gebotBtn.textContent = 'Verschlüssele…';
+    gebotBtn.textContent = 'Wird gesendet…';
 
     try {
       const selectedIdx = parseInt(
@@ -402,7 +402,7 @@ export async function initGebot(): Promise<void> {
     e.preventDefault();
     versteckeFeedback('korrektur-fehler');
     korrekturBtn.disabled = true;
-    korrekturBtn.textContent = 'Verschlüssele…';
+    korrekturBtn.textContent = 'Wird gesendet…';
 
     try {
       const emojiId = (document.getElementById('korrektur-emoji') as HTMLInputElement).value.trim();


### PR DESCRIPTION
## Summary

- Subtitle in „Meine Runden" von „Gespeichert in deinem Browser." zu „Nur auf diesem Gerät" + ⓘ-Button mit Tooltip-Text (natives `<details>`/`<summary>`, kein JS)
- Lade-Texte „Lade und entschlüssele…" und „Verschlüssele…" durch „Lade Auswertung…" bzw. „Wird gesendet…" ersetzt
- Alle Fehlermeldungen ohne Crypto-Jargon — Ursache und nächster Schritt bleiben erhalten
- Sicherheitshinweis für den Admin-Link nennt keinen „privaten Schlüssel" mehr

## Test plan

- [ ] „Meine Runden" zeigt Subtitle „Nur auf diesem Gerät" + ⓘ-Button
- [ ] Klick auf ⓘ blendet Erklärungstext ein/aus
- [ ] Admin-Ansicht zeigt „Lade Auswertung…" beim Laden
- [ ] Gebot absenden und korrigieren zeigt „Wird gesendet…"
- [ ] Fehlerhafter Teilnehmer-Link → nutzerverständliche Meldung ohne „Schlüssel"/"Entschlüsselung"
- [ ] Fehlerhafter Admin-Link → Meldung ohne Crypto-Begriffe
- [ ] Sicherheitshinweis auf neu.astro ohne „privaten Schlüssel"
- [ ] `npm run test` → 210/210 grün

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)