### PR TITLE
fix: UX-Bugs im Formular «Neue Runde» (#142)

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -64,6 +64,23 @@ import FeedbackBox from '../components/FeedbackBox.astro';
         />
       </div>
 
+      <!-- Gesamtkosten -->
+      <div>
+        <label for="gesamtkosten" class="block text-sm font-medium text-fg-secondary mb-1">
+          Gesamtkosten (€)
+        </label>
+        <input
+          type="text"
+          inputmode="decimal"
+          id="gesamtkosten"
+          name="gesamtkosten"
+          required
+          placeholder="z.B. 1200"
+          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+        />
+        <p id="gesamtkosten-fehler" class="hidden text-xs text-danger-fg mt-1"></p>
+      </div>
+
       <!-- Personen -->
       <div>
         <div class="flex items-center justify-between mb-2">
@@ -123,10 +140,6 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Erwachsen</span>
                     </label>
                     <label class="slot-gewichtung-label cursor-pointer">
-                      <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.75" />
-                      <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Ermäßigt</span>
-                    </label>
-                    <label class="slot-gewichtung-label cursor-pointer">
                       <input type="radio" class="slot-gewichtung-radio sr-only" name="gw-slot-0" value="0.25" />
                       <span class="slot-gewichtung-badge inline-block border border-border-strong rounded-md px-2.5 py-1 text-xs text-fg-secondary hover:border-brand transition-colors">Kind</span>
                     </label>
@@ -138,7 +151,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       type="text"
                       inputmode="decimal"
                       class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand"
-                      value="0.125"
+                      value="1"
                       placeholder="0,xxx"
                       readonly
                     />
@@ -184,23 +197,6 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           aria-expanded="false"
           class="text-xs text-fg-faint hover:text-fg-secondary mt-1 transition-colors"
         >+ Ausgaben erfassen</button>
-      </div>
-
-      <!-- Gesamtkosten -->
-      <div>
-        <label for="gesamtkosten" class="block text-sm font-medium text-fg-secondary mb-1">
-          Gesamtkosten (€)
-        </label>
-        <input
-          type="text"
-          inputmode="decimal"
-          id="gesamtkosten"
-          name="gesamtkosten"
-          required
-          placeholder="z.B. 1200"
-          class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
-        />
-        <p id="gesamtkosten-fehler" class="hidden text-xs text-danger-fg mt-1"></p>
       </div>
 
       <!-- Fehler -->

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -74,6 +74,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
           inputmode="decimal"
           id="gesamtkosten"
           name="gesamtkosten"
+          data-auto="true"
           required
           placeholder="z.B. 1200"
           class="w-full border border-border-strong bg-surface-raised text-fg rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"

--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -151,7 +151,7 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                       type="text"
                       inputmode="decimal"
                       class="slot-gewichtung-manuell w-16 border border-border-strong bg-surface-elevated text-fg rounded-md px-2 py-1 text-sm text-center opacity-50 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand"
-                      value="1"
+                      value="1.0"
                       placeholder="0,xxx"
                       readonly
                     />

--- a/src/scripts/neu.test.ts
+++ b/src/scripts/neu.test.ts
@@ -348,6 +348,20 @@ describe('initNeu', () => {
     expect(document.getElementById('gesamtkosten-fehler')!.classList.contains('hidden')).toBe(true);
   });
 
+  it('überschreibt Gesamtkosten nicht wenn manuell eingegeben', () => {
+    initNeu();
+
+    const gesamtkostenInput = document.getElementById('gesamtkosten') as HTMLInputElement;
+    gesamtkostenInput.value = '500';
+    gesamtkostenInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const ausgabenInput = document.querySelector<HTMLInputElement>('[name="ausgaben[]"]')!;
+    ausgabenInput.value = '200';
+    ausgabenInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(gesamtkostenInput.value).toBe('500');
+  });
+
   it('aktualisiert Gesamtkosten nach Slot-Entfernen', () => {
     initNeu();
 

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -165,7 +165,7 @@ export function initNeu(): void {
       aktualisierePresetPlaceholder(eintrag);
       if (target.value === 'manuell') {
         if (manuellInput) {
-          const presetWerte = ['1', '1.0', '0.25'];
+          const presetWerte = ['1.0', '0.25'];
           if (presetWerte.includes(manuellInput.value)) {
             manuellInput.value = '0.125';
           }

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -415,7 +415,8 @@ export function initNeu(): void {
       };
 
       (form.querySelector('#rundeName') as HTMLInputElement).value = config.name;
-      (form.querySelector('#gesamtkosten') as HTMLInputElement).value = formatBetrag(config.kosten);
+      gesamtkostenInput.value = formatBetrag(config.kosten);
+      gesamtkostenInput.dataset.auto = 'false';
 
       function befuelleWiederholSlot(
         slotEl: HTMLDivElement,

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -50,9 +50,7 @@ export function initNeu(): void {
   }
 
   function aktualisiereRichtwert() {
-    const gesamtkosten = parseGeld(
-      (form.querySelector('#gesamtkosten') as HTMLInputElement).value,
-    );
+    const gesamtkosten = parseGeld(gesamtkostenInput.value);
     if (!gesamtkosten || gesamtkosten <= 0) {
       slotsContainer.querySelectorAll<HTMLSpanElement>('.standardgebot-richtwert').forEach(el => {
         el.textContent = '';

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -86,8 +86,10 @@ export function initNeu(): void {
     });
   }
 
-  document.getElementById('gesamtkosten')!.addEventListener('input', () => {
+  const gesamtkostenInput = document.getElementById('gesamtkosten') as HTMLInputElement;
+  gesamtkostenInput.addEventListener('input', () => {
     (document.getElementById('gesamtkosten-fehler') as HTMLParagraphElement).classList.add('hidden');
+    gesamtkostenInput.dataset.auto = gesamtkostenInput.value ? 'false' : 'true';
     aktualisiereRichtwert();
   });
 
@@ -95,14 +97,9 @@ export function initNeu(): void {
     const werte = [...slotsContainer.querySelectorAll<HTMLInputElement>('[name="ausgaben[]"]')]
       .map(el => parseGeld(el.value))
       .filter(v => !isNaN(v));
-    const gesamtkostenInput = form.querySelector('#gesamtkosten') as HTMLInputElement;
-    if (werte.length === 0) {
-      gesamtkostenInput.value = '';
-      aktualisiereRichtwert();
-      return;
+    if (gesamtkostenInput.dataset.auto !== 'false') {
+      gesamtkostenInput.value = werte.length > 0 ? formatBetrag(werte.reduce((a, b) => a + b, 0)) : '';
     }
-    const summe = werte.reduce((a, b) => a + b, 0);
-    gesamtkostenInput.value = formatBetrag(summe);
     aktualisiereRichtwert();
   }
 

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -53,7 +53,12 @@ export function initNeu(): void {
     const gesamtkosten = parseGeld(
       (form.querySelector('#gesamtkosten') as HTMLInputElement).value,
     );
-    if (!gesamtkosten || gesamtkosten <= 0) return;
+    if (!gesamtkosten || gesamtkosten <= 0) {
+      slotsContainer.querySelectorAll<HTMLSpanElement>('.standardgebot-richtwert').forEach(el => {
+        el.textContent = '';
+      });
+      return;
+    }
 
     const slotEls = [...slotsContainer.querySelectorAll<HTMLDivElement>('.slot-eintrag')];
     const summeGewichtungen = slotEls.reduce((s, el) => {
@@ -110,7 +115,7 @@ export function initNeu(): void {
     t.value = formatBetrag(v);
   }, true);
 
-  const presetNamen: Record<string, string> = { '1.0': 'Erwachsen', '0.75': 'Ermäßigt', '0.25': 'Kind' };
+  const presetNamen: Record<string, string> = { '1.0': 'Erwachsen', '0.25': 'Kind' };
   function aktualisierePresetPlaceholder(slotEl: HTMLElement) {
     const labelInput = slotEl.querySelector<HTMLInputElement>('[name="label[]"]');
     if (!labelInput) return;
@@ -160,6 +165,10 @@ export function initNeu(): void {
       aktualisierePresetPlaceholder(eintrag);
       if (target.value === 'manuell') {
         if (manuellInput) {
+          const presetWerte = ['1', '1.0', '0.25'];
+          if (presetWerte.includes(manuellInput.value)) {
+            manuellInput.value = '0.125';
+          }
           manuellInput.readOnly = false;
           manuellInput.classList.remove('opacity-50', 'cursor-not-allowed');
           if (hiddenInput && manuellInput.value) hiddenInput.value = manuellInput.value;
@@ -199,7 +208,13 @@ export function initNeu(): void {
     const eintrag = target.closest('.slot-eintrag') as HTMLDivElement;
     eintrag.remove();
     aktualisiereEntfernenButtons();
-    aktualisiereGesamtkosten();
+    const hatAusgabenWerte = [...slotsContainer.querySelectorAll<HTMLInputElement>('[name="ausgaben[]"]')]
+      .some(el => !isNaN(parseGeld(el.value)));
+    if (hatAusgabenWerte) {
+      aktualisiereGesamtkosten();
+    } else {
+      aktualisiereRichtwert();
+    }
   });
 
   // ---------------------------------------------------------------------------
@@ -369,7 +384,7 @@ export function initNeu(): void {
     if (hiddenInput) hiddenInput.value = String(gewichtung);
 
     // Passendes Radio auswählen oder Manuell
-    const presets = ['1.0', '0.75', '0.25'];
+    const presets = ['1.0', '0.25'];
     const matchingValue = presets.find(v => Math.abs(parseFloat(v) - gewichtung) < 0.001);
     if (matchingValue) {
       const radio = slotEl.querySelector<HTMLInputElement>(`.slot-gewichtung-radio[value="${matchingValue}"]`);
@@ -409,7 +424,7 @@ export function initNeu(): void {
         slotEl: HTMLDivElement,
         slot: { label: string; gewichtung: number; anzahl: number; standardgebot?: number; ausgaben?: number },
       ) {
-        const presetNamenWiederhol: Record<string, string> = { 'Erwachsen': '', 'Ermäßigt': '', 'Kind': '', 'Beitrag': '' };
+        const presetNamenWiederhol: Record<string, string> = { 'Erwachsen': '', 'Kind': '', 'Beitrag': '' };
         // Labels die reine Preset-Namen sind, als leer behandeln (Preset-Name wird beim Absenden wieder gesetzt)
         (slotEl.querySelector('[name="label[]"]') as HTMLInputElement).value =
           (slot.label in presetNamenWiederhol) ? '' : slot.label;


### PR DESCRIPTION
## Summary

- Gesamtkosten-Feld steht jetzt vor der Personen-Sektion (logische Eingabereihenfolge)
- Gewichtungs-Option „Ermäßigt" (0,75) entfernt aus Template, `presetNamen` und `setzeGewichtungRadio`
- Manuell-Feld zeigt initial den Preset-Wert (`1.0` für Erwachsen); beim Wechsel auf „Manuell" erscheint `0,125` als Vorbelegung
- Richtwert-Anzeige wird geleert wenn Gesamtkosten-Feld leer oder 0 ist
- Slot entfernen: Richtwert wird neu berechnet ohne das manuell eingetragene Gesamtkosten-Feld zu überschreiben
- Gesamtkosten wird nicht durch Ausgaben-Summe überschrieben, wenn manuell eingegeben (`data-auto`-Flag, analog zu Standardgebot)
- Beim Wiederholen einer Runde ist das Gesamtkosten-Feld ebenfalls vor Auto-Überschreiben geschützt

## Test plan

- [ ] Neue Runde öffnen → „Erweitert" aufklappen → Manuell-Feld zeigt `1.0`, nicht `0,125`
- [ ] „Manuell" wählen → Feld zeigt `0,125` und ist editierbar
- [ ] Zurück auf „Erwachsen" wechseln → Feld zeigt wieder `1.0` (read-only)
- [ ] Keine „Ermäßigt"-Option sichtbar
- [ ] Gesamtkosten eingeben → Richtwert erscheint → Gesamtkosten löschen → Richtwert verschwindet
- [ ] Zwei Slots anlegen, Gesamtkosten eintragen → Richtwert erscheint → zweiten Slot entfernen → Richtwert aktualisiert, Gesamtkosten bleibt
- [ ] Gesamtkosten-Feld steht im Formular vor den Personen/Slots
- [ ] Gesamtkosten manuell eingeben → Ausgaben befüllen → Gesamtkosten bleibt unverändert
- [ ] Ausgaben befüllen (Gesamtkosten leer) → Gesamtkosten wird auto-befüllt → alle Ausgaben leeren → Gesamtkosten wird wieder geleert
- [ ] Runde wiederholen → Gesamtkosten aus vorheriger Runde bleibt erhalten auch wenn Ausgaben geändert werden
- [ ] `npm run test` grün (240 Tests)

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)