### PR TITLE
chore: add local branch cleanup step to /pr-merge command

### DIFF
--- a/.claude/commands/pr-merge.md
+++ b/.claude/commands/pr-merge.md
@@ -22,3 +22,9 @@ Dann:
    `git checkout main && git pull`
 
 4. Kurze Bestätigung: welcher PR gemergt wurde, aktueller HEAD-Commit.
+
+5. Lokale Branches aufräumen:
+   - `git fetch --prune` — entfernt veraltete Remote-Tracking-Referenzen für gelöschte Remote-Branches
+   - `git branch --merged main` — listet lokale Branches, die Git als literalen Vorfahren von main erkennt (klassischer Merge). Diese direkt löschen: `git branch -D <branch>`
+   - Für alle übrigen lokalen Branches (nicht in `--merged`, meist wegen Squash-Merge nicht als Vorfahre erkennbar): mit `gh pr list --state all --head <branch> --json state,mergedAt` prüfen, ob der zugehörige PR gemerged wurde. Falls ja: löschen.
+   - Für Branches ganz ohne zugehörigen PR: Inhalt gegen main prüfen (`git diff main...<branch>`). Nur löschen, wenn der Inhalt bereits in main enthalten oder erkennbar überholt ist — sonst dem Nutzer vorlegen und einzeln bestätigen lassen, nicht pauschal per Bulk-Befehl.


### PR DESCRIPTION
## Summary
- After a PR merge, squash-merged branches aren't recognized as ancestors by `git branch --merged`, so stale local branches accumulate over time (32 had piled up in this repo)
- Added step 5 to `/pr-merge`: prune dead remote-tracking refs, auto-delete literal-ancestor branches, verify squash-merged branches via GitHub PR history before deleting, and flag anything without a PR for manual review instead of bulk-deleting

## Test plan
- [x] Manually ran the new workflow against this repo's 32 accumulated local branches — all correctly classified (27 git-recognized merges, 5 confirmed squash-merged via `gh pr list --state all`, 1 confirmed superseded/no-PR and confirmed with the user before deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)