### PR TITLE
fix: Gesamtkosten live aus Slot-Ausgaben berechnen und validieren

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -64,22 +64,6 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         />
       </div>
 
-      <!-- Gesamtkosten -->
-      <div>
-        <label for="gesamtkosten" class="block text-sm font-medium text-fg-secondary mb-1">
-          Gesamtkosten (€)
-        </label>
-        <input
-          type="text"
-          inputmode="decimal"
-          id="gesamtkosten"
-          name="gesamtkosten"
-          required
-          placeholder="z.B. 1200"
-          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
-        />
-      </div>
-
       <!-- Personen -->
       <div>
         <div class="flex items-center justify-between mb-2">
@@ -199,6 +183,23 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           aria-expanded="false"
           class="text-xs text-fg-faint hover:text-fg-secondary mt-1 transition-colors"
         >+ Ausgaben erfassen</button>
+      </div>
+
+      <!-- Gesamtkosten -->
+      <div>
+        <label for="gesamtkosten" class="block text-sm font-medium text-fg-secondary mb-1">
+          Gesamtkosten (€)
+        </label>
+        <input
+          type="text"
+          inputmode="decimal"
+          id="gesamtkosten"
+          name="gesamtkosten"
+          required
+          placeholder="z.B. 1200"
+          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+        />
+        <p id="gesamtkosten-fehler" class="hidden text-xs text-danger-fg mt-1"></p>
       </div>
 
       <!-- Fehler -->

--- a/src/scripts/neu.test.ts
+++ b/src/scripts/neu.test.ts
@@ -27,8 +27,9 @@ function setupDom() {
     <button id="copy-admin"></button>
     <form id="runde-form">
       <input id="rundeName" name="rundeName" type="text" value="Testrunde" />
-      <input id="gesamtkosten" name="gesamtkosten" type="text" value="600" />
       <button type="submit" id="submit-btn">Runde erstellen</button>
+      <input id="gesamtkosten" name="gesamtkosten" type="text" value="600" />
+      <p id="gesamtkosten-fehler" class="hidden"></p>
     </form>
     <div id="slots-container">
       <div class="slot-eintrag">
@@ -244,5 +245,72 @@ describe('initNeu', () => {
     const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
     expect(ausgabenInput.value).toBe('');
     expect(document.getElementById('ausgaben-link')!.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('berechnet Gesamtkosten live aus Slot-Ausgaben', () => {
+    initNeu();
+
+    const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
+    ausgabenInput.value = '350';
+    ausgabenInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect((document.getElementById('gesamtkosten') as HTMLInputElement).value).toBe('350,00');
+  });
+
+  it('blockiert Submit wenn Slot-Summe nicht mit Gesamtkosten übereinstimmt', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    initNeu();
+
+    const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
+    ausgabenInput.value = '300';
+    ausgabenInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Gesamtkosten manuell auf abweichenden Wert setzen
+    (document.getElementById('gesamtkosten') as HTMLInputElement).value = '500';
+
+    document.getElementById('runde-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+    await vi.waitFor(() =>
+      expect(document.getElementById('gesamtkosten-fehler')!.classList.contains('hidden')).toBe(false),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(document.getElementById('gesamtkosten-fehler')!.textContent).toContain('300');
+  });
+
+  it('lässt Submit zu wenn keine Ausgaben erfasst sind', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'abc12345', adminToken: 'tok1234567890abcd' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    initNeu();
+
+    // Ausgaben-Feld bleibt leer
+    document.getElementById('runde-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+    expect(document.getElementById('gesamtkosten-fehler')!.classList.contains('hidden')).toBe(true);
+  });
+
+  it('lässt Submit zu wenn Slot-Summe mit Gesamtkosten übereinstimmt', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'abc12345', adminToken: 'tok1234567890abcd' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    initNeu();
+
+    const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
+    ausgabenInput.value = '600';
+    ausgabenInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    document.getElementById('runde-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+    expect(document.getElementById('gesamtkosten-fehler')!.classList.contains('hidden')).toBe(true);
   });
 });

--- a/src/scripts/neu.test.ts
+++ b/src/scripts/neu.test.ts
@@ -313,4 +313,70 @@ describe('initNeu', () => {
 
     expect(document.getElementById('gesamtkosten-fehler')!.classList.contains('hidden')).toBe(true);
   });
+
+  it('setzt Gesamtkosten zurück wenn alle Ausgaben-Felder geleert werden', () => {
+    initNeu();
+
+    const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
+    ausgabenInput.value = '350';
+    ausgabenInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    ausgabenInput.value = '';
+    ausgabenInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect((document.getElementById('gesamtkosten') as HTMLInputElement).value).toBe('');
+  });
+
+  it('blendet Inline-Fehler aus wenn Gesamtkosten manuell korrigiert wird', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    initNeu();
+
+    const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
+    ausgabenInput.value = '300';
+    ausgabenInput.dispatchEvent(new Event('input', { bubbles: true }));
+    (document.getElementById('gesamtkosten') as HTMLInputElement).value = '500';
+
+    document.getElementById('runde-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+    await vi.waitFor(() =>
+      expect(document.getElementById('gesamtkosten-fehler')!.classList.contains('hidden')).toBe(false),
+    );
+
+    const gesamtkostenInput = document.getElementById('gesamtkosten') as HTMLInputElement;
+    gesamtkostenInput.value = '300';
+    gesamtkostenInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(document.getElementById('gesamtkosten-fehler')!.classList.contains('hidden')).toBe(true);
+  });
+
+  it('aktualisiert Gesamtkosten nach Slot-Entfernen', () => {
+    initNeu();
+
+    document.getElementById('slot-hinzufuegen')!.click();
+
+    const ausgabenInputs = document.querySelectorAll<HTMLInputElement>('[name="ausgaben[]"]');
+    ausgabenInputs[0].value = '300';
+    ausgabenInputs[0].dispatchEvent(new Event('input', { bubbles: true }));
+    ausgabenInputs[1].value = '200';
+    ausgabenInputs[1].dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect((document.getElementById('gesamtkosten') as HTMLInputElement).value).toBe('500,00');
+
+    document.querySelectorAll<HTMLButtonElement>('.slot-entfernen')[0].click();
+
+    expect((document.getElementById('gesamtkosten') as HTMLInputElement).value).toBe('200,00');
+  });
+
+  it('zählt €0-Ausgaben bei der Summenberechnung mit', () => {
+    initNeu();
+
+    document.getElementById('slot-hinzufuegen')!.click();
+
+    const ausgabenInputs = document.querySelectorAll<HTMLInputElement>('[name="ausgaben[]"]');
+    ausgabenInputs[0].value = '0';
+    ausgabenInputs[0].dispatchEvent(new Event('input', { bubbles: true }));
+    ausgabenInputs[1].value = '600';
+    ausgabenInputs[1].dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect((document.getElementById('gesamtkosten') as HTMLInputElement).value).toBe('600,00');
+  });
 });

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -83,6 +83,16 @@ export function initNeu(): void {
 
   document.getElementById('gesamtkosten')!.addEventListener('input', aktualisiereRichtwert);
 
+  function aktualisiereGesamtkosten() {
+    const werte = [...slotsContainer.querySelectorAll<HTMLInputElement>('[name="ausgaben[]"]')]
+      .map(el => parseGeld(el.value))
+      .filter(v => !isNaN(v) && v > 0);
+    if (werte.length === 0) return;
+    const summe = werte.reduce((a, b) => a + b, 0);
+    (form.querySelector('#gesamtkosten') as HTMLInputElement).value = formatBetrag(summe);
+    aktualisiereRichtwert();
+  }
+
   form.addEventListener('blur', (e) => {
     const t = e.target as HTMLInputElement;
     if (!['gesamtkosten', 'ausgaben[]', 'standardgebot[]'].includes(t.name)) return;
@@ -104,6 +114,8 @@ export function initNeu(): void {
     const target = e.target as HTMLInputElement;
     if (target.name === 'standardgebot[]') {
       target.dataset.auto = 'false';
+    } else if (target.name === 'ausgaben[]') {
+      aktualisiereGesamtkosten();
     } else if (target.name === 'anzahl[]') {
       aktualisiereRichtwert();
     } else if (target.classList.contains('slot-gewichtung-manuell')) {
@@ -179,6 +191,7 @@ export function initNeu(): void {
     const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
     eintrag.remove();
     aktualisiereEntfernenButtons();
+    aktualisiereGesamtkosten();
   });
 
   // ---------------------------------------------------------------------------
@@ -470,6 +483,25 @@ export function initNeu(): void {
       if (!gesamtkosten || gesamtkosten <= 0 || !isFinite(gesamtkosten)) {
         zeigeFeedback('fehler', 'Bitte gib gültige Gesamtkosten ein.', 'rot');
         return;
+      }
+
+      const gesamtkostenFehlerEl = document.getElementById('gesamtkosten-fehler') as HTMLParagraphElement;
+      gesamtkostenFehlerEl.classList.add('hidden');
+      const ausgabenWerte = [...slotsContainer.querySelectorAll<HTMLInputElement>('[name="ausgaben[]"]')]
+        .map(el => parseGeld(el.value))
+        .filter(v => !isNaN(v) && v > 0);
+      if (ausgabenWerte.length > 0) {
+        const slotSumme = ausgabenWerte.reduce((a, b) => a + b, 0);
+        if (Math.abs(slotSumme - gesamtkosten) > 0.01) {
+          gesamtkostenFehlerEl.textContent = `Stimmt nicht mit der Summe der Slot-Ausgaben (${formatEur(slotSumme)}) überein.`;
+          gesamtkostenFehlerEl.classList.remove('hidden');
+          const gesamtkostenInput = form.querySelector('#gesamtkosten') as HTMLInputElement;
+          gesamtkostenInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          gesamtkostenInput.focus();
+          submitBtn.disabled = false;
+          submitBtn.textContent = 'Runde erstellen';
+          return;
+        }
       }
 
       const labels = [...slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag')].map((slotEl) => {

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -81,15 +81,23 @@ export function initNeu(): void {
     });
   }
 
-  document.getElementById('gesamtkosten')!.addEventListener('input', aktualisiereRichtwert);
+  document.getElementById('gesamtkosten')!.addEventListener('input', () => {
+    (document.getElementById('gesamtkosten-fehler') as HTMLParagraphElement).classList.add('hidden');
+    aktualisiereRichtwert();
+  });
 
   function aktualisiereGesamtkosten() {
     const werte = [...slotsContainer.querySelectorAll<HTMLInputElement>('[name="ausgaben[]"]')]
       .map(el => parseGeld(el.value))
-      .filter(v => !isNaN(v) && v > 0);
-    if (werte.length === 0) return;
+      .filter(v => !isNaN(v));
+    const gesamtkostenInput = form.querySelector('#gesamtkosten') as HTMLInputElement;
+    if (werte.length === 0) {
+      gesamtkostenInput.value = '';
+      aktualisiereRichtwert();
+      return;
+    }
     const summe = werte.reduce((a, b) => a + b, 0);
-    (form.querySelector('#gesamtkosten') as HTMLInputElement).value = formatBetrag(summe);
+    gesamtkostenInput.value = formatBetrag(summe);
     aktualisiereRichtwert();
   }
 
@@ -489,7 +497,7 @@ export function initNeu(): void {
       gesamtkostenFehlerEl.classList.add('hidden');
       const ausgabenWerte = [...slotsContainer.querySelectorAll<HTMLInputElement>('[name="ausgaben[]"]')]
         .map(el => parseGeld(el.value))
-        .filter(v => !isNaN(v) && v > 0);
+        .filter(v => !isNaN(v));
       if (ausgabenWerte.length > 0) {
         const slotSumme = ausgabenWerte.reduce((a, b) => a + b, 0);
         if (Math.abs(slotSumme - gesamtkosten) > 0.01) {


### PR DESCRIPTION
## Summary

- Gesamtkosten-Feld unter die Personen-Sektion verschoben (natürlicher Workflow: Name → Personen → Gesamtkosten)
- Gesamtkosten wird live aus den Slot-Ausgaben berechnet, sobald ein Ausgaben-Feld befüllt wird
- Beim Absenden: wenn Slot-Summe und Gesamtkosten um mehr als 0,01 € abweichen, erscheint eine Inline-Fehlermeldung direkt unter dem Feld, das Formular scrollt automatisch dorthin und das Feld erhält den Fokus
- Ohne Slot-Ausgaben bleibt die Validierung inaktiv

## Test plan

- [ ] Runde ohne Ausgaben erstellen → funktioniert wie bisher, kein Fehler
- [ ] „+ Ausgaben erfassen" klicken, Beträge pro Slot eintragen → Gesamtkosten aktualisiert sich automatisch
- [ ] Gesamtkosten manuell auf abweichenden Wert ändern, absenden → Inline-Fehler erscheint mit korrekter Slot-Summe, Seite scrollt zum Feld
- [ ] Slot hinzufügen und Ausgaben eintragen → Gesamtkosten addiert alle Slots korrekt
- [ ] Slot entfernen → Gesamtkosten aktualisiert sich
- [ ] Splid-Import → Gesamtkosten und Ausgaben konsistent, kein Fehler beim Absenden

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)