### PR TITLE
fix: Layout-Shift beim Erscheinen des Richtwerts in Slot-Zeile verhindern

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -105,12 +105,13 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                 aria-label="Slot entfernen"
               >×</button>
             </div>
-            <span class="standardgebot-richtwert text-xs text-fg-faint"></span>
-
             <!-- Erweiterte Optionen (eingeklappt) -->
             <details class="slot-erweitert-details">
-              <summary class="text-xs text-fg-faint cursor-pointer hover:text-fg-secondary transition-colors select-none list-none flex items-center gap-1">
-                <span class="inline-block transition-transform details-arrow">›</span> Erweitert
+              <summary class="text-xs text-fg-faint cursor-pointer hover:text-fg-secondary transition-colors select-none list-none flex items-center justify-between">
+                <span class="standardgebot-richtwert text-xs text-fg-faint"></span>
+                <span class="flex items-center gap-1">
+                  <span class="inline-block transition-transform details-arrow">›</span> Erweitert
+                </span>
               </summary>
               <div class="pt-3 space-y-3">
                 <!-- Gewichtungs-Kategorien -->


### PR DESCRIPTION
## Summary

- `<span class="standardgebot-richtwert">` aus der Slot-Zeile entfernt und in die `<summary>`-Zeile von `<details>` verschoben
- Summary nutzt jetzt `justify-between`: Richtwert links (initial leer), „Erweitert ›" rechts
- Der Span ist von Anfang an im DOM — kein neues Element beim Eintippen der Gesamtkosten, kein Reflow
- JS-Selektor `.standardgebot-richtwert` in `neu.ts` bleibt unverändert

## Test plan

- [ ] Neue Runde erstellen, einen Slot anlegen
- [ ] Gesamtkosten eintippen → Richtwert erscheint links in der Erweitert-Zeile, kein Layout-Shift
- [ ] Zweiten Slot hinzufügen → Richtwert erscheint auch dort korrekt
- [ ] Slot entfernen und neu hinzufügen → Richtwert-Span ist leer (Clone-Reset funktioniert)
- [ ] Mobil prüfen: kein Overflow/Umbruch in der Summary-Zeile

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)