### PR TITLE
feat: Emoji-ID per Tap in Zwischenablage kopieren

### DIFF
--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -259,7 +259,7 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   <div id="zustand-bestaetigung" class="hidden text-center space-y-4 py-8">
     <h2 id="bestaetigung-titel" class="text-xl font-semibold">Gebot abgegeben</h2>
     <p id="bestaetigung-text" class="text-fg-muted text-sm max-w-sm mx-auto"></p>
-    <div id="emoji-anzeige" class="text-6xl tracking-widest mb-2 cursor-pointer select-none active:scale-95 transition-transform"></div>
+    <div id="emoji-anzeige" class="text-6xl tracking-widest mb-2 cursor-pointer select-none active:scale-95 transition-transform duration-100"></div>
     <p id="emoji-id-label" class="text-xs text-fg-muted">Deine Emoji-ID</p>
   </div>
 </Layout>

--- a/src/pages/runde/[id].astro
+++ b/src/pages/runde/[id].astro
@@ -259,8 +259,8 @@ import FeedbackBox from '../../components/FeedbackBox.astro';
   <div id="zustand-bestaetigung" class="hidden text-center space-y-4 py-8">
     <h2 id="bestaetigung-titel" class="text-xl font-semibold">Gebot abgegeben</h2>
     <p id="bestaetigung-text" class="text-fg-muted text-sm max-w-sm mx-auto"></p>
-    <div id="emoji-anzeige" class="text-6xl tracking-widest mb-2"></div>
-    <p class="text-xs text-fg-muted">Deine Emoji-ID</p>
+    <div id="emoji-anzeige" class="text-6xl tracking-widest mb-2 cursor-pointer select-none active:scale-95 transition-transform"></div>
+    <p id="emoji-id-label" class="text-xs text-fg-muted">Deine Emoji-ID</p>
   </div>
 </Layout>
 

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -72,6 +72,7 @@ function setupDom() {
     </form>
     <div id="korrektur-fehler" class="hidden"></div>
     <div id="emoji-anzeige"></div>
+    <p id="emoji-id-label">Deine Emoji-ID</p>
     <p id="bestaetigung-titel"></p>
     <p id="bestaetigung-text"></p>
   `;
@@ -548,6 +549,51 @@ describe('initGebot', () => {
     slot1Radio.dispatchEvent(new Event('change', { bubbles: true }));
 
     expect((document.getElementById('betrag') as HTMLInputElement).value).toBe('75');
+  });
+
+  it('kopiert Emoji-ID bei Klick und zeigt Bestätigungslabel', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob();
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ encTeilnehmerBlob, gebote: [] }) })
+      .mockResolvedValue({ ok: true, status: 200, json: async () => ({}) }));
+
+    await initGebot();
+    (document.getElementById('betrag') as HTMLInputElement).value = '80';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+    await vi.waitFor(() => expect(document.getElementById('zustand-bestaetigung')!.classList.contains('hidden')).toBe(false));
+
+    vi.useFakeTimers();
+    document.getElementById('emoji-anzeige')!.dispatchEvent(new Event('click'));
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith(expect.any(String));
+    expect(document.getElementById('emoji-id-label')!.textContent).toBe('✓ Kopiert');
+
+    vi.advanceTimersByTime(2000);
+    expect(document.getElementById('emoji-id-label')!.textContent).toBe('Deine Emoji-ID');
+    vi.useRealTimers();
+  });
+
+  it('ignoriert Clipboard-Fehler still', async () => {
+    const { partKeyB64, encTeilnehmerBlob } = await createEncryptedBlob();
+    mockLocation('/runde/abc12345', `#pk=${partKeyB64}`);
+    vi.stubGlobal('navigator', { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) } });
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ encTeilnehmerBlob, gebote: [] }) })
+      .mockResolvedValue({ ok: true, status: 200, json: async () => ({}) }));
+
+    await initGebot();
+    (document.getElementById('betrag') as HTMLInputElement).value = '80';
+    document.getElementById('gebot-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+    await vi.waitFor(() => expect(document.getElementById('zustand-bestaetigung')!.classList.contains('hidden')).toBe(false));
+
+    document.getElementById('emoji-anzeige')!.dispatchEvent(new Event('click'));
+    await Promise.resolve();
+
+    expect(document.getElementById('emoji-id-label')!.textContent).toBe('Deine Emoji-ID');
   });
 
   it('leert Betrag beim Wechsel von Auto-Slot zu normalem Slot', async () => {

--- a/src/scripts/gebot.test.ts
+++ b/src/scripts/gebot.test.ts
@@ -566,15 +566,18 @@ describe('initGebot', () => {
     await vi.waitFor(() => expect(document.getElementById('zustand-bestaetigung')!.classList.contains('hidden')).toBe(false));
 
     vi.useFakeTimers();
-    document.getElementById('emoji-anzeige')!.dispatchEvent(new Event('click'));
-    await Promise.resolve();
+    try {
+      document.getElementById('emoji-anzeige')!.dispatchEvent(new Event('click'));
+      await Promise.resolve();
 
-    expect(writeText).toHaveBeenCalledWith(expect.any(String));
-    expect(document.getElementById('emoji-id-label')!.textContent).toBe('✓ Kopiert');
+      expect(writeText).toHaveBeenCalledWith(expect.any(String));
+      expect(document.getElementById('emoji-id-label')!.textContent).toBe('✓ Kopiert');
 
-    vi.advanceTimersByTime(2000);
-    expect(document.getElementById('emoji-id-label')!.textContent).toBe('Deine Emoji-ID');
-    vi.useRealTimers();
+      vi.advanceTimersByTime(2000);
+      expect(document.getElementById('emoji-id-label')!.textContent).toBe('Deine Emoji-ID');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('ignoriert Clipboard-Fehler still', async () => {

--- a/src/scripts/gebot.ts
+++ b/src/scripts/gebot.ts
@@ -237,6 +237,13 @@ export async function initGebot(): Promise<void> {
     const emojiAnzeige = document.getElementById('emoji-anzeige')!;
     emojiAnzeige.textContent = emojiId;
     emojiAnzeige.classList.add('animate-pop-in');
+    emojiAnzeige.onclick = () => {
+      navigator.clipboard?.writeText(emojiId).then(() => {
+        const label = document.getElementById('emoji-id-label')!;
+        label.textContent = '✓ Kopiert';
+        setTimeout(() => { label.textContent = 'Deine Emoji-ID'; }, 2000);
+      }).catch(() => {});
+    };
     document.getElementById('bestaetigung-titel')!.textContent = istKorrektur ? 'Gebot korrigiert' : 'Gebot abgegeben';
     document.getElementById('bestaetigung-text')!.textContent = istKorrektur
       ? 'Dein Gebot wurde erfolgreich ersetzt. Deine Emoji-ID bleibt dieselbe.'

--- a/src/scripts/gebot.ts
+++ b/src/scripts/gebot.ts
@@ -238,10 +238,11 @@ export async function initGebot(): Promise<void> {
     emojiAnzeige.textContent = emojiId;
     emojiAnzeige.classList.add('animate-pop-in');
     emojiAnzeige.onclick = () => {
+      const label = document.getElementById('emoji-id-label')!;
+      const originalText = label.textContent ?? '';
       navigator.clipboard?.writeText(emojiId).then(() => {
-        const label = document.getElementById('emoji-id-label')!;
         label.textContent = '✓ Kopiert';
-        setTimeout(() => { label.textContent = 'Deine Emoji-ID'; }, 2000);
+        setTimeout(() => { label.textContent = originalText; }, 2000);
       }).catch(() => {});
     };
     document.getElementById('bestaetigung-titel')!.textContent = istKorrektur ? 'Gebot korrigiert' : 'Gebot abgegeben';


### PR DESCRIPTION
## Summary
- Emoji-Anzeige nach Gebots-Bestätigung ist jetzt tippbar/klickbar
- Tap kopiert die Emoji-ID via `navigator.clipboard` in die Zwischenablage
- Label „Deine Emoji-ID" wechselt kurz zu „✓ Kopiert" und kehrt nach 2 s zurück
- Schlägt das Kopieren fehl, passiert nichts (stilles Ignorieren, kein Fehler-UI)

## Test plan
- [ ] Gebot abgeben, danach auf Emojis tippen → Text in Zwischenablage
- [ ] Label wechselt zu „✓ Kopiert" und kehrt nach 2 s zurück
- [ ] Kein sichtbarer Button, keine neuen UI-Elemente
- [ ] Funktioniert auf Mobile (Touch) und Desktop (Klick)
- [ ] Vitest: 23/23 Tests grün (`npm run test`)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)