### PR TITLE
chore: redundante Navigationslinks entfernen

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -85,15 +85,3 @@ import Layout from '../layouts/Layout.astro';
   </section>
 </Layout>
 
-<script>
-  try {
-    const runden = JSON.parse(localStorage.getItem('fairshare_runden') || '[]');
-    if (Array.isArray(runden) && runden.length > 0) {
-      const el = document.getElementById('cta-meine-runden');
-      if (el) {
-        el.classList.remove('hidden');
-        el.classList.add('inline-flex', 'animate-fade-in');
-      }
-    }
-  } catch { /* ignore */ }
-</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,13 +18,6 @@ import Layout from '../layouts/Layout.astro';
         >
           Neue Runde erstellen
         </a>
-        <a
-          id="cta-meine-runden"
-          href="/meine-runden"
-          class="hidden items-center gap-2 text-sm text-fg-muted hover:text-fg-strong transition-colors px-4 py-2"
-        >
-          Meine gespeicherten Runden →
-        </a>
       </div>
     </div>
   </section>

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -291,12 +291,6 @@ import FeedbackBox from '../components/FeedbackBox.astro';
       </p>
     </div>
 
-    <a
-      href="/neu"
-      class="block text-center text-sm text-fg-muted hover:text-fg-strong transition-colors"
-    >
-      Weitere Runde erstellen →
-    </a>
   </div>
 </Layout>
 

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -25,7 +25,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
     </div>
 
     <!-- Tab-Navigation -->
-    <div class="flex border-b border-border">
+    <div class="flex items-end border-b border-border">
       <button
         id="tab-abgeben"
         class="px-4 py-2 text-sm font-medium border-b-2 border-brand text-brand -mb-px transition-colors"
@@ -37,6 +37,13 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         class="hidden px-4 py-2 text-sm font-medium border-b-2 border-transparent text-fg-muted -mb-px hover:text-fg-strong transition-colors"
       >
         Gebot korrigieren
+      </button>
+      <button
+        type="button"
+        id="korrektur-link-btn"
+        class="ml-auto pb-2 text-xs text-fg-faint hover:text-fg-secondary transition-colors hover:underline underline-offset-2"
+      >
+        Gebot korrigieren →
       </button>
     </div>
 
@@ -146,11 +153,6 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
           Gebot abgeben
         </button>
 
-        <p class="text-center mt-1">
-          <button type="button" id="korrektur-link-btn" class="text-xs text-fg-faint hover:text-fg-secondary underline transition-colors">
-            Gebot korrigieren →
-          </button>
-        </p>
       </form>
     </div>
 

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -43,7 +43,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
         id="korrektur-link-btn"
         class="ml-auto pb-2 text-xs text-fg-faint hover:text-fg-secondary transition-colors hover:underline underline-offset-2"
       >
-        Gebot korrigieren →
+        Bereits geboten?
       </button>
     </div>
 

--- a/src/scripts/gebot.ts
+++ b/src/scripts/gebot.ts
@@ -193,6 +193,11 @@ export async function initGebot(): Promise<void> {
     panelKorrigieren.classList.toggle('hidden', istAbgeben);
   }
 
+  function blendeKorrekturTabEin() {
+    tabKorrigieren.classList.remove('hidden');
+    document.getElementById('korrektur-link-btn')!.classList.add('hidden');
+  }
+
   tabAbgeben.addEventListener('click', () => zeigeTab('abgeben'));
   tabKorrigieren.addEventListener('click', () => zeigeTab('korrigieren'));
 
@@ -209,10 +214,8 @@ export async function initGebot(): Promise<void> {
   document.getElementById('korrektur-betrag-einzel')!.classList.toggle('hidden', dreiGebotModus);
   document.getElementById('korrektur-betrag-drei')!.classList.toggle('hidden', !dreiGebotModus);
 
-  // Korrektur-Tab einblenden falls bereits geboten; Link im Tab-Bereich ausblenden
   if (blob.slots.some(s => slotBereitsGeboten(s.label))) {
-    document.getElementById('tab-korrigieren')!.classList.remove('hidden');
-    document.getElementById('korrektur-link-btn')!.classList.add('hidden');
+    blendeKorrekturTabEin();
   }
 
   // ── Tab 1: Gebot abgeben ──────────────────────────────────────────────────
@@ -309,7 +312,7 @@ export async function initGebot(): Promise<void> {
 
       slotAlsGebotenMarkieren(selectedSlot.label);
       saveGebotLokal(rundenId, emojiId!, selectedSlot.label);
-      document.getElementById('tab-korrigieren')!.classList.remove('hidden');
+      blendeKorrekturTabEin();
       zeigeBestaetigung(emojiId!, false);
     } catch (err) {
       zeigeFeedback('gebot-fehler', 'Unerwarteter Fehler. Bitte versuche es erneut.', 'rot');
@@ -372,7 +375,7 @@ export async function initGebot(): Promise<void> {
   });
   duplikatKorrigieren.addEventListener('click', () => {
     duplikatZuruecksetzen();
-    tabKorrigieren.classList.remove('hidden');
+    blendeKorrekturTabEin();
     zeigeTab('korrigieren');
     document.getElementById('korrektur-emoji')?.focus();
   });
@@ -381,9 +384,8 @@ export async function initGebot(): Promise<void> {
     await gebot_einreichen();
   });
 
-  // Korrektur-Link (immer sichtbar, öffnet Korrektur-Tab)
   document.getElementById('korrektur-link-btn')!.addEventListener('click', () => {
-    tabKorrigieren.classList.remove('hidden');
+    blendeKorrekturTabEin();
     zeigeTab('korrigieren');
     document.getElementById('korrektur-emoji')?.focus();
   });

--- a/src/scripts/gebot.ts
+++ b/src/scripts/gebot.ts
@@ -209,9 +209,10 @@ export async function initGebot(): Promise<void> {
   document.getElementById('korrektur-betrag-einzel')!.classList.toggle('hidden', dreiGebotModus);
   document.getElementById('korrektur-betrag-drei')!.classList.toggle('hidden', !dreiGebotModus);
 
-  // Korrektur-Tab einblenden falls bereits geboten
+  // Korrektur-Tab einblenden falls bereits geboten; Link im Tab-Bereich ausblenden
   if (blob.slots.some(s => slotBereitsGeboten(s.label))) {
     document.getElementById('tab-korrigieren')!.classList.remove('hidden');
+    document.getElementById('korrektur-link-btn')!.classList.add('hidden');
   }
 
   // ── Tab 1: Gebot abgeben ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Entfernt redundanten Link „Meine gespeicherten Runden →" von der Startseite (Nav deckt das ab)
- Entfernt redundanten Link „Weitere Runde erstellen →" von der Erfolgsseite (Nav deckt das ab)
- Verschiebt „Gebot korrigieren"-Einstieg aus dem Submit-Bereich in die Tab-Leiste (rechts, dezent als „Bereits geboten?")
- Extrahiert `blendeKorrekturTabEin()` als Helper, der an allen vier Stellen einheitlich Tab einblendet und Link ausblendet

## Test plan

- [ ] Startseite: Link „Meine gespeicherten Runden →" nicht mehr sichtbar
- [ ] Erfolgsseite: Link „Weitere Runde erstellen →" nicht mehr sichtbar
- [ ] Runden-Seite ohne localStorage-Gebot: „Bereits geboten?" in der Tab-Leiste sichtbar, kein Korrektur-Tab
- [ ] Klick auf „Bereits geboten?": Korrektur-Tab erscheint, Link verschwindet, Korrektur-Panel öffnet sich
- [ ] Runden-Seite mit localStorage-Gebot: Korrektur-Tab sichtbar, „Bereits geboten?"-Link ausgeblendet
- [ ] Nach erfolgreichem Gebot abgeben: Korrektur-Tab eingeblendet, Link ausgeblendet
- [ ] Duplikat-Banner „Gebot korrigieren"-Button: Korrektur-Tab eingeblendet, Link ausgeblendet

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)