### PR TITLE
feat: (Teil-)Deckungsmodus als Alternative zum Drei-Gebot-Modus

### DIFF
--- a/src/pages/neu.astro
+++ b/src/pages/neu.astro
@@ -23,6 +23,17 @@ import FeedbackBox from '../components/FeedbackBox.astro';
                         after:bg-white after:rounded-full after:transition-all
                         peer-checked:after:translate-x-4"></div>
           </label>
+          <label class="flex items-center justify-between px-4 py-2 cursor-pointer hover:bg-surface-elevated transition-colors select-none">
+            <div>
+              <span class="text-sm text-fg-secondary block">(Teil-)Deckungsmodus</span>
+              <span class="text-xs text-fg-faint">Beiträge live zeigen, auch bei Unterdeckung</span>
+            </div>
+            <input type="checkbox" id="teildeckung-toggle" class="sr-only peer" />
+            <div class="w-9 h-5 bg-border-strong rounded-full peer-checked:bg-brand relative shrink-0 ml-3
+                        after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4
+                        after:bg-white after:rounded-full after:transition-all
+                        peer-checked:after:translate-x-4"></div>
+          </label>
           <div class="border-t border-border my-1"></div>
           <div>
             <div class="flex items-center">

--- a/src/scripts/admin.test.ts
+++ b/src/scripts/admin.test.ts
@@ -25,7 +25,9 @@ function setupDom() {
     <h1 id="runde-name"></h1>
     <span id="kz-gesamtkosten"></span>
     <span id="kz-richtwert"></span>
-    <span id="kz-summe-beitraege"></span>
+    <div class="vollstaendig-spalte hidden">
+      <span id="kz-summe-beitraege"></span>
+    </div>
     <div id="duplikat-box" class="hidden"></div>
     <ul id="duplikat-liste"></ul>
     <div id="status-banner" class="hidden"></div>
@@ -46,7 +48,13 @@ interface TestKeys {
   hmacKey: CryptoKey;
 }
 
-async function createTestKeys(slotOverrides?: Partial<{ anzahl: number; ausgaben: number }>): Promise<TestKeys> {
+async function createTestKeys(slotOverrides?: Partial<{
+  anzahl: number;
+  ausgaben: number;
+  slots: { label: string; gewichtung: number; anzahl: number; ausgaben?: number; standardgebot?: number }[];
+  teildeckungModus: boolean;
+  dreiGebotModus: boolean;
+}>): Promise<TestKeys> {
   const partKey = await generatePartKey();
   const { publicKey: adminPubKey, privateKey: adminPrivKey } = await generateAdminKeyPair();
   const hmacKey = await generateHmacKey();
@@ -61,24 +69,26 @@ async function createTestKeys(slotOverrides?: Partial<{ anzahl: number; ausgaben
     gesamtkosten: 600,
     adminPubKey: adminPubKeyB64,
     hmacKey: hmacKeyB64,
-    slots: [{
+    slots: slotOverrides?.slots ?? [{
       label: 'Erwachsen',
       gewichtung: 1.0,
       anzahl: slotOverrides?.anzahl ?? 1,
       ...(slotOverrides?.ausgaben !== undefined ? { ausgaben: slotOverrides.ausgaben } : {}),
     }],
+    ...(slotOverrides?.teildeckungModus !== undefined ? { teildeckungModus: slotOverrides.teildeckungModus } : {}),
+    ...(slotOverrides?.dreiGebotModus !== undefined ? { dreiGebotModus: slotOverrides.dreiGebotModus } : {}),
   };
   const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blobData));
 
   return { partKeyB64, adminPrivKeyB64, encTeilnehmerBlob, adminPubKey, adminPrivKey, hmacKey };
 }
 
-async function createEncryptedGebot(adminPubKey: CryptoKey, hmacKey: CryptoKey, betrag = 80) {
+async function createEncryptedGebot(adminPubKey: CryptoKey, hmacKey: CryptoKey, betrag = 80, slotLabel = 'Erwachsen') {
   const emojiId = generiereEmojiId();
   const emojiHmac = await hmac(hmacKey, emojiId);
   const encGebot = await encryptGebot(adminPubKey, JSON.stringify({
     emojiId,
-    slotLabel: 'Erwachsen',
+    slotLabel,
     gewichtung: 1.0,
     betrag,
   }));
@@ -187,6 +197,74 @@ describe('initAdmin', () => {
 
     expect(document.getElementById('status-banner')!.textContent).toContain('vollständig');
     expect(document.getElementById('kz-richtwert')!.textContent).not.toBe('');
+  });
+
+  it('zeigt Beiträge im (Teil-)Deckungsmodus live an, trotz Fehlbetrag und Unvollständigkeit', async () => {
+    const keys = await createTestKeys({
+      slots: [
+        { label: 'Slot A', gewichtung: 1.0, anzahl: 1 },
+        { label: 'Slot B', gewichtung: 1.0, anzahl: 1 },
+      ],
+      teildeckungModus: true,
+    });
+    // Nur ein Gebot, deutlich unter dem Richtwert-Anteil (300) → Fehlbetrag, allesDa=false
+    const gebot = await createEncryptedGebot(keys.adminPubKey, keys.hmacKey, 100, 'Slot A');
+    mockLocation('/runde/abc12345/admin/tok123', `#pk=${keys.partKeyB64}&bk=${keys.adminPrivKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob: keys.encTeilnehmerBlob, gebote: [gebot] }),
+    }));
+
+    await initAdmin();
+
+    expect(document.getElementById('status-banner')!.textContent).toContain('Ziel noch nicht erreicht');
+    expect(document.getElementById('status-banner')!.textContent).toContain('anderweitig gedeckt');
+    expect(document.querySelector('.vollstaendig-spalte')!.classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('kz-summe-beitraege')!.textContent).toContain('100');
+    expect(document.querySelector('[data-emoji-hmac]')!.textContent).toContain('100');
+  });
+
+  it('zeigt normale Auswertung wenn das Ziel im (Teil-)Deckungsmodus erreicht ist, auch ohne dass alle geboten haben', async () => {
+    const keys = await createTestKeys({
+      slots: [
+        { label: 'Slot A', gewichtung: 1.0, anzahl: 1 },
+        { label: 'Slot B', gewichtung: 1.0, anzahl: 1 },
+      ],
+      teildeckungModus: true,
+    });
+    // Nur ein Gebot, deckt aber allein schon die Gesamtkosten → Ziel erreicht trotz allesDa=false
+    const gebot = await createEncryptedGebot(keys.adminPubKey, keys.hmacKey, 600, 'Slot A');
+    mockLocation('/runde/abc12345/admin/tok123', `#pk=${keys.partKeyB64}&bk=${keys.adminPrivKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob: keys.encTeilnehmerBlob, gebote: [gebot] }),
+    }));
+
+    await initAdmin();
+
+    expect(document.getElementById('status-banner')!.textContent).toContain('Ziel erreicht');
+    expect(document.querySelector('.vollstaendig-spalte')!.classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('kz-summe-beitraege')!.textContent).not.toBe('');
+  });
+
+  it('berechnet keine Ausgleichszahlungen im (Teil-)Deckungsmodus solange ein Fehlbetrag besteht', async () => {
+    const keys = await createTestKeys({
+      slots: [
+        { label: 'Slot A', gewichtung: 1.0, anzahl: 1, ausgaben: 50 },
+        { label: 'Slot B', gewichtung: 1.0, anzahl: 1, ausgaben: 250 },
+      ],
+      teildeckungModus: true,
+    });
+    const gebot = await createEncryptedGebot(keys.adminPubKey, keys.hmacKey, 100, 'Slot A');
+    mockLocation('/runde/abc12345/admin/tok123', `#pk=${keys.partKeyB64}&bk=${keys.adminPrivKeyB64}`);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ encTeilnehmerBlob: keys.encTeilnehmerBlob, gebote: [gebot] }),
+    }));
+
+    await initAdmin();
+
+    expect(document.getElementById('ausgleich-section')!.classList.contains('hidden')).toBe(true);
   });
 
   it('feuert DELETE-Request beim Klick auf Löschen-Button', async () => {

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -236,10 +236,13 @@ export async function initAdmin(): Promise<void> {
     ? berechneAuswertung(blob.gesamtkosten, geboteFuerBerechnung, blob.slots)
     : null;
 
+  // Ziel erreicht = Gesamtkosten durch eingegangene Gebote gedeckt (unabhängig von Vollständigkeit)
+  const zielErreicht = auswertung !== null && auswertung.fehlbetrag <= 0.005;
+
   // Beiträge anzeigen wenn: Runde vollständig + kein Fehlbetrag (Normalmodus),
   // oder im (Teil-)Deckungsmodus grundsätzlich live — unabhängig von Vollständigkeit/Fehlbetrag
   const zeigeBeitraege = !hatDuplikate && auswertung !== null &&
-    (teildeckungModus || (allesDa && auswertung.fehlbetrag <= 0.005));
+    (teildeckungModus || (allesDa && zielErreicht));
 
   // Richtwert für Anzeige + "fehlt"-Zeilen
   const summeAlleGewichtungen = blob.slots.reduce((s, sl) => s + sl.gewichtung * sl.anzahl, 0);
@@ -457,8 +460,7 @@ export async function initAdmin(): Promise<void> {
 
   // Ausgleichszahlungen (nur wenn Ziel erreicht, keine Duplikate, Ausgaben vorhanden;
   // "Ziel erreicht" heißt im Normalmodus vollständig + kein Fehlbetrag, im (Teil-)Deckungsmodus reicht kein Fehlbetrag)
-  const berechnungVollstaendig = !hatDuplikate && auswertung !== null && auswertung.fehlbetrag <= 0.005 &&
-    (allesDa || teildeckungModus);
+  const berechnungVollstaendig = !hatDuplikate && zielErreicht && (allesDa || teildeckungModus);
   if (berechnungVollstaendig && ausgabenMap.size > 0) {
     const zahlungen = berechneAusgleich(auswertung.ergebnisse, ausgabenMap);
     if (zahlungen.length > 0) {
@@ -505,8 +507,6 @@ export async function initAdmin(): Promise<void> {
     .reduce((s, sl) => s + sl.anzahl, 0);
   const erledigt = autoAnzahlGesamt + geboteOhneStandard.length;
   const ausstehend = totalAlle - erledigt;
-
-  const zielErreicht = auswertung !== null && auswertung.fehlbetrag <= 0.005;
 
   if (hatDuplikate) {
     zeigeBanner('Auswertung pausiert — Doppelgebote bitte klären.', 'amber');

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -23,6 +23,7 @@ interface TeilnehmerBlob {
   hmacKey: string;
   slots: { label: string; gewichtung: number; anzahl: number; ausgaben?: number; standardgebot?: number }[];
   dreiGebotModus?: boolean;
+  teildeckungModus?: boolean;
 }
 
 interface RawGebotPayload {
@@ -144,6 +145,7 @@ export async function initAdmin(): Promise<void> {
 
   // Gebote entschlüsseln
   const dreiGebotModus = blob.dreiGebotModus === true;
+  const teildeckungModus = blob.teildeckungModus === true;
   const geboteWithHmac: Array<{ emojiHmac: string; gebot: Gebot }> = [];
   const dreiGebotTriples: DreiGebotTriple[] = [];
 
@@ -234,14 +236,19 @@ export async function initAdmin(): Promise<void> {
     ? berechneAuswertung(blob.gesamtkosten, geboteFuerBerechnung, blob.slots)
     : null;
 
+  // Beiträge anzeigen wenn: Runde vollständig + kein Fehlbetrag (Normalmodus),
+  // oder im (Teil-)Deckungsmodus grundsätzlich live — unabhängig von Vollständigkeit/Fehlbetrag
+  const zeigeBeitraege = !hatDuplikate && auswertung !== null &&
+    (teildeckungModus || (allesDa && auswertung.fehlbetrag <= 0.005));
+
   // Richtwert für Anzeige + "fehlt"-Zeilen
   const summeAlleGewichtungen = blob.slots.reduce((s, sl) => s + sl.gewichtung * sl.anzahl, 0);
   const rawRichtwert = blob.gesamtkosten / summeAlleGewichtungen;
   document.getElementById('kz-richtwert')!.textContent = auswertung
     ? formatEur(auswertung.richtwert)
     : formatEur(Math.ceil(rawRichtwert * 100) / 100);
-  // Summe Beiträge nur zeigen wenn kein Fehlbetrag (sonst rekonstruierbar)
-  if (auswertung && auswertung.fehlbetrag <= 0.005) {
+  // Summe Beiträge nur zeigen wenn kein Fehlbetrag (sonst rekonstruierbar) — außer im (Teil-)Deckungsmodus
+  if (auswertung && (teildeckungModus || auswertung.fehlbetrag <= 0.005)) {
     document.getElementById('kz-summe-beitraege')!.textContent = formatEur(auswertung.summeBeitraege);
   }
 
@@ -263,9 +270,6 @@ export async function initAdmin(): Promise<void> {
 
   // Container befüllen — alle Slot-Positionen (geboten / auto / fehlt)
   const slotsContainer = document.getElementById('slots-container')!;
-
-  // Beiträge nur anzeigen wenn Runde vollständig, keine Duplikate, kein Fehlbetrag
-  const zeigeBeitraege = allesDa && !hatDuplikate && auswertung !== null && auswertung.fehlbetrag <= 0.005;
 
   for (const slot of blob.slots) {
     const slotErgebnisse = ergebnisseBySlot.get(slot.label) ?? [];
@@ -451,8 +455,11 @@ export async function initAdmin(): Promise<void> {
     }
   });
 
-  // Ausgleichszahlungen (nur wenn vollständig, kein Fehlbetrag, keine Duplikate, Ausgaben vorhanden)
-  if (allesDa && !hatDuplikate && auswertung && auswertung.fehlbetrag <= 0.005 && ausgabenMap.size > 0) {
+  // Ausgleichszahlungen (nur wenn Ziel erreicht, keine Duplikate, Ausgaben vorhanden;
+  // "Ziel erreicht" heißt im Normalmodus vollständig + kein Fehlbetrag, im (Teil-)Deckungsmodus reicht kein Fehlbetrag)
+  const berechnungVollstaendig = !hatDuplikate && auswertung !== null && auswertung.fehlbetrag <= 0.005 &&
+    (allesDa || teildeckungModus);
+  if (berechnungVollstaendig && ausgabenMap.size > 0) {
     const zahlungen = berechneAusgleich(auswertung.ergebnisse, ausgabenMap);
     if (zahlungen.length > 0) {
       // Hilfsmaps: emojiId → slotLabel (für Namensanzeige statt Emoji-ID)
@@ -479,8 +486,8 @@ export async function initAdmin(): Promise<void> {
     }
   }
 
-  // Beitrag-Spalten einblenden wenn vollständig, keine Duplikate, kein Fehlbetrag
-  if (allesDa && !hatDuplikate && auswertung && auswertung.fehlbetrag <= 0.005) {
+  // Beitrag-Spalten einblenden wenn Beiträge sichtbar sind (siehe zeigeBeitraege oben)
+  if (zeigeBeitraege) {
     document.querySelectorAll('.vollstaendig-spalte').forEach((el) => el.classList.remove('hidden'));
     if (!hatSplidDaten) {
       document.querySelectorAll('.splid-spalte').forEach((el) => el.classList.add('hidden'));
@@ -499,15 +506,14 @@ export async function initAdmin(): Promise<void> {
   const erledigt = autoAnzahlGesamt + geboteOhneStandard.length;
   const ausstehend = totalAlle - erledigt;
 
+  const zielErreicht = auswertung !== null && auswertung.fehlbetrag <= 0.005;
+
   if (hatDuplikate) {
     zeigeBanner('Auswertung pausiert — Doppelgebote bitte klären.', 'amber');
     document.getElementById('gebote-anzahl')!.textContent =
       `${geboteOhneStandard.length} von ${totalErwartet} Geboten eingegangen`;
-  } else if (allesDa) {
-    const fehlbetragVorhanden = auswertung && auswertung.fehlbetrag > 0.005;
-    if (fehlbetragVorhanden) {
-      zeigeBanner(`Fehlbetrag: ${formatEur(auswertung!.fehlbetrag)} — Runde muss wiederholt werden.`, 'red');
-    } else if (dreiGebotStatus) {
+  } else if (zielErreicht && (allesDa || teildeckungModus)) {
+    if (dreiGebotStatus) {
       const statusTexte: Record<string, string> = {
         gruen: '🟢 Grün — Minimalgebote decken die Kosten. Auswertung mit Minimalgeboten.',
         gelb:  '🟡 Gelb — Erst mittlere Gebote decken die Kosten. Auswertung mit mittleren Geboten.',
@@ -516,9 +522,18 @@ export async function initAdmin(): Promise<void> {
       };
       const bannerFarbe = dreiGebotStatus === 'gruen' ? 'green' : dreiGebotStatus === 'kritisch' ? 'red' : 'amber';
       zeigeBanner(statusTexte[dreiGebotStatus], bannerFarbe);
+    } else if (teildeckungModus && !allesDa) {
+      zeigeBanner('Ziel erreicht — nicht alle haben geboten, aber die Kosten sind gedeckt.', 'green');
     } else {
       zeigeBanner('Alle Beiträge vollständig. Auswertung abgeschlossen.', 'green');
     }
+    document.getElementById('gebote-anzahl')!.textContent = '';
+  } else if (teildeckungModus && auswertung) {
+    zeigeBanner(`Ziel noch nicht erreicht — ${formatEur(auswertung.fehlbetrag)} fehlen noch. Restbetrag wird anderweitig gedeckt.`, 'amber');
+    document.getElementById('gebote-anzahl')!.textContent =
+      `${geboteOhneStandard.length} von ${totalErwartet} Geboten eingegangen`;
+  } else if (allesDa) {
+    zeigeBanner(`Fehlbetrag: ${formatEur(auswertung!.fehlbetrag)} — Runde muss wiederholt werden.`, 'red');
     document.getElementById('gebote-anzahl')!.textContent = '';
   } else {
     zeigeBanner(`${ausstehend} von ${totalAlle} Beiträge ausstehend.`, 'amber');

--- a/src/scripts/neu.test.ts
+++ b/src/scripts/neu.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as cryptoLib from '../lib/crypto';
 import { initNeu } from './neu';
 
 // ---------------------------------------------------------------------------
@@ -11,7 +12,10 @@ function setupDom() {
     <div id="form-bereich"></div>
     <div id="ergebnis-bereich" class="hidden"></div>
     <button id="power-menu-btn" aria-expanded="false"></button>
-    <div id="power-menu" class="hidden"></div>
+    <div id="power-menu" class="hidden">
+      <input type="checkbox" id="drei-gebot-toggle" />
+      <input type="checkbox" id="teildeckung-toggle" />
+    </div>
     <button id="splid-import-btn"></button>
     <button id="import-info-btn"></button>
     <div id="import-info-popover" class="hidden"></div>
@@ -115,6 +119,43 @@ describe('initNeu', () => {
     const body = JSON.parse(options.body);
     // Blob ist verschlüsselt: Format <iv>.<ciphertext>
     expect(body.encTeilnehmerBlob).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  });
+
+  it('Drei-Gebot-Modus und (Teil-)Deckungsmodus schließen sich gegenseitig aus', () => {
+    initNeu();
+    const dreiGebotToggle = document.getElementById('drei-gebot-toggle') as HTMLInputElement;
+    const teildeckungToggle = document.getElementById('teildeckung-toggle') as HTMLInputElement;
+
+    dreiGebotToggle.checked = true;
+    dreiGebotToggle.dispatchEvent(new Event('change', { bubbles: true }));
+    teildeckungToggle.checked = true;
+    teildeckungToggle.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(teildeckungToggle.checked).toBe(true);
+    expect(dreiGebotToggle.checked).toBe(false);
+
+    dreiGebotToggle.checked = true;
+    dreiGebotToggle.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(dreiGebotToggle.checked).toBe(true);
+    expect(teildeckungToggle.checked).toBe(false);
+  });
+
+  it('setzt teildeckungModus im Blob wenn Toggle aktiv ist', async () => {
+    const encryptSpy = vi.spyOn(cryptoLib, 'encrypt');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'abc12345', adminToken: 'tok1234567890abcd' }),
+    }));
+
+    initNeu();
+    (document.getElementById('teildeckung-toggle') as HTMLInputElement).checked = true;
+    document.getElementById('runde-form')!.dispatchEvent(new Event('submit', { bubbles: true }));
+    await vi.waitFor(() => expect(encryptSpy).toHaveBeenCalled());
+
+    const blob = JSON.parse(encryptSpy.mock.calls[0][1]);
+    expect(blob.teildeckungModus).toBe(true);
+    expect(blob.dreiGebotModus).toBe(false);
   });
 
   it('zeigt Ergebnis-Bereich nach erfolgreichem Erstellen', async () => {

--- a/src/scripts/neu.ts
+++ b/src/scripts/neu.ts
@@ -242,6 +242,17 @@ export function initNeu(): void {
     powerMenu.classList.contains('hidden') ? openPowerMenu() : closePowerMenu();
   });
 
+  // Drei-Gebot-Modus und (Teil-)Deckungsmodus schließen sich gegenseitig aus
+  const dreiGebotToggle = document.getElementById('drei-gebot-toggle') as HTMLInputElement | null;
+  const teildeckungToggle = document.getElementById('teildeckung-toggle') as HTMLInputElement | null;
+
+  dreiGebotToggle?.addEventListener('change', () => {
+    if (dreiGebotToggle.checked && teildeckungToggle) teildeckungToggle.checked = false;
+  });
+  teildeckungToggle?.addEventListener('change', () => {
+    if (teildeckungToggle.checked && dreiGebotToggle) dreiGebotToggle.checked = false;
+  });
+
   // ---------------------------------------------------------------------------
   // Datei-Import (Splid oder Basis-Format)
   // ---------------------------------------------------------------------------
@@ -592,6 +603,8 @@ export function initNeu(): void {
 
       const dreiGebotModus =
         (document.getElementById('drei-gebot-toggle') as HTMLInputElement)?.checked ?? false;
+      const teildeckungModus =
+        (document.getElementById('teildeckung-toggle') as HTMLInputElement)?.checked ?? false;
 
       // Blob zusammenstellen + verschlüsseln
       const blob = {
@@ -601,6 +614,7 @@ export function initNeu(): void {
         hmacKey: await exportKey(hmacKey),
         slots: finalSlots,
         dreiGebotModus,
+        teildeckungModus,
       };
       const encTeilnehmerBlob = await encrypt(partKey, JSON.stringify(blob));
 


### PR DESCRIPTION
## Summary
- Neuer, zum Drei-Gebot-Modus exklusiver Modus: „(Teil-)Deckungsmodus" — Admin sieht Beiträge live, unabhängig von Vollständigkeit oder Fehlbetrag; wer geboten hat, zahlt in jedem Fall, der Rest wird anderweitig gedeckt
- `neu.astro`/`neu.ts`: neuer Toggle, exklusiv zum Drei-Gebot-Modus-Toggle, Flag landet als `teildeckungModus` im verschlüsselten Blob
- `admin.ts`: Beiträge-Anzeige, Summenkennzahl und Status-Banner ignorieren im neuen Modus die Vollständigkeits-/Fehlbetrags-Gates; Ausgleichszahlungen bleiben weiterhin nur bei erreichtem Ziel aktiv; ist das Ziel erreicht, entspricht die Anzeige 1:1 dem Normalmodus — auch ohne vollständige Teilnahme

## Test plan
- [x] `npx vitest run` (ohne `ui.test.ts`, siehe #145 – unabhängiger, vorbestehender Hänger) — 238/238 Tests grün
- [x] Neue Tests: Toggle-Exklusivität, `teildeckungModus` im Blob, Beiträge live trotz Fehlbetrag/Unvollständigkeit, normale Auswertung bei erreichtem Ziel ohne `allesDa`, keine Ausgleichszahlungen bei bestehendem Fehlbetrag
- [x] `npx tsc --noEmit` ohne Fehler
- [x] Kein `console.log` in `src/`

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)