### PR TITLE
feat: Warnung beim Abgeben eines Gebots für weiteren Slot

### DIFF
--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -24,9 +24,6 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
       </p>
     </div>
 
-    <!-- Hinweis: bereits geboten -->
-    <div id="gebot-hinweis-banner" class="hidden bg-success-subtle border border-success-outline text-success-fg rounded-xl p-4 text-sm"></div>
-
     <!-- Tab-Navigation -->
     <div class="flex border-b border-border">
       <button
@@ -111,6 +108,15 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
 
         <!-- Fehler -->
         <FeedbackBox id="gebot-fehler" />
+
+        <!-- Warnung: Gebot für weiteren Slot -->
+        <div id="weiterer-slot-warnung" class="hidden bg-amber-subtle border border-amber-outline text-amber-fg rounded-lg p-3 text-sm">
+          <p id="weiterer-slot-text" class="font-medium"></p>
+          <div class="flex gap-2 pt-2">
+            <button type="button" id="weiterer-slot-abbrechen" class="border border-amber-outline text-amber-fg rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-tinted transition-colors">Abbrechen</button>
+            <button type="button" id="weiterer-slot-bestaetigen" class="border border-amber-border bg-amber-tinted text-amber-strong rounded-lg px-3 py-1.5 text-xs font-medium hover:bg-amber-outline transition-colors">Trotzdem bieten</button>
+          </div>
+        </div>
 
         <!-- Duplikat-Warnung Two-Step (Soft-Warning, kein Hard-Block) -->
         <div id="duplikat-warnung" class="hidden bg-amber-subtle border border-amber-outline text-amber-fg rounded-lg p-3 text-sm">

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -39,6 +39,11 @@ function setupDom() {
         <input type="number" id="betrag-mittel" />
         <input type="number" id="betrag-max" />
       </div>
+      <div id="weiterer-slot-warnung" class="hidden">
+        <p id="weiterer-slot-text"></p>
+        <button type="button" id="weiterer-slot-abbrechen"></button>
+        <button type="button" id="weiterer-slot-bestaetigen"></button>
+      </div>
       <div id="duplikat-warnung" class="hidden"></div>
       <div id="duplikat-schritt1"></div>
       <div id="duplikat-schritt2" class="hidden"></div>
@@ -69,7 +74,6 @@ function setupDom() {
     <div id="emoji-anzeige"></div>
     <p id="bestaetigung-titel"></p>
     <p id="bestaetigung-text"></p>
-    <div id="gebot-hinweis-banner" class="hidden"></div>
   `;
 }
 
@@ -369,25 +373,7 @@ describe('initGebot', () => {
     await vi.waitFor(() => expect(document.getElementById('korrektur-fehler')!.classList.contains('hidden')).toBe(false));
   });
 
-  it('zeigt Hinweis-Banner mit Slot-Namen wenn genau ein Slot geboten wurde', async () => {
-    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob();
-    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
-    }));
-
-    localStorage.setItem('fairshare-slot-abc12345-Erwachsen', '1');
-
-    await initGebot();
-
-    const banner = document.getElementById('gebot-hinweis-banner')!;
-    expect(banner.classList.contains('hidden')).toBe(false);
-    expect(banner.textContent).toContain('Erwachsen');
-    expect(banner.querySelector('strong')?.textContent).toBe('Erwachsen');
-  });
-
-  it('zeigt Hinweis-Banner ohne Slot-Namen wenn mehrere Slots geboten wurden', async () => {
+  it('zeigt Warnung mit Slot-Namen wenn anderer Slot bereits geboten wurde', async () => {
     const partKey = await generatePartKey();
     const { publicKey: adminPubKey } = await generateAdminKeyPair();
     const hmacKey = await generateHmacKey();
@@ -403,6 +389,47 @@ describe('initGebot', () => {
       ],
     };
     const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blobData));
+
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
+    }));
+
+    // Slot 0 (Erwachsen) bereits geboten
+    localStorage.setItem('fairshare-slot-abc12345-Erwachsen', '1');
+
+    await initGebot();
+
+    // Formular-Radio auf Slot 1 (Kind) umschreiben, damit der Submit-Handler Kind auswählt
+    (document.querySelector('form#gebot-form input[name="slot"]') as HTMLInputElement).value = '1';
+    (document.getElementById('betrag') as HTMLInputElement).value = '40';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('weiterer-slot-warnung')!.classList.contains('hidden')).toBe(false));
+    const text = document.getElementById('weiterer-slot-text')!;
+    expect(text.textContent).toContain('Erwachsen');
+    expect(text.querySelector('strong')?.textContent).toBe('Erwachsen');
+  });
+
+  it('zeigt generische Warnung wenn mehrere andere Slots bereits geboten wurden', async () => {
+    const partKey = await generatePartKey();
+    const { publicKey: adminPubKey } = await generateAdminKeyPair();
+    const hmacKey = await generateHmacKey();
+    const partKeyB64 = await exportKey(partKey);
+    const blobData = {
+      rundeName: 'Testrunde',
+      gesamtkosten: 900,
+      adminPubKey: await exportKey(adminPubKey),
+      hmacKey: await exportKey(hmacKey),
+      slots: [
+        { label: 'Erwachsen', gewichtung: 1.0, anzahl: 1 },
+        { label: 'Kind', gewichtung: 0.5, anzahl: 1 },
+        { label: 'Baby', gewichtung: 0.25, anzahl: 1 },
+      ],
+    };
+    const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blobData));
+
     mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
@@ -414,22 +441,28 @@ describe('initGebot', () => {
 
     await initGebot();
 
-    const banner = document.getElementById('gebot-hinweis-banner')!;
-    expect(banner.classList.contains('hidden')).toBe(false);
-    expect(banner.textContent).toBe('Du hast bereits Gebote abgegeben.');
-    expect(banner.querySelector('strong')).toBeNull();
+    // Formular-Radio auf Slot 2 (Baby) umschreiben
+    (document.querySelector('form#gebot-form input[name="slot"]') as HTMLInputElement).value = '2';
+    (document.getElementById('betrag') as HTMLInputElement).value = '20';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('weiterer-slot-warnung')!.classList.contains('hidden')).toBe(false));
+    expect(document.getElementById('weiterer-slot-text')!.querySelector('strong')).toBeNull();
   });
 
-  it('zeigt keinen Hinweis-Banner wenn kein Slot geboten wurde', async () => {
+  it('zeigt keine Warnung wenn noch kein Gebot vorliegt', async () => {
     const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob();
     mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
-    }));
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ encTeilnehmerBlob, gebote: [] }) })
+      .mockResolvedValue({ ok: true, status: 200, json: async () => ({}) }));
 
     await initGebot();
 
-    expect(document.getElementById('gebot-hinweis-banner')!.classList.contains('hidden')).toBe(true);
+    (document.getElementById('betrag') as HTMLInputElement).value = '80';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('zustand-bestaetigung')!.classList.contains('hidden')).toBe(false));
+    expect(document.getElementById('weiterer-slot-warnung')!.classList.contains('hidden')).toBe(true);
   });
 });

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -450,6 +450,82 @@ describe('initGebot', () => {
     expect(document.getElementById('weiterer-slot-text')!.querySelector('strong')).toBeNull();
   });
 
+  it('Abbrechen-Button versteckt die Weiterer-Slot-Warnung', async () => {
+    const partKey = await generatePartKey();
+    const { publicKey: adminPubKey } = await generateAdminKeyPair();
+    const hmacKey = await generateHmacKey();
+    const partKeyB64 = await exportKey(partKey);
+    const blobData = {
+      rundeName: 'Testrunde',
+      gesamtkosten: 600,
+      adminPubKey: await exportKey(adminPubKey),
+      hmacKey: await exportKey(hmacKey),
+      slots: [
+        { label: 'Erwachsen', gewichtung: 1.0, anzahl: 1 },
+        { label: 'Kind', gewichtung: 0.5, anzahl: 1 },
+      ],
+    };
+    const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blobData));
+
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
+    }));
+
+    localStorage.setItem('fairshare-slot-abc12345-Erwachsen', '1');
+
+    await initGebot();
+
+    (document.querySelector('form#gebot-form input[name="slot"]') as HTMLInputElement).value = '1';
+    (document.getElementById('betrag') as HTMLInputElement).value = '40';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('weiterer-slot-warnung')!.classList.contains('hidden')).toBe(false));
+
+    document.getElementById('weiterer-slot-abbrechen')!.dispatchEvent(new Event('click'));
+
+    expect(document.getElementById('weiterer-slot-warnung')!.classList.contains('hidden')).toBe(true);
+  });
+
+  it('zeigt Weiterer-Slot-Warnung im Drei-Gebot-Modus', async () => {
+    const partKey = await generatePartKey();
+    const { publicKey: adminPubKey } = await generateAdminKeyPair();
+    const hmacKey = await generateHmacKey();
+    const partKeyB64 = await exportKey(partKey);
+    const blobData = {
+      rundeName: 'Testrunde',
+      gesamtkosten: 600,
+      adminPubKey: await exportKey(adminPubKey),
+      hmacKey: await exportKey(hmacKey),
+      slots: [
+        { label: 'Erwachsen', gewichtung: 1.0, anzahl: 1 },
+        { label: 'Kind', gewichtung: 0.5, anzahl: 1 },
+      ],
+      dreiGebotModus: true,
+    };
+    const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blobData));
+
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob, gebote: [] }),
+    }));
+
+    localStorage.setItem('fairshare-slot-abc12345-Erwachsen', '1');
+
+    await initGebot();
+
+    (document.querySelector('form#gebot-form input[name="slot"]') as HTMLInputElement).value = '1';
+    (document.getElementById('betrag-min') as HTMLInputElement).value = '30';
+    (document.getElementById('betrag-mittel') as HTMLInputElement).value = '40';
+    (document.getElementById('betrag-max') as HTMLInputElement).value = '60';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.getElementById('weiterer-slot-warnung')!.classList.contains('hidden')).toBe(false));
+    expect(document.getElementById('weiterer-slot-text')!.textContent).toContain('Erwachsen');
+  });
+
   it('zeigt keine Warnung wenn noch kein Gebot vorliegt', async () => {
     const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob();
     mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);

--- a/src/scripts/gebot.ts
+++ b/src/scripts/gebot.ts
@@ -210,23 +210,13 @@ export async function initGebot(): Promise<void> {
     document.getElementById('tab-korrigieren')!.classList.remove('hidden');
   }
 
-  // Hinweis-Banner anzeigen falls bereits geboten
-  const bereitsGeboteteSlots = blob.slots.filter(s => slotBereitsGeboten(s.label));
-  if (bereitsGeboteteSlots.length > 0) {
-    const banner = document.getElementById('gebot-hinweis-banner')!;
-    if (bereitsGeboteteSlots.length === 1) {
-      const strong = document.createElement('strong');
-      strong.textContent = bereitsGeboteteSlots[0].label;
-      banner.append('Du hast für ', strong, ' bereits ein Gebot abgegeben.');
-    } else {
-      banner.textContent = 'Du hast bereits Gebote abgegeben.';
-    }
-    banner.classList.remove('hidden');
-  }
-
   // ── Tab 1: Gebot abgeben ──────────────────────────────────────────────────
   const gebotForm = document.getElementById('gebot-form') as HTMLFormElement;
   const gebotBtn = document.getElementById('gebot-btn') as HTMLButtonElement;
+  const weitererSlotWarnung = document.getElementById('weiterer-slot-warnung') as HTMLDivElement;
+  const weitererSlotText = document.getElementById('weiterer-slot-text') as HTMLParagraphElement;
+  const weitererSlotAbbrechen = document.getElementById('weiterer-slot-abbrechen') as HTMLButtonElement;
+  const weitererSlotBestaetigen = document.getElementById('weiterer-slot-bestaetigen') as HTMLButtonElement;
   const duplikatWarnung = document.getElementById('duplikat-warnung') as HTMLDivElement;
   const duplikatAbbrechen = document.getElementById('duplikat-abbrechen') as HTMLButtonElement;
   const duplikatWeiter = document.getElementById('duplikat-weiter') as HTMLButtonElement;
@@ -252,6 +242,7 @@ export async function initGebot(): Promise<void> {
   // Kernfunktion: Gebot tatsächlich einreichen (mit Auto-Retry bei Emoji-Kollision)
   async function gebot_einreichen() {
     versteckeFeedback('gebot-fehler');
+    weitererSlotWarnung.classList.add('hidden');
     duplikatWarnung.classList.add('hidden');
     gebotBtn.disabled = true;
     gebotBtn.textContent = 'Wird gesendet…';
@@ -338,6 +329,26 @@ export async function initGebot(): Promise<void> {
       return;
     }
 
+    const andereGeboteneSlots = blob.slots.filter(s => s.label !== selectedSlot.label && slotBereitsGeboten(s.label));
+    if (andereGeboteneSlots.length > 0) {
+      if (andereGeboteneSlots.length === 1) {
+        const strong = document.createElement('strong');
+        strong.textContent = andereGeboteneSlots[0].label;
+        weitererSlotText.replaceChildren('Du hast bereits ein Gebot für ', strong, ' abgegeben. Willst du wirklich für eine weitere Person bieten?');
+      } else {
+        weitererSlotText.textContent = 'Du hast bereits Gebote für andere Slots abgegeben. Willst du wirklich für eine weitere Person bieten?';
+      }
+      weitererSlotWarnung.classList.remove('hidden');
+      return;
+    }
+
+    await gebot_einreichen();
+  });
+
+  weitererSlotAbbrechen.addEventListener('click', () => {
+    weitererSlotWarnung.classList.add('hidden');
+  });
+  weitererSlotBestaetigen.addEventListener('click', async () => {
     await gebot_einreichen();
   });
 


### PR DESCRIPTION
## Summary
- Neuer Submit-Handler-Check: wenn bereits für einen anderen Slot geboten wurde, erscheint eine Warnung mit Bestätigen/Abbrechen — noch bevor das Gebot abgeschickt wird
- Bei einem gebotenen Slot nennt die Warnung den Slot-Namen namentlich; bei mehreren erscheint ein generischer Text
- Redundanter Seitenlade-Banner (`gebot-hinweis-banner`) entfernt — war slop, da das `✓ abgegeben`-Label neben dem Slot denselben Hinweis bereits gibt

## Test plan
- [ ] Seite öffnen, Slot A bieten, Seite neu laden → kein Banner mehr sichtbar
- [ ] Slot B auswählen und absenden (Slot A war geboten) → Warnung erscheint mit Slot-A-Name
- [ ] Abbrechen → Warnung verschwindet, kein Gebot abgeschickt
- [ ] Trotzdem bieten → Gebot wird eingereicht, Bestätigungsseite erscheint
- [ ] Eigenen Slot nochmal einreichen → Duplikat-Warnung (nicht die neue Warnung)
- [ ] Erstes Gebot ohne Vorgebot → keine Warnung, direkt Bestätigung
- [ ] Drei-Gebot-Modus: Warnung erscheint analog
- [ ] `npm run test` läuft grün durch

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)