### PR TITLE
feat: Bei 'Runde wiederholen' Ausgaben per Browser-Dialog übernehmen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Encryption formats:
 - **Progressive Disclosure:** Komplexität erscheint erst, wenn sie gebraucht wird. Features werden nicht entfernt — sie werden zum richtigen Moment sichtbar.
 - Kein Feature im primären Sichtbereich, das die meisten Nutzer nie brauchen.
 - Power-Features sind auffindbar, aber nie aufdringlich.
-- **Nutzersprache statt Technikbegriffe:** UI-Texte beschreiben die *Konsequenz*, nicht den Mechanismus. Keine Crypto-Begriffe (Schlüssel, Verschlüsseln, Entschlüsseln), keine internen Datenbegriffe. Maßstab: würde ein Apple-Produkttexter das so schreiben? Beispiele: „Wird gesendet…" statt „Verschlüssele…", „Der Link ist unvollständig" statt „Kein Schlüssel im Link", „Nur auf diesem Gerät" statt „Gespeichert in deinem Browser". Gilt für Lade-Texte, Fehlermeldungen, Bestätigungsdialoge und Erklärungstexte gleichermaßen. (Hintergrund: Issue #121)
+- **Nutzersprache statt Technikbegriffe:** Konsequenz beschreiben, nicht Mechanismus. Keine Crypto-Begriffe. Maßstab: würde Apple das so schreiben? „Wird gesendet…" statt „Verschlüssele…"; „Link ist unvollständig" statt „Kein Schlüssel im Link".
 
 ## Git-Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Encryption formats:
 - **Progressive Disclosure:** Komplexität erscheint erst, wenn sie gebraucht wird. Features werden nicht entfernt — sie werden zum richtigen Moment sichtbar.
 - Kein Feature im primären Sichtbereich, das die meisten Nutzer nie brauchen.
 - Power-Features sind auffindbar, aber nie aufdringlich.
+- **Nutzersprache statt Technikbegriffe:** UI-Texte beschreiben die *Konsequenz*, nicht den Mechanismus. Keine Crypto-Begriffe (Schlüssel, Verschlüsseln, Entschlüsseln), keine internen Datenbegriffe. Maßstab: würde ein Apple-Produkttexter das so schreiben? Beispiele: „Wird gesendet…" statt „Verschlüssele…", „Der Link ist unvollständig" statt „Kein Schlüssel im Link", „Nur auf diesem Gerät" statt „Gespeichert in deinem Browser". Gilt für Lade-Texte, Fehlermeldungen, Bestätigungsdialoge und Erklärungstexte gleichermaßen. (Hintergrund: Issue #121)
 
 ## Git-Workflow
 

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -73,10 +73,10 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
       </button>
     </div>
     <div id="wiederholen-dialog" class="hidden mt-3 rounded-xl border border-border-default bg-surface-secondary px-4 py-3 text-sm">
-      <p class="text-fg-secondary mb-2">Slot-Ausgaben aus dieser Runde übernehmen?</p>
+      <p class="text-fg-secondary mb-2">Ausgaben aus dieser Runde übernehmen?</p>
       <div class="flex gap-2">
         <button id="wiederholen-ja" class="rounded-lg bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-dark transition-colors">Ja, übernehmen</button>
-        <button id="wiederholen-nein" class="rounded-lg border border-border-strong px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors">Nein, leer starten</button>
+        <button id="wiederholen-nein" class="rounded-lg border border-border-strong px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors">Weglassen</button>
       </div>
     </div>
   </div>

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -72,13 +72,6 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         Runde wiederholen
       </button>
     </div>
-    <div id="wiederholen-dialog" class="hidden mt-3 rounded-xl border border-border-default bg-surface-secondary px-4 py-3 text-sm">
-      <p class="text-fg-secondary mb-2">Ausgaben aus dieser Runde übernehmen?</p>
-      <div class="flex gap-2">
-        <button id="wiederholen-ja" class="rounded-lg bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-dark transition-colors">Ja, übernehmen</button>
-        <button id="wiederholen-nein" class="rounded-lg border border-border-strong px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors">Weglassen</button>
-      </div>
-    </div>
   </div>
 </Layout>
 

--- a/src/pages/runde/[id]/admin/[token].astro
+++ b/src/pages/runde/[id]/admin/[token].astro
@@ -72,6 +72,13 @@ import FeedbackBox from '../../../../components/FeedbackBox.astro';
         Runde wiederholen
       </button>
     </div>
+    <div id="wiederholen-dialog" class="hidden mt-3 rounded-xl border border-border-default bg-surface-secondary px-4 py-3 text-sm">
+      <p class="text-fg-secondary mb-2">Slot-Ausgaben aus dieser Runde übernehmen?</p>
+      <div class="flex gap-2">
+        <button id="wiederholen-ja" class="rounded-lg bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-dark transition-colors">Ja, übernehmen</button>
+        <button id="wiederholen-nein" class="rounded-lg border border-border-strong px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-hover transition-colors">Nein, leer starten</button>
+      </div>
+    </div>
   </div>
 </Layout>
 

--- a/src/scripts/admin.test.ts
+++ b/src/scripts/admin.test.ts
@@ -46,7 +46,7 @@ interface TestKeys {
   hmacKey: CryptoKey;
 }
 
-async function createTestKeys(slotOverrides?: Partial<{ anzahl: number }>): Promise<TestKeys> {
+async function createTestKeys(slotOverrides?: Partial<{ anzahl: number; ausgaben: number }>): Promise<TestKeys> {
   const partKey = await generatePartKey();
   const { publicKey: adminPubKey, privateKey: adminPrivKey } = await generateAdminKeyPair();
   const hmacKey = await generateHmacKey();
@@ -61,7 +61,12 @@ async function createTestKeys(slotOverrides?: Partial<{ anzahl: number }>): Prom
     gesamtkosten: 600,
     adminPubKey: adminPubKeyB64,
     hmacKey: hmacKeyB64,
-    slots: [{ label: 'Erwachsen', gewichtung: 1.0, anzahl: slotOverrides?.anzahl ?? 1 }],
+    slots: [{
+      label: 'Erwachsen',
+      gewichtung: 1.0,
+      anzahl: slotOverrides?.anzahl ?? 1,
+      ...(slotOverrides?.ausgaben !== undefined ? { ausgaben: slotOverrides.ausgaben } : {}),
+    }],
   };
   const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blobData));
 
@@ -254,6 +259,61 @@ describe('initAdmin', () => {
     await initAdmin();
 
     expect(localStorage.getItem('fairshare_runden')).toBeNull();
+  });
+
+  it('ruft confirm auf und speichert Ausgaben bei OK', async () => {
+    const keys = await createTestKeys({ ausgaben: 200 });
+    mockLocation('/runde/abc12345/admin/tok123', `#pk=${keys.partKeyB64}&bk=${keys.adminPrivKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob: keys.encTeilnehmerBlob, gebote: [] }),
+    }));
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    const sessionStorageMock = makeLocalStorageMock();
+    vi.stubGlobal('sessionStorage', sessionStorageMock);
+
+    await initAdmin();
+    document.getElementById('wiederholen-btn')!.click();
+
+    expect(confirm).toHaveBeenCalledWith('Ausgaben aus dieser Runde übernehmen?');
+    const payload = JSON.parse(sessionStorageMock.getItem('rundeWiederholen')!);
+    expect(payload.slots[0].ausgaben).toBe(200);
+  });
+
+  it('speichert Payload ohne Ausgaben wenn confirm abgebrochen', async () => {
+    const keys = await createTestKeys({ ausgaben: 200 });
+    mockLocation('/runde/abc12345/admin/tok123', `#pk=${keys.partKeyB64}&bk=${keys.adminPrivKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob: keys.encTeilnehmerBlob, gebote: [] }),
+    }));
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(false));
+    const sessionStorageMock = makeLocalStorageMock();
+    vi.stubGlobal('sessionStorage', sessionStorageMock);
+
+    await initAdmin();
+    document.getElementById('wiederholen-btn')!.click();
+
+    const payload = JSON.parse(sessionStorageMock.getItem('rundeWiederholen')!);
+    expect(payload.slots[0]).not.toHaveProperty('ausgaben');
+  });
+
+  it('navigiert ohne confirm wenn keine Ausgaben vorhanden', async () => {
+    const keys = await createTestKeys({ anzahl: 1 });
+    mockLocation('/runde/abc12345/admin/tok123', `#pk=${keys.partKeyB64}&bk=${keys.adminPrivKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob: keys.encTeilnehmerBlob, gebote: [] }),
+    }));
+    vi.stubGlobal('confirm', vi.fn());
+    const sessionStorageMock = makeLocalStorageMock();
+    vi.stubGlobal('sessionStorage', sessionStorageMock);
+
+    await initAdmin();
+    document.getElementById('wiederholen-btn')!.click();
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(sessionStorageMock.getItem('rundeWiederholen')).not.toBeNull();
   });
 
   it('upgradet bestehenden Teilnehmer-Eintrag auf Admin-Link', async () => {

--- a/src/scripts/admin.test.ts
+++ b/src/scripts/admin.test.ts
@@ -34,9 +34,6 @@ function setupDom() {
     <div id="ausgleich-liste"></div>
     <p id="gebote-anzahl"></p>
     <button id="wiederholen-btn"></button>
-    <div id="wiederholen-dialog" class="hidden"></div>
-    <button id="wiederholen-ja"></button>
-    <button id="wiederholen-nein"></button>
   `;
 }
 

--- a/src/scripts/admin.test.ts
+++ b/src/scripts/admin.test.ts
@@ -10,7 +10,7 @@ import {
   hmac,
 } from '../lib/crypto';
 import { generiereEmojiId } from '../lib/solidarisch';
-import { initAdmin } from './admin';
+import { initAdmin, baueWiederholenPayload } from './admin';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -34,6 +34,9 @@ function setupDom() {
     <div id="ausgleich-liste"></div>
     <p id="gebote-anzahl"></p>
     <button id="wiederholen-btn"></button>
+    <div id="wiederholen-dialog" class="hidden"></div>
+    <button id="wiederholen-ja"></button>
+    <button id="wiederholen-nein"></button>
   `;
 }
 
@@ -277,5 +280,55 @@ describe('initAdmin', () => {
     const runden = JSON.parse(localStorage.getItem('fairshare_runden')!);
     expect(runden).toHaveLength(1);
     expect(runden[0].adminLink).toContain('/runde/abc12345/admin/tok123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// baueWiederholenPayload
+// ---------------------------------------------------------------------------
+
+const testBlob = {
+  rundeName: 'Testrunde',
+  gesamtkosten: 600,
+  slots: [
+    { label: 'Erwachsen', gewichtung: 1, anzahl: 3, ausgaben: 200 },
+    { label: 'Kind', gewichtung: 0.5, anzahl: 2, ausgaben: 100, standardgebot: 50 },
+    { label: 'Ohne Ausgaben', gewichtung: 1, anzahl: 1 },
+  ],
+};
+
+describe('baueWiederholenPayload', () => {
+  it('enthält keine ausgaben wenn mitAusgaben=false (Nein-Pfad)', () => {
+    const payload = baueWiederholenPayload(testBlob, false);
+    for (const slot of payload.slots) {
+      expect(slot).not.toHaveProperty('ausgaben');
+    }
+  });
+
+  it('enthält ausgaben für Slots mit Ausgaben wenn mitAusgaben=true (Ja-Pfad)', () => {
+    const payload = baueWiederholenPayload(testBlob, true);
+    expect(payload.slots[0].ausgaben).toBe(200);
+    expect(payload.slots[1].ausgaben).toBe(100);
+  });
+
+  it('lässt Slot ohne ausgaben auch bei mitAusgaben=true ohne ausgaben', () => {
+    const payload = baueWiederholenPayload(testBlob, true);
+    expect(payload.slots[2]).not.toHaveProperty('ausgaben');
+  });
+
+  it('überträgt name und kosten korrekt', () => {
+    const payload = baueWiederholenPayload(testBlob, false);
+    expect(payload.name).toBe('Testrunde');
+    expect(payload.kosten).toBe(600);
+  });
+
+  it('überträgt standardgebot unabhängig von mitAusgaben', () => {
+    expect(baueWiederholenPayload(testBlob, false).slots[1].standardgebot).toBe(50);
+    expect(baueWiederholenPayload(testBlob, true).slots[1].standardgebot).toBe(50);
+  });
+
+  it('überträgt label, gewichtung und anzahl', () => {
+    const payload = baueWiederholenPayload(testBlob, false);
+    expect(payload.slots[0]).toMatchObject({ label: 'Erwachsen', gewichtung: 1, anzahl: 3 });
   });
 });

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -528,20 +528,10 @@ export async function initAdmin(): Promise<void> {
   document.getElementById('zustand-laden')!.classList.add('hidden');
   document.getElementById('zustand-auswertung')!.classList.remove('hidden');
 
-  // Runde wiederholen: ggf. Dialog für Slot-Ausgaben, dann zu /neu navigieren
-  function navigiereWiederholen(mitAusgaben: boolean) {
+  // Runde wiederholen: ggf. Browser-Dialog für Ausgaben-Übernahme, dann zu /neu navigieren
+  document.getElementById('wiederholen-btn')!.addEventListener('click', () => {
+    const mitAusgaben = ausgabenMap.size > 0 && confirm('Ausgaben aus dieser Runde übernehmen?');
     sessionStorage.setItem('rundeWiederholen', JSON.stringify(baueWiederholenPayload(blob, mitAusgaben)));
     location.href = '/neu';
-  }
-
-  document.getElementById('wiederholen-btn')!.addEventListener('click', () => {
-    if (ausgabenMap.size === 0) {
-      navigiereWiederholen(false);
-      return;
-    }
-    document.getElementById('wiederholen-dialog')!.classList.remove('hidden');
   });
-
-  document.getElementById('wiederholen-ja')!.addEventListener('click', () => navigiereWiederholen(true));
-  document.getElementById('wiederholen-nein')!.addEventListener('click', () => navigiereWiederholen(false));
 }

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -36,6 +36,23 @@ interface RawGebotPayload {
   istStandard?: boolean;
 }
 
+export function baueWiederholenPayload(
+  blob: Pick<TeilnehmerBlob, 'rundeName' | 'gesamtkosten' | 'slots'>,
+  mitAusgaben: boolean,
+) {
+  return {
+    name: blob.rundeName,
+    kosten: blob.gesamtkosten,
+    slots: blob.slots.map(({ label, gewichtung, anzahl, standardgebot, ausgaben }) => ({
+      label,
+      gewichtung,
+      anzahl,
+      ...(standardgebot !== undefined ? { standardgebot } : {}),
+      ...(mitAusgaben && ausgaben !== undefined ? { ausgaben } : {}),
+    })),
+  };
+}
+
 export async function initAdmin(): Promise<void> {
   function zeigeFehler(msg: string) {
     document.getElementById('zustand-laden')!.classList.add('hidden');
@@ -511,18 +528,20 @@ export async function initAdmin(): Promise<void> {
   document.getElementById('zustand-laden')!.classList.add('hidden');
   document.getElementById('zustand-auswertung')!.classList.remove('hidden');
 
-  // Runde wiederholen: Slot-Konfiguration in sessionStorage speichern und zu /neu navigieren
-  document.getElementById('wiederholen-btn')!.addEventListener('click', () => {
-    sessionStorage.setItem('rundeWiederholen', JSON.stringify({
-      name: blob.rundeName,
-      kosten: blob.gesamtkosten,
-      slots: blob.slots.map(({ label, gewichtung, anzahl, standardgebot }) => ({
-        label,
-        gewichtung,
-        anzahl,
-        ...(standardgebot !== undefined ? { standardgebot } : {}),
-      })),
-    }));
+  // Runde wiederholen: ggf. Dialog für Slot-Ausgaben, dann zu /neu navigieren
+  function navigiereWiederholen(mitAusgaben: boolean) {
+    sessionStorage.setItem('rundeWiederholen', JSON.stringify(baueWiederholenPayload(blob, mitAusgaben)));
     location.href = '/neu';
+  }
+
+  document.getElementById('wiederholen-btn')!.addEventListener('click', () => {
+    if (ausgabenMap.size === 0) {
+      navigiereWiederholen(false);
+      return;
+    }
+    document.getElementById('wiederholen-dialog')!.classList.remove('hidden');
   });
+
+  document.getElementById('wiederholen-ja')!.addEventListener('click', () => navigiereWiederholen(true));
+  document.getElementById('wiederholen-nein')!.addEventListener('click', () => navigiereWiederholen(false));
 }

--- a/src/scripts/neu.test.ts
+++ b/src/scripts/neu.test.ts
@@ -217,4 +217,32 @@ describe('initNeu', () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(document.getElementById('fehler')!.textContent).toContain('Gesamtkosten');
   });
+
+  it('Ja-Pfad: füllt ausgaben vor und macht Ausgaben-Felder sichtbar', () => {
+    sessionStorage.setItem('rundeWiederholen', JSON.stringify({
+      name: 'Wiederholrunde',
+      kosten: 300,
+      slots: [{ label: 'Erwachsen', gewichtung: 1, anzahl: 2, ausgaben: 150 }],
+    }));
+
+    initNeu();
+
+    const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
+    expect(ausgabenInput.value).toBe('150,00');
+    expect(document.getElementById('ausgaben-link')!.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('Nein-Pfad: ausgaben bleibt leer wenn kein ausgaben im Payload', () => {
+    sessionStorage.setItem('rundeWiederholen', JSON.stringify({
+      name: 'Wiederholrunde',
+      kosten: 300,
+      slots: [{ label: 'Erwachsen', gewichtung: 1, anzahl: 2 }],
+    }));
+
+    initNeu();
+
+    const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
+    expect(ausgabenInput.value).toBe('');
+    expect(document.getElementById('ausgaben-link')!.getAttribute('aria-expanded')).toBe('false');
+  });
 });

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -378,7 +378,7 @@ export function initNeu(): void {
       const config = JSON.parse(wiederholenRaw) as {
         name: string;
         kosten: number;
-        slots: { label: string; gewichtung: number; anzahl: number; standardgebot?: number }[];
+        slots: { label: string; gewichtung: number; anzahl: number; standardgebot?: number; ausgaben?: number }[];
       };
 
       (form.querySelector('#rundeName') as HTMLInputElement).value = config.name;
@@ -386,7 +386,7 @@ export function initNeu(): void {
 
       function befuelleWiederholSlot(
         slotEl: HTMLDivElement,
-        slot: { label: string; gewichtung: number; anzahl: number; standardgebot?: number },
+        slot: { label: string; gewichtung: number; anzahl: number; standardgebot?: number; ausgaben?: number },
       ) {
         const presetNamenWiederhol: Record<string, string> = { 'Erwachsen': '', 'Ermäßigt': '', 'Kind': '', 'Beitrag': '' };
         // Labels die reine Preset-Namen sind, als leer behandeln (Preset-Name wird beim Absenden wieder gesetzt)
@@ -410,6 +410,10 @@ export function initNeu(): void {
           stdInput.value = '';
           stdInput.dataset.auto = 'true';
         }
+
+        if (slot.ausgaben !== undefined) {
+          (slotEl.querySelector('[name="ausgaben[]"]') as HTMLInputElement).value = formatBetrag(slot.ausgaben);
+        }
       }
 
       slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag').forEach((s, i) => {
@@ -430,6 +434,12 @@ export function initNeu(): void {
       }
 
       aktualisiereEntfernenButtons();
+
+      if (config.slots.some(s => s.ausgaben !== undefined)) {
+        ausgabenSichtbar = true;
+        setzeAusgabenSichtbarkeit(true);
+      }
+
       aktualisiereRichtwert();
     } catch {
       // Ungültiger sessionStorage-Eintrag — ignorieren


### PR DESCRIPTION
## Summary

- Neuer `baueWiederholenPayload(blob, mitAusgaben)`-Helper in `admin.ts` extrahiert und exportiert — baut den sessionStorage-Payload für „Runde wiederholen", optional mit Slot-Ausgaben
- Beim Klick auf „Runde wiederholen" öffnet ein nativer Browser-`confirm()`-Dialog wenn Slot-Ausgaben vorhanden sind (`ausgabenMap.size > 0`); bei fehlenden Ausgaben wird direkt navigiert
- `neu.ts`: `befuelleWiederholSlot()` füllt Ausgaben-Felder vor und macht den Ausgaben-Bereich sichtbar wenn Ausgaben im Payload enthalten sind
- CLAUDE.md: Design-Prinzip „Nutzersprache statt Technikbegriffe" dokumentiert (Issue #121)

## Test plan

- [ ] Runde mit Slot-Ausgaben (z. B. via Splid-Import) öffnen → „Runde wiederholen" klicken → Browser-Dialog erscheint → „OK": Ausgaben auf `/neu` vorausgefüllt, Felder sichtbar
- [ ] Gleiche Runde → Dialog → „Abbrechen": Ausgaben leer, Rest (Name, Kosten, Slots) übernommen
- [ ] Runde ohne Slot-Ausgaben → kein Dialog, direkt zu `/neu`
- [ ] `npm run test` → alle 218 Tests grün

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)